### PR TITLE
fix: draw unit image comparing arrays not possible 

### DIFF
--- a/scripts/scr_draw_unit_image/scr_draw_unit_image.gml
+++ b/scripts/scr_draw_unit_image/scr_draw_unit_image.gml
@@ -362,7 +362,7 @@ function scr_draw_unit_image(_background=false){
             for (var _right_left = 1; _right_left <= 2; _right_left++) {
                 // Draw bionic arms
                 var _bionic_arm = get_body_data("bionic", _right_left == 1 ? "right_arm" : "left_arm");
-                if (arm_variant[_right_left] == 1 && _bionic_options != [] && !_hide_bionics && _bionic_arm) {
+                if (arm_variant[_right_left] == 1 && array_length(_bionic_options) && !_hide_bionics && _bionic_arm) {
                     var _bionic_variant = _bionic_arm.variant % array_length(_bionic_options);
                     var _bionic_spr_index = 0;
                     var _bionic_spr = _bionic_options[_bionic_variant];


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix the condition to check for non-empty bionic options array using array_length instead of direct comparison.