### PR TITLE
ci: Update access key name

### DIFF
--- a/.github/workflows/gamemaker_build.yml
+++ b/.github/workflows/gamemaker_build.yml
@@ -93,7 +93,7 @@ jobs:
         with:
           runtime-version: 2023.11.1.160
           target-yyp: ${{ steps.find_yyp.outputs.yyp-path }}
-          access-key: ${{ secrets.ACCESS_KEY }}
+          access-key: ${{ secrets.GM_ACCESS_KEY }}
           
       # Update the version.json file with build date and other versioning information
       - id: igor_build


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Use `GM_ACCESS_KEY` secret instead of `ACCESS_KEY` for the GameMaker build workflow.