### PR TITLE
fix: Minor scoping error in one of the new ship return events

### DIFF
--- a/scripts/scr_player_ship_functions/scr_player_ship_functions.gml
+++ b/scripts/scr_player_ship_functions/scr_player_ship_functions.gml
@@ -50,7 +50,7 @@ function return_lost_ship(){
 				if (array_length(_units)){
 					_text += $"While in the warp the geller fields temporarily went down leaving the ships crew to face the horror of the warp";
 					for (var i=0;i<array_length(_units);i++){
-						_units.edit_corruption(max(0,irandom_range(20, 120)-_unit.piety));
+						_units[i].edit_corruption(max(0,irandom_range(20, 120)-_unit.piety));
 					}
 				}
 			} else if (_return_defect>50){


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix an issue where piety was not correctly used when calculating corruption for returned ships.