### PR TITLE
fix: Initialisation of local complex_set variable moved in draw_unit_image

### DIFF
--- a/scripts/scr_draw_unit_image/scr_draw_unit_image.gml
+++ b/scripts/scr_draw_unit_image/scr_draw_unit_image.gml
@@ -290,6 +290,7 @@ function set_shader_array(shader_array){
 /// @mixin
 function scr_draw_unit_image(_background=false){
     var _role = obj_ini.role[100];
+    var complex_set={};    
     var draw_unit_hands = function(x_surface_offset, y_surface_offset, armour_type, specialist_colours, hide_bionics, right_left){
         if (arm_variant[right_left] == 1) {
             return;
@@ -448,7 +449,6 @@ function scr_draw_unit_image(_background=false){
         var armour_type = ArmourType.Normal;
         var armour_sprite = spr_weapon_blank;
         var complex_livery = false;
-        var complex_set={};
         var back_equipment = BackType.None;
         var psy_hood = 0;
         var skull_mask = 0;


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Move the initialization of the local variable 'complex_set' to the beginning of the 'scr_draw_unit_image' function to ensure it is properly initialized before use.