### PR TITLE
fix: Stop bug where Squad View no longer appears

### DIFF
--- a/objects/obj_bomb_select/Create_0.gml
+++ b/objects/obj_bomb_select/Create_0.gml
@@ -41,23 +41,22 @@ necrons=0;
 with(obj_en_fleet){
     if (owner == eFACTION.Imperium) or (owner == eFACTION.Mechanicus) or (owner  == eFACTION.Inquisition) or (action!="") then instance_deactivate_object(id);
 }
-instance_create(obj_star_select.target.x,obj_star_select.target.y,obj_temp3);
+var _select_x = obj_star_select.target.x;
+var _select_y = obj_star_select.target.y;
 with(obj_fleet){
-    if (point_distance(x,y,obj_temp3.x,obj_temp3.y)>35) then instance_deactivate_object(id);
+    if (point_distance(x,y,_select_x,_select_y)>20) then instance_deactivate_object(id);
 }
 
-var bib=instance_nearest(obj_temp3.x,obj_temp3.y,obj_en_fleet);
+var bib=instance_nearest(_select_x,_select_y,obj_en_fleet);
 if (instance_exists(bib)){
-    if (point_distance(obj_temp3.x,obj_temp3.y,bib.x,bib.y)<=35){
+    if (point_distance(_select_x,_select_y,bib.x,bib.y)<=35){
         
         scr_popup("Cannot Bombard","Enemy fleets are preventing bombardment!","","");
         
-        with(obj_temp3){instance_destroy();}
         instance_activate_object(obj_en_fleet);
         instance_destroy();
         exit;
     }
-    with(obj_temp3){instance_destroy();}
 }
 instance_activate_object(obj_en_fleet);
 

--- a/objects/obj_controller/Alarm_1.gml
+++ b/objects/obj_controller/Alarm_1.gml
@@ -494,11 +494,18 @@ if (did==1){
     }
     
     // Ork planets here
+
+    var _imperial_planets = [];
+    var _non_xenos_chaos = [];
     with(obj_star){
-        if (planets>0) and (owner == eFACTION.Imperium) and (p_type[1]!="Dead"){
-            //this object simply acts as a counter of ork owned planets
-            instance_create(x,y,obj_temp3);
+        if (is_dead_star() || planets==0){
+            continue;
         }
+        if  (owner == eFACTION.Imperium){
+            //this object simply acts as a counter of ork owned planets
+            array_push(_imperial_planets, id);
+        }
+      
     }
     
     var ed2,n,i,orkz=choose(4,5,6)+5;
@@ -508,22 +515,14 @@ if (did==1){
     if (is_test_map==true) then orkz=4;
 
     for(var j=0; j<orkz; j++){
-        n=instance_number(obj_temp3);
-        i=floor(random(n));
-        current_system=instance_find(obj_temp3, i);
-        ed2=instance_nearest(current_system.x,current_system.y,obj_star);
+        n=array_length(_imperial_planets);
+        i = array_random_index(_imperial_planets);
+        current_system=_imperial_planets[i];
         
-        ed2.planet[1]=1;
-        ed2.owner = eFACTION.Ork;
-		ed2.p_owner = array_create(5, ed2.owner)
-        with(current_system){instance_destroy();}
-    }
-    with(obj_temp3){instance_destroy();}
-    
-    with(obj_star){
-        if (planets>0) and (owner == eFACTION.Imperium) and (p_type[1]!="Dead"){
-            instance_create(x,y,obj_temp3);
-        }
+        current_system.planet[1]=1;
+        current_system.owner = eFACTION.Ork;
+		current_system.p_owner = array_create(5, current_system.owner)
+        array_delete(_imperial_planets, i, 1);
     }
 
     if (field=="tyranids"){
@@ -531,39 +530,42 @@ if (did==1){
         if (obj_ini.fleet_type==ePlayerBase.penitent) then orkz+=2;
         
         for(var j=0; j<orkz; j++){
-            n=instance_number(obj_temp3);
-            i=floor(random(n));
-            current_system=instance_find(obj_temp3, i);
-            ed2=instance_nearest(current_system.x,current_system.y,obj_star);
+            n=array_length(_imperial_planets);
+            i = array_random_index(_imperial_planets);
+            current_system=_imperial_planets[i];
 
-            ed2.planet[1]=1;
-            ed2.p_owner[1]=9;
-            ed2.owner = eFACTION.Tyranids;
-            with(current_system){instance_destroy();}
+            current_system.planet[1]=1;
+            current_system.p_owner[1]=9;
+            current_system.owner = eFACTION.Tyranids;
+
+            array_delete(_imperial_planets, i, 1);
         }
     }
-    with(obj_temp3){instance_destroy();}
     
     with(obj_star){
-        if (planets>0) and (owner<=5) and (p_type[1]!="Dead"){
-            instance_create(x,y,obj_temp3);
-        }
+        if (is_dead_star() || planets==0){
+            continue;
+        }        
+        if (owner<=5) {
+            array_push(_non_xenos_chaos, id);
+        } 
     }
+
+
     if (field=="both"){
         if (obj_ini.fleet_type==ePlayerBase.penitent) then orkz+=3;
         orkz+=3;
         for(var j=0; j<orkz; j++){
-            n=instance_number(obj_temp3);
-            i=floor(random(n));
-            current_system=instance_find(obj_temp3, i);
-            ed2=instance_nearest(current_system.x,current_system.y,obj_star);
-            ed2.planet[1]=1;
-            ed2.p_owner[1]=90;
-            ed2.owner=90;
-            with(current_system){instance_destroy();}
+            n=array_length(_non_xenos_chaos);
+            i=array_random_index(_non_xenos_chaos);
+            current_system=_non_xenos_chaos[i];
+
+            current_system.planet[1]=1;
+            current_system.p_owner[1]=90;
+            current_system.owner=90;
+            array_delete(_non_xenos_chaos, i, 1);
         }
     }
-    with(obj_temp3){instance_destroy();}
     
     // Another mechanicus
     repeat(choose(3,4,5)){
@@ -630,27 +632,28 @@ scr_restart_variables(2);
 if (!instance_exists(obj_saveload)) and (instance_exists(obj_creation)) and (global.load=0){
     for(var i=1; i<=10; i++){
         if (obj_creation.world[i]!=""){
+            var _wanted_worlds = [];
             with(obj_star){
                 for(var run=1; run<=4; run++){
-                    if (p_type[run]=obj_creation.world_type[i]) then instance_create(x,y,obj_temp3);
+                    if (p_type[run]=obj_creation.world_type[i]){
+                        array_push(_wanted_worlds, id);
+                    }
                 }
             }
             
-            var him=instance_nearest(random(room_width),random(room_height),obj_temp3);
+            var _chosen_world=array_random_element(_wanted_worlds);
             
-            if (instance_exists(him)){
-                var him2=instance_nearest(him.x,him.y,obj_star);
-                with(obj_temp3){instance_destroy();}
+            if (instance_exists(_chosen_world)){
                 for(var run=1; run<=4; run++){
-                    if (him2.p_type[run]=obj_creation.world_type[i]){
-                        him2.name=obj_creation.world[i];
-                        if (obj_creation.world_feature[i]!="") then him2.p_feature[run]=[];
+                    if (_chosen_world.p_type[run]=obj_creation.world_type[i]){
+                        _chosen_world.name=obj_creation.world[i];
+                        if (obj_creation.world_feature[i]!="") then _chosen_world.p_feature[run]=[];
                         obj_creation.world[i]="";
                         obj_creation.world_type[i]="";
                         obj_creation.world_feature[i]="";
                     }
                 }
-                instance_deactivate_object(him2);
+                instance_deactivate_object(_chosen_world);
             }
         }
     }

--- a/objects/obj_ground_mission/Alarm_6.gml
+++ b/objects/obj_ground_mission/Alarm_6.gml
@@ -18,7 +18,6 @@ if (obj_controller.disposition[3]>50) then obj_controller.disposition[3]+=11;
 with(obj_controller){scr_dialogue("stc_thanks");}
 
 with(obj_temp2){instance_destroy();}
-with(obj_temp3){instance_destroy();}
 with(obj_temp7){instance_destroy();}
 
 if (obj_ini.fleet_type=ePlayerBase.home_world) then with(obj_star){
@@ -33,27 +32,32 @@ if (obj_ini.fleet_type != ePlayerBase.home_world) then with(obj_p_fleet){// Get 
 if (obj_ini.fleet_type != ePlayerBase.home_world){
     with(obj_p_fleet){if (action="") then instance_deactivate_object(instance_nearest(x,y,obj_star));}
 }
-with(obj_star){// Get origin star system for enemy fleet
-    if (owner=obj_controller.diplomacy) and ((p_owner[1]=obj_controller.diplomacy) or (p_owner[2]=obj_controller.diplomacy) 
-    or (p_owner[3]=obj_controller.diplomacy) or (p_owner[4]=obj_controller.diplomacy)){
-        instance_create(x,y,obj_temp3);
-    }
+
+var flit, i,chasing;chasing=0;// Set target
+var targ
+if (instance_exists(obj_temp2)){
+    targ = nearest_star_with_ownership(obj_temp2.x, obj_temp2.y,obj_controller.diplomacy );
+} else if (instance_exists(obj_temp7)){
+    targ = nearest_star_with_ownership(obj_temp7.x, obj_temp7.y,obj_controller.diplomacy );
 }
 
-var targ, flit, i,chasing;chasing=0;// Set target
 
-if (instance_exists(obj_temp2)) then targ=instance_nearest(obj_temp2.x,obj_temp2.y,obj_temp3);
-if (!instance_exists(obj_temp2)) and (instance_exists(obj_temp7)) then targ=instance_nearest(obj_temp7.x,obj_temp7.y,obj_temp3);
 
 // If player fleet is flying about then get their target for new target
-if (!instance_exists(obj_temp2)) and (!instance_exists(obj_temp7)) and (instance_exists(obj_p_fleet)) and (obj_ini.fleet_type = ePlayerBase.home_world){chasing=1;
+else if (!instance_exists(obj_temp2)) and (!instance_exists(obj_temp7)) and (instance_exists(obj_p_fleet)) and (obj_ini.fleet_type = ePlayerBase.home_world){
+    chasing=1;
     with(obj_p_fleet){var pop;
-        if (capital_number>0) and (action!=""){pop=instance_create(action_x,action_y,obj_temp2);pop.action_eta=action_eta;}
-        if (frigate_number>0) and (action!=""){pop=instance_create(action_x,action_y,obj_temp7);pop.action_eta=action_eta;}
+        if (capital_number>0) and (action!=""){
+            pop=instance_create(action_x,action_y,obj_temp2);
+            pop.action_eta=action_eta;
+        }
+        if (frigate_number>0) and (action!=""){
+            pop=instance_create(action_x,action_y,obj_temp7);
+            pop.action_eta=action_eta;
+        }
     }
 }
-if (instance_exists(obj_temp2)) then targ=instance_nearest(obj_temp2.x,obj_temp2.y,obj_temp3);
-if (!instance_exists(obj_temp2)) and (instance_exists(obj_temp7)) then targ=instance_nearest(obj_temp7.x,obj_temp7.y,obj_temp3);
+
 
 flit=instance_create(targ.x,targ.y,obj_en_fleet);
 
@@ -78,7 +82,6 @@ flit.alarm[4]=1;
 
 instance_activate_all();
 with(obj_temp2){instance_destroy();}
-with(obj_temp3){instance_destroy();}
 with(obj_temp7){instance_destroy();}
 instance_destroy();
 

--- a/objects/obj_ncombat/Alarm_5.gml
+++ b/objects/obj_ncombat/Alarm_5.gml
@@ -689,7 +689,6 @@ if (obj_ini.omophagea){
                 instance_deactivate_object(obj_turn_end);
 
                 with(inquisitor_ship){instance_destroy();}
-                with(obj_temp3){instance_destroy();}
                 with(obj_ground_mission){instance_destroy();}
             }
             instance_deactivate_object(obj_star);

--- a/objects/obj_star_select/Draw_64.gml
+++ b/objects/obj_star_select/Draw_64.gml
@@ -711,7 +711,6 @@ if (obj_controller.selecting_planet!=0){
             if (instance_exists(obj_bomb_select)){
                 obj_bomb_select.p_target=target;
                 obj_bomb_select.sh_target=instance_nearest(x,y,obj_p_fleet);
-                if (instance_nearest(x,y,obj_p_fleet).acted=0) then instance_create(target.x,target.y,obj_temp3);
                 if (instance_nearest(x,y,obj_p_fleet).acted>0) then with(obj_bomb_select){instance_destroy();}
             }
         }else if (current_button=="+Recruiting"){

--- a/scripts/scr_system_search_helpers/scr_system_search_helpers.gml
+++ b/scripts/scr_system_search_helpers/scr_system_search_helpers.gml
@@ -193,7 +193,7 @@ function nearest_star_proper(xx,yy) {
 }
 
 
-function nearest_star_with_ownership(xx,yy, ownership, start_star="none"){
+function nearest_star_with_ownership(xx,yy, ownership, start_star="none", ignore_dead = true){
 	var nearest = "none"
 	var total_stars =  instance_number(obj_star);
 	var i=0;
@@ -204,7 +204,7 @@ function nearest_star_with_ownership(xx,yy, ownership, start_star="none"){
 		i++;
 		var cur_star =  instance_nearest(xx,yy, obj_star);
 		if (start_star!="none"){
-			if (start_star.id == cur_star.id){
+			if (start_star.id == cur_star.id ||( is_dead_star(cur_star) && ignore_dead)){
 				instance_deactivate_object(cur_star.id);
 				continue;
 			}

--- a/scripts/scr_ui_manage/scr_ui_manage.gml
+++ b/scripts/scr_ui_manage/scr_ui_manage.gml
@@ -1111,7 +1111,7 @@ function scr_ui_manage() {
 					stats_displayed = false;
 				}
 		        with (obj_controller){
-    		        if (view_squad && !instance_exists(obj_temp3) && !instance_exists(obj_popup)){
+    		        if (view_squad && !instance_exists(obj_popup)){
     		        	if (managing>10){
     		        		view_squad=false;
     		        		unit_profile=false;


### PR DESCRIPTION
- attempts to fix the common bug of the squad view becoming inaccessible 
  - it appears it was due to a clause making it non viewable if instances of obj_temp3 existed
- attempt to remove as many uneeded obj_temp3 references as possible that can be done safely and easily

## Summary by Sourcery

Bug Fixes:
- Fix a bug that prevented the Squad View from appearing when instances of obj_temp3 existed.