### PR TITLE
fix: Homeworld saveload

### DIFF
--- a/scripts/scr_save_chapter/scr_save_chapter.gml
+++ b/scripts/scr_save_chapter/scr_save_chapter.gml
@@ -20,7 +20,7 @@ function scr_save_chapter(chapter_id){
 	chap.purity = purity;
 	chap.stability = stability;
 	chap.cooperation = cooperation;
-	chap.homeword = homeworld;
+	chap.homeworld = homeworld;
 	chap.homeworld_exists = homeworld_exists;
 	chap.homeworld_name = homeworld_name;
 	chap.homeworld_rule = homeworld_rule;


### PR DESCRIPTION
<!--- PR title format should be `commit type: Title` -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add `@sourcery-ai` into the title, so that the bot auto-generates a title -->
## Description of changes
<!--- Leverage the list functionality, if you have many changes -->
-Fixes an issue where all loaded custom chapters had a hive world due to a typo in scr_save_chapter
## Reasons for changes
<!--- Leverage the list functionality, here as well -->
- bigfix
## Related links
<!--- Other PRs; Discord bug reports, messages, threads, etc.; outside docs, etc.; -->
-https://discord.com/channels/714022226810372107/1322375198493904989
