### PR TITLE
fix: Spawning bugs with outdated function name

### DIFF
--- a/scripts/scr_add_man/scr_add_man.gml
+++ b/scripts/scr_add_man/scr_add_man.gml
@@ -229,7 +229,7 @@ function scr_add_man(man_role, target_company, spawn_exp, spawn_name, corruption
 			unit = new TTRPG_stats("chapter", target_company, good, "scout", other_data);
 			unit.corruption = corruption
 			unit.roll_age(); // Age here
-			unit.alter_unit_equipment(_gear);
+			unit.alter_equipment(_gear);
 			marines += 1;
 
 			if (!other_gear) {

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -1603,7 +1603,11 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data={}) 
 			} else {
 				location_type =  location_types.ship; //marine is on ship
 				location_id = ship_location; //ship array position
-				location_name = obj_ini.ship_location[location_id]; //location of ship
+				if (location_id<array_length(obj_ini.ship_location)){
+					location_name = obj_ini.ship_location[location_id]; //location of ship
+				} else {
+					location_name = location_name = obj_ini.loc[company][marine_number];
+				}
 			}
 			return [location_type,location_id ,location_name];
 		};


### PR DESCRIPTION
- bug from outdated function name in scr_add_man
- occasionally stored unit.ship_location would go stale 
   - will need to find better solution in future in theory scr_ship_clean should prevent this

## Summary by Sourcery

Bug Fixes:
- Fixed a bug that caused marine location data to become stale.