### PR TITLE
fix: ai_a script increase efficiency and error handling to find unresolved crash

### DIFF
--- a/objects/obj_star/Step_0.gml
+++ b/objects/obj_star/Step_0.gml
@@ -34,7 +34,7 @@ if (ai_a>=0){
     ai_a--;
     if (ai_a==0){
         try{
-            scr_enemy_ai_a
+            scr_enemy_ai_a();
         } catch(_exception){
             handle_exception(_exception);
         }
@@ -44,7 +44,7 @@ if (ai_b>=0){
     ai_b--;
     if (ai_b==0){
         try{
-            scr_enemy_ai_b
+            scr_enemy_ai_b();
         } catch(_exception){
             handle_exception(_exception);
         }
@@ -54,7 +54,7 @@ if (ai_c>=0){
     ai_c--;
     if (ai_c==0){
         try{
-            scr_enemy_ai_c
+            scr_enemy_ai_c();
         } catch(_exception){
             handle_exception(_exception);
         }
@@ -64,7 +64,7 @@ if (ai_d>=0){
     ai_d--;
     if (ai_d==0){
         try{
-            scr_enemy_ai_d
+            scr_enemy_ai_d();
         } catch(_exception){
             handle_exception(_exception);
         }
@@ -74,7 +74,7 @@ if (ai_e>=0){
     ai_e--;
     if (ai_e==0){
         try{
-            scr_enemy_ai_e
+            scr_enemy_ai_e();
         } catch(_exception){
             handle_exception(_exception);
         }

--- a/scripts/scr_enemy_ai_a/scr_enemy_ai_a.gml
+++ b/scripts/scr_enemy_ai_a/scr_enemy_ai_a.gml
@@ -40,22 +40,19 @@ function scr_enemy_ai_a() {
 
 	// checking for inquisition dead world inspections here
 	if (present_fleet[eFACTION.Player]>=0) and (present_fleet[eFACTION.Inquisition]==0){
-	    var chapter_asset_discovery,cur_planet=0,yep=0,stop=false,shitty=false;
-    
-	    chapter_asset_discovery=floor(random(200))+1;
-
-	    if (array_contains(obj_ini.dis,"Shitty Luck")) then shitty=true;
-
-	    if (shitty=true) then chapter_asset_discovery=floor(random(50))+1;
+	    var chapter_asset_discovery,yep=0,stop=false;
+   
+	    var shitty = scr_has_disadv("Shitty Luck");
     
 	    if (present_fleet[1]=0){
-	        chapter_asset_discovery=floor(random(2000))+1;
-	        if (shitty=true) then chapter_asset_discovery=floor(random(800))+1;
+	    	chapter_asset_discovery = irandom_range(1, shitty?800:2000);
+	    } else {
+	    	chapter_asset_discovery = irandom_range(1, shitty?50:200);
 	    }
     
 	    // 137 ; chapter_asset_discovery=floor(random(20))+1;
     
-	    cur_planet=0;
+	    var cur_planet=0;
 	    if (chapter_asset_discovery<=5){
 		    repeat(planets){
 		    	cur_planet+=1;
@@ -86,7 +83,7 @@ function scr_enemy_ai_a() {
 	            var plap=0,old_x=x,old_y=y,flee=0;
             	var _current_planet_name = name;
             	var launch_planet, launch_point_found=false;
-            	launch_planet = nearest_star_with_ownership(x,y, [owner=eFACTION.Imperium, owner=eFACTION.Mechanicus], self.id);
+            	launch_planet = nearest_star_with_ownership(x,y, [eFACTION.Imperium, eFACTION.Mechanicus], self.id);
             	if (launch_planet != "none"){
 	            	if (instance_exists(launch_planet)){
 			            flee=instance_create(launch_planet.x,launch_planet.y,obj_en_fleet);
@@ -870,6 +867,7 @@ function scr_enemy_ai_a() {
 	    }
 	    
 	    if (p_raided[_run] > 0) then p_raided[_run] = 0;
+	    delete _planet_data;
 	} // end repeat here
 
 


### PR DESCRIPTION
- increase efficiency of calling of ai scripts in obj_Star step
- deprecate try_And_Report_loop for try{}catch(){handle_exception}
- improves checks for "Shitty Luck" in ai_a

- aim is to make https://discord.com/channels/714022226810372107/1320239221830844546 this easier to find and resolve
## Summary by Sourcery

Improve the efficiency and error handling of the AI scripts for the "obj_Star" step. Replace the "try_And_Report_loop" with a try-catch block. Improve the checks for "Shitty Luck" in "ai_a".

New Features:
- Implement error handling for AI scripts.

Enhancements:
- Improve the efficiency of calling AI scripts.

Tests:
- Update tests for AI scripts.