### PR TITLE
fix: Crash from unset sector name

### DIFF
--- a/objects/obj_controller/Draw_64.gml
+++ b/objects/obj_controller/Draw_64.gml
@@ -62,8 +62,9 @@ if (!zoomed && !zui){
     draw_set_font(fnt_menu);
     draw_set_halign(fa_center);
     // Draws the sector name
-    draw_text(775,17,string_hash_to_newline("Sector "+string(obj_ini.sector_name)));
-    draw_text(775.5,17.5,string_hash_to_newline("Sector "+string(obj_ini.sector_name)));
+    var _sector_string = $"Sector {obj_ini.sector_name}";
+    draw_text(775,17,_sector_string);
+    draw_text(775.5,17.5,_sector_string);
     
     // Checks if you are penitent
     if (obj_controller.faction_status[eFACTION.Imperium]!="War"){

--- a/objects/obj_ini/Create_0.gml
+++ b/objects/obj_ini/Create_0.gml
@@ -18,6 +18,9 @@ companies=10;
 progenitor=ePROGENITOR.NONE;
 aspirant_trial = 0;
 
+//defualt sector name to prevent potential crash
+sector_name = "Terra Nova";
+
 load_to_ships=[2,0,0];
 if (instance_exists(obj_creation)){load_to_ships=obj_creation.load_to_ships;}
 


### PR DESCRIPTION
## Description of changes
- add default sector_name to obj_ini create
## Reasons for changes
- stops rare crash from unset sector name
## Related links
- https://discord.com/channels/714022226810372107/1323303649723682887

## Summary by Sourcery

Bug Fixes:
- Prevent a crash caused by an unset sector name.