### PR TITLE
refactor: trait usage standardisation 

### DIFF
--- a/objects/obj_controller/Alarm_5.gml
+++ b/objects/obj_controller/Alarm_5.gml
@@ -563,11 +563,11 @@ if (turn=240) and (global.chapter_name="Lamenters"){
 }
 */
 // ** Battlefield Loot **
-if (array_contains(obj_ini.adv,"Tech-Scavengers")){
+if (scr_has_adv("Tech-Scavengers")){
     var lroll1,lroll2,loot="";
     lroll1=floor(random(100))+1;
     lroll2=floor(random(100))+1;
-    if (array_contains(obj_ini.dis,"Shitty Luck")){
+    if (scr_has_disadv("Shitty Luck")){
         lroll1+=2;
         lroll2+=25;
     }
@@ -1079,7 +1079,7 @@ for(var i=1; i<=99; i++){
             if (string_count("inquisitor_spared",event[i])>0){
                 var diceh=floor(random(100))+1;
 
-                if (string_count("Shit",obj_ini.strin2)>0) then diceh-=25;
+                if (scr_has_disadv("Shitty Luck")) then diceh-=25;
 
                 if (diceh<=25){
                     alarm[8]=1;

--- a/objects/obj_controller/Create_0.gml
+++ b/objects/obj_controller/Create_0.gml
@@ -1283,7 +1283,7 @@ other1="";
 // ** Sets up bonuses once chapter is created **
 if (instance_exists(obj_ini)){
     // Tolerant trait
-    if (global.load==0) and (string_count("Tolerant",obj_ini.strin2)>0){
+    if (global.load==0 && scr_has_disadv("Tolerant")){
         obj_controller.disposition[6]+=5;
         obj_controller.disposition[7]+=5;
         obj_controller.disposition[8]+=10;
@@ -1376,7 +1376,7 @@ penitorium=0;
 end_turn_insights = {};
 // Redefines training based on chapter
 if (instance_exists(obj_ini)){
-    if (string_count("Intolerant",obj_ini.strin2)>0) then training_psyker=0;
+    if (scr_has_disadv("Psyker Intolerant")) then training_psyker=0;
     if (global.chapter_name="Space Wolves") then training_chaplain=0;
 }
 

--- a/objects/obj_fleet/Create_0.gml
+++ b/objects/obj_fleet/Create_0.gml
@@ -105,20 +105,20 @@ en_mutation[1]="";
 en_mutation[2]="";
 
 // 
-ambushers=0;if (string_count("Ambushers",obj_ini.strin)>0) then ambushers=1;
-bolter_drilling=0;if (string_count("Bolter",obj_ini.strin)>0) then bolter_drilling=1;
-enemy_eldar=0;if (string_count("Enemy: Eldar",obj_ini.strin)>0) then enemy_eldar=1;
-enemy_fallen=0;if (string_count("Enemy: Fallen",obj_ini.strin)>0) then enemy_fallen=1;
-enemy_orks=0;if (string_count("Enemy: Orks",obj_ini.strin)>0) then enemy_orks=1;
-enemy_tau=0;if (string_count("Enemy: Tau",obj_ini.strin)>0) then enemy_tau=1;
-enemy_tyranids=0;if (string_count("Enemy: Tyraninids",obj_ini.strin)>0) then enemy_tyranids=1;
-siege=0;if (string_count("Siege",obj_ini.strin)>0) then siege=1;
-slow=0;if (string_count("Purposeful",obj_ini.strin)>0) then slow=1;
-melee=0;if (string_count("Melee Enthus",obj_ini.strin)>0) then melee=1;
+ambushers = scr_has_adv("Ambushers");
+bolter_drilling = scr_has_adv("Bolter Drilling");
+enemy_eldar= scr_has_adv("Enemy: Eldar");
+enemy_fallen=scr_has_adv("Enemy: Fallen");
+enemy_orks=scr_has_adv("Enemy: Orks");
+enemy_tau = scr_has_adv("Enemy: Tau");
+enemy_tyranids= scr_has_adv("Enemy: Tyranids");
+siege=scr_has_adv("Siege Masters");
+slow=scr_has_adv("Devastator Doctrine");
+melee=scr_has_adv("Assault Doctrine");
 // 
-black_rage=0;if (string_count("Black Rage",obj_ini.strin2)>0) then black_rage=1;
-shitty_luck=0;if (string_count("Shitty",obj_ini.strin2)>0) then shitty_luck=1;
-warp_touched=0;if (string_count("Warp Touched",obj_ini.strin2)>0) then warp_touched=1;
+black_rage=scr_has_disadv("Black Rage");
+shitty_luck=scr_has_disadv("Shitty Luck");
+warp_touched=scr_has_disadv("Warp Touched");
 lyman=obj_ini.lyman;// drop pod penalties
 omophagea=obj_ini.omophagea;// feast
 ossmodula=obj_ini.ossmodula;// small penalty to all
@@ -139,7 +139,11 @@ if (obj_controller.stc_bonus[5]=2) then global_attack=1.05;
 if (obj_controller.stc_bonus[6]=1) then global_defense+=0.1;
 
 // Kings of Space Bonus
-if (string_count("Kings of Space",obj_ini.strin)>0){control=1;global_defense+=0.1;global_attack+=0.1;}
+if (scr_has_adv("Kings of Space")){
+    control=1;
+    global_defense+=0.1;
+    global_attack+=0.1;
+}
 
 
 

--- a/objects/obj_ini/Create_0.gml
+++ b/objects/obj_ini/Create_0.gml
@@ -11,8 +11,8 @@ sixths=0;sevenths=0;eighths=0;ninths=0;tenths=0;commands=0;
 
 heh1=0;heh2=0;
 
-strin="";
-strin2="";
+// strin="";
+// strin2="";
 tolerant=0;
 companies=10;
 progenitor=ePROGENITOR.NONE;

--- a/objects/obj_ncombat/Alarm_5.gml
+++ b/objects/obj_ncombat/Alarm_5.gml
@@ -51,20 +51,20 @@ if (ground_mission){
 };
 
 seed_saved=(min(seed_max,apothecaries_alive*40))-gene_penalty;
-if (string_count("Doom",obj_ini.strin2)>0) then seed_saved=0;
+if (obj_ini.doomed) then seed_saved=0;
 if (seed_saved>0) then obj_controller.gene_seed+=seed_saved;
 
-if (string_count("Doom",obj_ini.strin2)>0) &&  (!apothecaries_alive){
+if (obj_ini.doomed && !apothecaries_alive){
     part3=$"Chapter Mutation prevents retrieving Gene-Seed.  {seed_max} Gene-Seed lost.";
     newline=part3;
     scr_newtext();
     newline=" ";
     scr_newtext();
-}else if (!apothecaries_alive) and (string_count("Doom",obj_ini.strin2)=0){
+}else if (!apothecaries_alive && !obj_ini.doomed){
     part3=$"No able-bodied {roles[eROLE.Apothecary]}.  {seed_max} Gene-Seed lost.";
     newline=part3;scr_newtext();
     newline=" ";scr_newtext();
-}else if (apothecaries_alive>0) and (final_deaths+final_command_deaths>0) and (string_count("Doom",obj_ini.strin2)=0){
+}else if (apothecaries_alive>0 && final_deaths+final_command_deaths>0 && !obj_ini.doomed){
     part3=$"Gene-Seed Recovered: {seed_saved}(";
     part3 += seed_saved ? $"{round((seed_saved/seed_max)*100)}" : "0";
     part3 += "%)";
@@ -246,7 +246,7 @@ if (defeat=0) and (battle_special="space_hulk"){
     if (ex=100) then newline_color="red";
     scr_newtext();
 
-    if (string_count("Shitty",obj_ini.strin2)>0) then dicey=dicey*1.5;
+    if (scr_has_disadv("Shitty Luck")) then dicey=dicey*1.5;
     // show_message("Roll Under: "+string(enemy_power*10)+", Roll: "+string(dicey));
 
     if (dicey<=(enemy_power*10)){
@@ -577,7 +577,7 @@ if (obj_ini.omophagea){
 
     if (red_thirst=3) then thirsty=1;if (red_thirst>3) then thirsty=red_thirst-2;
     if (thirsty>0) then eatme-=(thirsty*6);if (really_thirsty>0) then eatme-=(really_thirsty*15);
-    if (string_count("Shitty",obj_ini.strin2)=1) then eatme-=10;
+    if (scr_has_disadv("Shitty Luck")) then eatme-=10;
 
     if (allies>0){
         obj_controller.disposition[2]-=choose(1,0,0);
@@ -609,7 +609,7 @@ if (obj_ini.omophagea){
 
         // check for pdf/guardsmen
         eatme=floor(random(100))+1;
-        if (array_contains(obj_ini.dis,"Shitty Luck")) then eatme-=10;
+        if (scr_has_disadv("Shitty Luck")) then eatme-=10;
         if (eatme<=10) and (allies>0){
             obj_controller.disposition[2]-=2;
             if (allies=1){
@@ -625,7 +625,7 @@ if (obj_ini.omophagea){
 
         // check for inquisitor
         eatme=floor(random(100))+1;
-        if (array_contains(obj_ini.dis,"Shitty Luck")) then eatme-=5;
+        if (scr_has_disadv("Shitty Luck")) then eatme-=5;
         if (eatme<=40) and (present_inquisitor=1){
             var thatta=0,remove=0,i=0;
             obj_controller.disposition[4]-=10;

--- a/objects/obj_popup/Draw_0.gml
+++ b/objects/obj_popup/Draw_0.gml
@@ -123,7 +123,7 @@ if (type=99){
             if (giveto=5) and (!is_daemon){
                 obj_controller.disposition[5]+=4;
                 var o=0
-                if (array_contains(obj_ini.adv, "Reverent Guardians")) then obj_controller.disposition[5]+=2;
+                if (scr_has_adv("Reverent Guardians")) then obj_controller.disposition[5]+=2;
             }
             if (giveto=6) then obj_controller.disposition[6]+=3;
             if (giveto=8) then obj_controller.disposition[8]+=4;

--- a/objects/obj_popup/Step_0.gml
+++ b/objects/obj_popup/Step_0.gml
@@ -333,7 +333,7 @@ if (title="Planetary Governor Assassinated") and (option1!="") and (cooldown<=0)
     
     if (press>0){
         var randa,randa2;randa=floor(random(100))+1;randa2=floor(random(100))+1;
-        if (string_count("Shitty",obj_ini.strin2)>0) then randa-=20;
+        if (scr_has_disadv("Shitty Luck")) then randa-=20;
     }
     
     if (press=1){
@@ -570,7 +570,7 @@ if (image="ancient_ruins" && woopwoopwoop && move_to_next_stage()) {
         _ruins.determine_race()
         
         dice=floor(random(100))+1;
-        var shit_luck = array_contains(obj_ini.dis,"Shitty Luck")
+        var shit_luck = scr_has_disadv("Shitty Luck")
         var pass_mark = shit_luck ? 66 : 50;
         ruins_battle = dice<=pass_mark;
         

--- a/objects/obj_star_select/Draw_64.gml
+++ b/objects/obj_star_select/Draw_64.gml
@@ -384,7 +384,7 @@ if (obj_controller.selecting_planet!=0){
                 
                 var improve_cost=1500,yep=0,o=0;
 
-                if (array_contains(obj_ini.adv, "Siege Masters")) then improve_cost=1100;
+                if (scr_has_adv("Siege Masters")) then improve_cost=1100;
                 
                 draw_text_glow(xx+671, yy+281,string(improve_cost),16291875,0);
                 

--- a/scripts/scr_add_artifact/scr_add_artifact.gml
+++ b/scripts/scr_add_artifact/scr_add_artifact.gml
@@ -96,7 +96,7 @@ function scr_add_artifact(artifact_type, artifact_tags, is_identified, artifact_
 
 
 	rand2=floor(random(100))+1;good=0;
-	if (string_count("Shit",obj_ini.strin2)>0){rand2=min(rand2+20,100);}
+	if (scr_has_disadv("Shitty Luck")){rand2=min(rand2+20,100);}
 	if (rand2<=70){t3="";}
 	else if (rand2<=90 && artifact_type!="random_nodemon"){
 		array_push(tags, "chaos");

--- a/scripts/scr_draw_unit_image/scr_draw_unit_image.gml
+++ b/scripts/scr_draw_unit_image/scr_draw_unit_image.gml
@@ -813,7 +813,7 @@ function scr_draw_unit_image(_background=false){
                     dev_trait=1
                 }
                 if (unit_specialization == UnitSpecialization.Techmarine){
-                    if (array_contains(obj_ini.adv,"Tech-Brothers")){
+                    if (scr_has_adv("Tech-Brothers")){
                         tech_brothers_trait=0
                     }
 				}
@@ -1473,7 +1473,7 @@ function scr_draw_unit_image(_background=false){
                     var psy_hood_offset_x = 0;
                     var psy_hood_offset_y = 0;
                     robes_hood_bypass = true;
-                    if (array_contains(obj_ini.adv,"Daemon Binders") && !modest_livery && psy_hood<7){
+                    if (scr_has_adv("Daemon Binders") && !modest_livery && psy_hood<7){
 						robes_bypass = true;
                         if (pauldron_trim=1){
 							draw_sprite(spr_gear_hood2,0,x_surface_offset-2,y_surface_offset-11);
@@ -1669,9 +1669,9 @@ function scr_draw_unit_image(_background=false){
                 var helm_ii,o,yep;
                 helm_ii=0;
 				yep=0;
-                if (array_contains(obj_ini.adv,"Tech-Brothers")){
+                if (scr_has_adv("Tech-Brothers")){
                     helm_ii=2;
-                }else if (array_contains(obj_ini.adv, "Never Forgive") || obj_ini.progenitor == ePROGENITOR.DARK_ANGELS){
+                }else if (scr_has_adv("Never Forgive") || obj_ini.progenitor == ePROGENITOR.DARK_ANGELS){
                     helm_ii=3;
                 } else if (reverent_guardians) {
                     helm_ii=4;

--- a/scripts/scr_enemy_ai_b/scr_enemy_ai_b.gml
+++ b/scripts/scr_enemy_ai_b/scr_enemy_ai_b.gml
@@ -66,7 +66,7 @@ function scr_enemy_ai_b() {
             
 	            var fleet_spawn_chance=irandom(99)+1
 	            onceh=0;
-	            if (array_contains(obj_ini.dis,"Shitty Luck")) then fleet_spawn_chance-=5;
+	            if (scr_has_disadv("Shitty Luck")) then fleet_spawn_chance-=5;
 
 	            if (fleet_spawn_chance<=15){
 	                if (present_fleet[eFACTION.Necrons] > 0) {//if necron fleet

--- a/scripts/scr_enemy_ai_d/scr_enemy_ai_d.gml
+++ b/scripts/scr_enemy_ai_d/scr_enemy_ai_d.gml
@@ -450,7 +450,7 @@ function scr_enemy_ai_d() {
             var woop=scr_role_count("Chief "+string(obj_ini.role[100,17]),"");
         
             var o,yep,yep2;o=0;yep=true;yep2=false;
-            if (array_contains(obj_ini.dis, "Psyker Intolerant")) then yep=false;
+            if (scr_has_disadv("Psyker Intolerant")) then yep=false;
             
             if (obj_controller.known[eFACTION.Tyranids]=0) and (woop!=0) and (yep!=false){
                 scr_popup("Shadow in the Warp",$"Chief {obj_ini.role[100,17]} "+string(obj_ini.name[0,5])+" reports a disturbance in the warp.  He claims it is like a shadow.","shadow","");

--- a/scripts/scr_garrison/scr_garrison.gml
+++ b/scripts/scr_garrison/scr_garrison.gml
@@ -273,7 +273,7 @@ function determine_pdf_defence(pdf, garrison="none", planet_forti=0, enemy=0){
 	explanations += $"Planet Defences:X{defence_mult+1}#"
 	if (garrison!="none"){//if player supports give garrison bonus
     	var garrison_mult = garrison.viable_garrison*(0.008+(0.001*planet_forti))
-    	var siege_masters =array_contains(obj_ini.adv, "Siege Masters");
+    	var siege_masters =scr_has_adv("Siege Masters");
     	if (siege_masters) then garrison_mult*=2;
     	explanations += $"Garrison Bonus:X{garrison_mult+1}#";
     	if (siege_masters){

--- a/scripts/scr_kill_unit/scr_kill_unit.gml
+++ b/scripts/scr_kill_unit/scr_kill_unit.gml
@@ -48,9 +48,8 @@ function kill_and_recover(company, unit_slot, equipment=true, gene_seed_collect=
 		unit.alter_equipment(strip,false, true);
 	} 
 	if (gene_seed_collect && unit.base_group=="astartes"){
-		//TODO get rid of string methods
-        if (unit.age() > 30) and (!obj_ini.zygote) and (string_count("Doom",obj_ini.strin2)==0) then obj_controller.gene_seed+=1;
-        if (unit.age() > 50) and (string_count("Doom",obj_ini.strin2)==0) then obj_controller.gene_seed+=1;		
+        if (unit.age() > 30 && !obj_ini.zygote && !obj_ini.doomed) then obj_controller.gene_seed+=1;
+        if (unit.age() > 50 && !obj_ini.doomed) then obj_controller.gene_seed+=1;		
 	}
     if (obj_ini.race[company][unit_slot]==1){
         if(is_specialist(obj_ini.role[company][unit_slot])){

--- a/scripts/scr_load/scr_load.gml
+++ b/scripts/scr_load/scr_load.gml
@@ -170,8 +170,8 @@ function scr_load(save_part, save_id) {
 	    obj_ini.icon_name=ini_read_string("Ini","icon_name","custom1");
 	    global.icon_name=obj_ini.icon_name;
 	    obj_ini.man_size=ini_read_real("Ini","man_size",0);
-	    obj_ini.strin=ini_read_string("Ini","strin1","");
-	    obj_ini.strin2=ini_read_string("Ini","strin2","");
+	    // obj_ini.strin=ini_read_string("Ini","strin1","");
+	    // obj_ini.strin2=ini_read_string("Ini","strin2","");
 	    obj_ini.psy_powers=ini_read_string("Ini","psy_powers","default");
 
 		

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -867,10 +867,10 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data={}) 
 				}
 			}
 
-			if (array_contains(obj_ini.adv, "Psyker Abundance")){
+			if (scr_has_adv("Psyker Abundance")){
 				if (psionic<16) then psionic++;
 				if (psionic<10) then psionic++;
-			} else if (array_contains(obj_ini.dis, "Psyker Intolerant")){
+			} else if (scr_has_disadv("Psyker Intolerant")){
 				if (warp_level<=190){
 					psionic=choose(0,1);
 				} else {

--- a/scripts/scr_perils_table/scr_perils_table.gml
+++ b/scripts/scr_perils_table/scr_perils_table.gml
@@ -136,8 +136,6 @@ function scr_perils_table(peril_roll, unit, psy_discipline, power_name, unit_id,
 				marine_dead[unit_id]=2;
 		        if (unit.role()="Chapter Master") then global.defeat=3;
 		        flavour_text2="The marine's flesh begins to twist and rip, seemingly turning inside out.  His form looms up, and up, and up.  Within seconds a Greater Daemon of ";
-		        //if (obj_ini.age[marine_co[unit_id],marine_id[unit_id]]<=((obj_controller.millenium*1000)+obj_controller.year)-10) and (obj_ini.zygote=0) and (string_count("Doom",obj_ini.strin2)=0) then obj_ncombat.gene_penalty+=1;
-		        //if (obj_ini.age[marine_co[unit_id],marine_id[unit_id]]<=((obj_controller.millenium*1000)+obj_controller.year)-5) and (string_count("Doom",obj_ini.strin2)=0) then obj_ncombat.gene_penalty+=1;
 	        
 		        var dem=choose("Slaanesh","Nurgle","Tzeentch");
 		        if (book_powers!=""){

--- a/scripts/scr_player_combat_weapon_stacks/scr_player_combat_weapon_stacks.gml
+++ b/scripts/scr_player_combat_weapon_stacks/scr_player_combat_weapon_stacks.gml
@@ -172,7 +172,7 @@ function scr_player_combat_weapon_stacks() {
 
                 if (unit.IsSpecialist("libs",true)||(unit.role()=="Chapter Master" && obj_ncombat.chapter_master_psyker=1)){
                     var cast_dice=irandom(99)+1;
-                    if (array_contains(obj_ini.dis,"Warp Touched")) then cast_dice-=5;
+                    if (scr_has_disadv("Warp Touched")) then cast_dice-=5;
 
                     cast_dice-=(unit.psionic+(unit.experience/60))
 

--- a/scripts/scr_powers/scr_powers.gml
+++ b/scripts/scr_powers/scr_powers.gml
@@ -75,7 +75,7 @@ function scr_powers(power_set, power_count, enemy_target, unit_id) {
         
 	    }
 	}
-	if (array_contains(obj_ini.adv,"Daemon Binders")) then binders=true;
+	if (scr_has_adv("Daemon Binders")) then binders=true;
 	var p_type="";p_rang=0;p_tar=0;p_spli=0;p_att=0;p_arp=0;p_duration=0;
 
 	if (string_count("Z",using)>0){
@@ -484,9 +484,9 @@ function scr_powers(power_set, power_count, enemy_target, unit_id) {
 	// peril1+=30;
 	if (string_count("Hood",marine_gear[unit_id])>0) then peril1-=5;
 	if (peril1<1) then peril1=1;
-	if (string_count("Warp Touched",obj_ini.strin2)>0) then peril1+=2;
+	if (scr_has_disadv("Warp Touched")) then peril1+=2;
 	if (marine_type[unit_id]="Chapter Master") and (peril1>1) then peril1=round(peril1/2);
-	if (string_count("Shitty",obj_ini.strin2)>0) then peril1+=3;
+	if (scr_has_disadv("Shitty Luck")) then peril1+=3;
 
 	if (book_powers!="") then peril1+=tome_bad;
 	if (string_count("daemon",book_powers)>0) then peril1+=3;
@@ -506,8 +506,8 @@ function scr_powers(power_set, power_count, enemy_target, unit_id) {
 
 	    p_type="perils";
 	    flavour_text3="";
-	    if (array_contains(obj_ini.dis,"Warp Touched")) then peril3+=20;
-	    if (array_contains(obj_ini.dis,"Shitty Luck")) then peril3+=25;
+	    if (scr_has_disadv("Warp Touched")) then peril3+=20;
+	    if (scr_has_disadv("Shitty Luck")) then peril3+=25;
 
 	    if (string_count("daemon",book_powers)>0) then peril1+=25;
 

--- a/scripts/scr_random_event/scr_random_event.gml
+++ b/scripts/scr_random_event/scr_random_event.gml
@@ -1133,7 +1133,7 @@ function scr_random_event(execute_now) {
 	    var own,time,him;
 		
 		time=irandom_range(6,24);
-	    if (string_count("Shitty",obj_ini.strin2)==1){
+	    if (scr_has_disadv("Shitty Luck")){
 			own=1;
 		}
 		else {
@@ -1169,7 +1169,7 @@ function scr_random_event(execute_now) {
 	else if (chosen_event == EVENT.enemy_forces){
 		debugl("RE: Enemy Forces");
 		var own;
-	    if (string_count("Shitty",obj_ini.strin2)==1) {
+	    if (scr_has_disadv("Shitty Luck")) {
 			own=1;
 		}
 		else{

--- a/scripts/scr_save/scr_save.gml
+++ b/scripts/scr_save/scr_save.gml
@@ -275,8 +275,8 @@ function scr_save(save_part,save_id) {
 	    ini_write_real("Ini","icon",obj_ini.icon);
 	    ini_write_string("Ini","icon_name",obj_ini.icon_name);
 	    ini_write_real("Ini","man_size",obj_ini.man_size);
-	    ini_write_string("Ini","strin1",obj_ini.strin);
-	    ini_write_string("Ini","strin2",obj_ini.strin2);
+	    // ini_write_string("Ini","strin1",obj_ini.strin);
+	    // ini_write_string("Ini","strin2",obj_ini.strin2);
 	    ini_write_string("Ini","psy_powers",obj_ini.psy_powers);
 	    ini_encode_and_json("Ini", "FullLivery",obj_ini.full_liveries)
 		ini_write_real("Ini","companies",obj_ini.companies);

--- a/scripts/scr_specialist_point_handler/scr_specialist_point_handler.gml
+++ b/scripts/scr_specialist_point_handler/scr_specialist_point_handler.gml
@@ -146,7 +146,7 @@ function SpecialistPointHandler() constructor{
     static new_tech_heretic_spawn = function() {
         var _tester = global.character_tester;
         var _possibility_of_heresy = 8;
-        if (array_contains(obj_ini.dis, "Tech-Heresy")) {
+        if (scr_has_disadv("Tech-Heresy")) {
             _possibility_of_heresy = 6;
         }
         if (irandom(power(_possibility_of_heresy, (array_length(techs) + 2.2))) == 0 && array_length(techs) > 0) {

--- a/scripts/scr_squads/scr_squads.gml
+++ b/scripts/scr_squads/scr_squads.gml
@@ -651,7 +651,7 @@ function game_start_squads(){
 		create_squad("command_squad", company);
 		last_squad_count = array_length(obj_ini.squads);
 		while (last_squad_count == array_length(obj_ini.squads)){ ///keep making tact squads for as long as there are enough tact marines
-			if (global.chapter_name == "White Scars") or (array_contains(obj_ini.adv, "Lightning Warriors")) {
+			if (scr_has_adv("Lightning Warriors")) {
 				last_squad_count = (array_length(obj_ini.squads) + 1);
 				if(last_squad_count%2 == 0){		
 					create_squad("tactical_squad", company);
@@ -670,7 +670,7 @@ function game_start_squads(){
 		}		
 		last_squad_count = array_length(obj_ini.squads);
 		while (last_squad_count == array_length(obj_ini.squads)){
-			if (array_contains(obj_ini.adv, "Boarders")) {
+			if (scr_has_adv("Boarders")) {
 				last_squad_count = (array_length(obj_ini.squads) + 1);
 				if(last_squad_count%2 == 0){		
 					create_squad("assault_squad", company);

--- a/scripts/scr_unit_spawn_functions/scr_unit_spawn_functions.gml
+++ b/scripts/scr_unit_spawn_functions/scr_unit_spawn_functions.gml
@@ -362,7 +362,7 @@ function scr_marine_game_spawn_constructions(){
 			if (religion != "cult_mechanicus") {
 				religion_sub_cult = "none";
 			}
-			if (array_contains(obj_ini.adv, "Crafters")) {
+			if (scr_has_adv("Crafters")) {
 				if (irandom(2) == 0) {
 					add_trait("crafter");
 				}

--- a/scripts/scr_unit_traits/scr_unit_traits.gml
+++ b/scripts/scr_unit_traits/scr_unit_traits.gml
@@ -982,14 +982,14 @@ function scr_marine_trait_spawning(distribution_set){
 			var dist_rate=[];
 			array_copy(dist_rate, 0, distribution_set[i][1], 0, array_length(distribution_set[i][1]));
 			if (struct_exists(dist_modifiers, "disadvantage")){
-				if (array_contains(obj_ini.dis, dist_modifiers[$"disadvantage"][0])){
+				if (scr_has_disadv(dist_modifiers[$"disadvantage"][0])){
 					dist_rate = dist_modifiers[$"disadvantage"][1];  //apply new modifier rate
 				} else if (is_state_required(dist_modifiers[$"disadvantage"])){
 					dist_rate=[0,0];
 				}
 			}
 			if (struct_exists(dist_modifiers, "advantage")){
-				if (array_contains(obj_ini.adv, dist_modifiers[$"advantage"][0])){
+				if (scr_has_adv(dist_modifiers[$"advantage"][0])){
 					dist_rate = dist_modifiers[$"advantage"][1];  //apply new modifier rate
 				} else if (is_state_required(dist_modifiers[$"advantage"])){
 					dist_rate=[0,0];


### PR DESCRIPTION
<!--- PR title format should be "commit type: Title" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->

## Description of changes
- remove old useage of trait checking still found in code
## Reasons for changes
- standardisation and legibility 
## Related links
- found thanks to investigating trait effects and found a number of old usages which are probably broken in 0.10+ because of the new 8 trait limit

## Summary by Sourcery

Standardize trait usage by replacing string comparisons with a dedicated function.

Enhancements:
- Replace string-based trait checking with `scr_has_adv` and `scr_has_disadv` functions.

Tests:
- Update tests to reflect the changes in trait checking.