### PR TITLE
fix: Misplaced broken trait check

### DIFF
--- a/objects/obj_controller/Create_0.gml
+++ b/objects/obj_controller/Create_0.gml
@@ -1104,7 +1104,6 @@ faction_status[eFACTION.Ecclesiarchy]="Allied";
 faction_leader[eFACTION.Eldar]=global.name_generator.generate_eldar_name(2);
 faction_title[6]="Farseer";
 faction_status[eFACTION.Eldar]="Antagonism";// If disposition = 0 then instead set it to "Antagonism"
-if (scr_has_adv("Enemy: Eldar")) then faction_status[eFACTION.Eldar]="War";
 // Orkz faction
 faction_leader[eFACTION.Ork]=global.name_generator.generate_ork_name();
 faction_title[7]="Warboss";
@@ -1282,14 +1281,17 @@ other1_disposition=0;
 other1="";
 // ** Sets up bonuses once chapter is created **
 if (instance_exists(obj_ini)){
-    // Tolerant trait
-    if (global.load==0 && scr_has_disadv("Tolerant")){
-        obj_controller.disposition[6]+=5;
-        obj_controller.disposition[7]+=5;
-        obj_controller.disposition[8]+=10;
-    }
     // General setup
     if (global.load==0){
+        // Tolerant trait
+        if (scr_has_disadv("Tolerant")) {
+            obj_controller.disposition[6]+=5;
+            obj_controller.disposition[7]+=5;
+            obj_controller.disposition[8]+=10;
+        }
+        if (scr_has_adv("Enemy: Eldar")) {
+            faction_status[eFACTION.Eldar]="War";
+        }
         // Founding Chapter STC Bonuses here
         if (global.chapter_name=="Salamanders"){
             stc_wargear=4;


### PR DESCRIPTION
## Description of changes
- Moved the trait check for the "Enemy: Eldar" to after the loading is finished.
## Reasons for changes
- It was crashing the game on load.
## Related links
- https://discord.com/channels/714022226810372107/1325235670150680746
## How have you tested your changes?
- [x] Compile
- [x] New game
- [x] Next turn
- [ ] Space Travel
- [ ] Ground Battle

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->

## Summary by Sourcery

Bug Fixes:
- Fixed a crash that occurred on game load.