### PR TITLE
fix(sprite): Iron halo display position on Artificer armor

### DIFF
--- a/scripts/scr_draw_unit_image/scr_draw_unit_image.gml
+++ b/scripts/scr_draw_unit_image/scr_draw_unit_image.gml
@@ -1150,9 +1150,7 @@ function scr_draw_unit_image(_background=false){
                     if (array_contains(["Raven Guard", "Dark Angels"], unit_chapter)) {
                         halo_color = 1;
                     }
-                    if (unit_armour=="Artificer Armour" && !armour_bypass){
-                        halo_offset_y -= 14;
-                    } else if (unit_armour=="Terminator Armour"){
+                    if (unit_armour=="Terminator Armour"){
                         halo_type = 2;
                         halo_offset_y -= 20;
                     } else if (unit_armour=="Tartaros"){


### PR DESCRIPTION
## Description of changes 
- Remove old offset of iron halo for artificer armor. I think it was there because of the old artificer sprite, that had a huge backpack.
## Reasons for changes
- Iron halo was hovering, separate from the marine.
## Related links
- https://discord.com/channels/714022226810372107/1322636284614807593
## How have you tested your changes?
- [x] Compile
- [x] New game
- [ ] Next turn
- [ ] Space Travel
- [ ] Ground Battle

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->

## Summary by Sourcery

Bug Fixes:
- Correct the vertical offset of the iron halo for units equipped with Artificer armor, aligning it properly with the marine sprite.