### PR TITLE
fix: Variable scope in scr_add_vehicle

### DIFF
--- a/scripts/scr_add_vehicle/scr_add_vehicle.gml
+++ b/scripts/scr_add_vehicle/scr_add_vehicle.gml
@@ -11,7 +11,7 @@ function scr_add_vehicle(vehicle_type, target_company, weapon1, weapon2, weapon3
 		arm = "";
 		missing = 0;
 
-		for (var i = 0; i < array_length(veh_role[target_company]); i++) {
+		for (var i = 0; i < array_length(obj_ini.veh_role[target_company]); i++) {
 			if (good == 0) {
 				if (obj_ini.veh_role[target_company, i] == "") {
 					good = i;


### PR DESCRIPTION
## Description of changes
- Fixed a crash caused by incorrect variable scope in scr_add_vehicle.
## Reasons for changes
- A bug report.
## Related links
- https://discord.com/channels/714022226810372107/1325240283939606653
## How have you tested your changes?
- [ ] Compile
- [ ] New game
- [ ] Next turn
- [ ] Space Travel
- [ ] Ground Battle

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->

## Summary by Sourcery

Bug Fixes:
- Fixed a crash caused by incorrect variable scope in `scr_add_vehicle`.

## Summary by Sourcery

Bug Fixes:
- Fixed a crash caused by incorrect variable scope in `scr_add_vehicle`.