### PR TITLE
fix: Term Sergeant and Veteran broken loadouts

### DIFF
--- a/objects/obj_creation/Create_0.gml
+++ b/objects/obj_creation/Create_0.gml
@@ -425,10 +425,10 @@ founding_chapters = array_filter(all_chapters, function(item){ return item.origi
 successor_chapters = array_filter(all_chapters, function(item){ return item.origin == eCHAPTER_ORIGINS.SUCCESSOR});
 custom_chapters = array_filter(all_chapters, function(item){ return item.origin == eCHAPTER_ORIGINS.CUSTOM});
 other_chapters = array_filter(all_chapters, function(item){ return item.origin == eCHAPTER_ORIGINS.NON_CANON});
-show_debug_message($"founding: {founding_chapters}");
-show_debug_message($"successor: {successor_chapters}");
-show_debug_message($"custom: {custom_chapters}");
-show_debug_message($"other: {other_chapters}");
+// show_debug_message($"founding: {founding_chapters}");
+// show_debug_message($"successor: {successor_chapters}");
+// show_debug_message($"custom: {custom_chapters}");
+// show_debug_message($"other: {other_chapters}");
 
 
 // TODO refactor into struct constructors stored in which are struct arrays 
@@ -841,7 +841,7 @@ function load_default_gear(_role_id, _role_name, _wep1, _wep2, _armour, _mobi, _
     race[defaults_slot, _role_id] = 1;
 }
 load_default_gear(eROLE.HonourGuard, "Honour Guard", "Power Sword", "Bolter", "Artificer Armour", "", "");
-load_default_gear(eROLE.Veteran, "Veteran", "Chainsword", "Combiflamer", "Power Armour", "", "");
+load_default_gear(eROLE.Veteran, "Veteran", "Combiflamer", "Combat Knife", "Power Armour", "", "");
 load_default_gear(eROLE.Terminator, "Terminator", "Power Fist", "Storm Bolter", "Terminator Armour", "", "");
 load_default_gear(eROLE.Captain, "Captain", "Power Sword", "Bolt Pistol", "Power Armour", "", "Iron Halo");
 load_default_gear(eROLE.Dreadnought, "Dreadnought", "Dreadnought Lightning Claw", "Lascannon", "Dreadnought", "", "");

--- a/scripts/scr_chapter_new/scr_chapter_new.gml
+++ b/scripts/scr_chapter_new/scr_chapter_new.gml
@@ -219,7 +219,7 @@ function scr_chapter_new(argument0) {
 		}
 	}
 	load_default_gear(eROLE.HonourGuard, "Honour Guard", "Power Sword", "Bolter", "Artificer Armour", "", "");
-	load_default_gear(eROLE.Veteran, "Veteran", "Chainsword", "Combiflamer", "Power Armour", "", "");
+	load_default_gear(eROLE.Veteran, "Veteran", "Combiflamer", "Combat Knife", "Power Armour", "", "");
 	load_default_gear(eROLE.Terminator, "Terminator", "Power Fist", "Storm Bolter", "Terminator Armour", "", "");
 	load_default_gear(eROLE.Captain, "Captain", "Power Sword", "Bolt Pistol", "Power Armour", "", "Iron Halo");
 	load_default_gear(eROLE.Dreadnought, "Dreadnought", "Dreadnought Lightning Claw", "Lascannon", "Dreadnought", "", "");

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -1233,7 +1233,7 @@ function scr_initialize_custom() {
 	}
 
 	load_default_gear(eROLE.HonourGuard, "Honour Guard", "Power Sword", "Bolter", _hi_qual_armour, "", "");
-	load_default_gear(eROLE.Veteran, "Veteran", "Combiflamer", "Chainsword","Power Armour", "", "");
+	load_default_gear(eROLE.Veteran, "Veteran", "Combiflamer", "Combat Knife","Power Armour", "", "");
 	load_default_gear(eROLE.Terminator, "Terminator", "Power Fist", "Storm Bolter", "Terminator Armour", "", "");
 	load_default_gear(eROLE.Captain, "Captain", "Power Sword", "Bolt Pistol", "Power Armour", "", "Iron Halo");
 	load_default_gear(eROLE.Dreadnought, "Dreadnought", "Close Combat Weapon", "Lascannon", "Dreadnought", "", "");
@@ -1438,7 +1438,8 @@ function scr_initialize_custom() {
 				"role": $"{roles.terminator} {roles.sergeant}",
 				"loadout": {
 					"required": {
-						"wep1": ["Power Sword", 1],
+						"wep1": [wep1[defaults_slot][eROLE.Terminator], 1],
+						"wep2": [wep2[defaults_slot][eROLE.Terminator], 1],
 					},
 				}
 			}],


### PR DESCRIPTION
## Description of changes
- Terminator Sergeants now get their default equip on the squad stage.
- Veterans have their default equip altered, to prevent the overload protection from triggering (a guess, but it works now).
- Also commented out a couple of forgotten debug lines.
## Reasons for changes
- Sergeants were getting a power sword and a chainsword(?), due to one weapon being changed through squads.
- Veterans were getting the same, but due to the overload protection (that's only a guess).
## Related links
- https://discord.com/channels/714022226810372107/1322623669482160210
## How have you tested your changes?
- [x] Compile
- [x] New game
- [ ] Next turn
- [ ] Space Travel
- [ ] Ground Battle

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->

## Summary by Sourcery

Fix loadout issues for Terminator Sergeants and Veterans. Give Terminator Sergeants their default equipment and adjust Veteran default equipment to prevent overload.

Bug Fixes:
- Correct the default equipment assigned to Terminator Sergeants and Veterans.
- Remove forgotten debug messages.