### PR TITLE
revert: Armour randomization by default

### DIFF
--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -2537,8 +2537,15 @@ function scr_initialize_custom() {
 		k += 1;
 		commands += 1; // 1st company Captain
 		name[company][k] = honor_captain_name;
+		var _armour = "Terminator Armour";
+		if(scr_has_adv("Crafters")){
+			var _armour = "Tartaros";
+		}
+		if (terminator <= 0) {
+			_armour = "MK6 Corvus";
+		}
 
-		var _spawn_unit = add_unit_to_company("marine", company, k, roles.captain, eROLE.Captain, "Relic Blade",choose("Storm Shield", "Storm Bolter"),"default","default","default");
+		var _spawn_unit = add_unit_to_company("marine", company, k, roles.captain, eROLE.Captain, "Relic Blade",choose("Storm Shield", "Storm Bolter"),"default","default",_armour);
 		if (_spawn_unit.armour() == "Terminator Armour" || _spawn_unit.armour() == "Tartaros") {
 			man_size += 1;
 		}
@@ -2546,7 +2553,14 @@ function scr_initialize_custom() {
 		repeat(chaplains_per_company){
 			k += 1;
 			commands += 1; // 1st company Chaplain
-			var _spawn_unit = add_unit_to_company("marine", company, k, roles.chaplain, eROLE.Chaplain,"default","Storm Bolter","default","default","default");
+			var _armour = "Terminator Armour";
+			if(scr_has_adv("Crafters")){
+				var _armour = "Tartaros";
+			}
+			if (terminator <= 0) {
+				_armour = "MK6 Corvus";
+			}
+			var _spawn_unit = add_unit_to_company("marine", company, k, roles.chaplain, eROLE.Chaplain,"default","Storm Bolter","default","default",_armour);
 
 			if (_spawn_unit.armour() == "Terminator Armour" || _spawn_unit.armour() == "Tartaros") {
 				man_size += 1;
@@ -2555,7 +2569,14 @@ function scr_initialize_custom() {
 		repeat(apothecary_per_company){
 			k += 1;
 			commands += 1; // 1st company Apothecary
-			var _spawn_unit = add_unit_to_company("marine", company, k, roles.apothecary, eROLE.Apothecary,"Storm Bolter","","default","default","default");
+			var _armour = "Terminator Armour";
+			if(scr_has_adv("Crafters")){
+				var _armour = "Tartaros";
+			}
+			if (terminator <= 0) {
+				_armour = "MK6 Corvus";
+			}
+			var _spawn_unit = add_unit_to_company("marine", company, k, roles.apothecary, eROLE.Apothecary,"Storm Bolter","","default","default",_armour);
 
 			if (_spawn_unit.armour() == "Terminator Armour" || _spawn_unit.armour() == "Tartaros") {
 				man_size += 1;
@@ -2566,7 +2587,14 @@ function scr_initialize_custom() {
 			repeat(epistolary_per_company){
 				k += 1; // 1st company  Librarian
 				commands += 1;
-				var _spawn_unit = add_unit_to_company("marine", company, k, roles.librarian, eROLE.Librarian,"default",choose_weighted(weapon_weighted_lists.pistols),"default","default","default");
+				var _armour = "Terminator Armour";
+				if(scr_has_adv("Crafters")){
+					var _armour = "Tartaros";
+				}
+				if (terminator <= 0) {
+					_armour = "MK6 Corvus";
+				}
+				var _spawn_unit = add_unit_to_company("marine", company, k, roles.librarian, eROLE.Librarian,"default",choose_weighted(weapon_weighted_lists.pistols),"default","default",_armour);
 
 				if (_spawn_unit.armour() == "Terminator Armour" || _spawn_unit.armour() == "Tartaros") {
 					man_size += 1;
@@ -2574,10 +2602,21 @@ function scr_initialize_custom() {
 			}
 		}
 		repeat(techmarines_per_company){
-			// show_debug_message($"chap terminators {terminator}")
+			show_debug_message($"chap terminators {terminator}")
 			k += 1;
 			commands += 1; // 1st company Techmarine
-			var _spawn_unit = add_unit_to_company("marine", company, k, roles.techmarine, eROLE.Techmarine, "default","Storm Bolter","default","default","default");
+			var _armour = "Terminator Armour";
+			if(scr_has_adv("Crafters")){
+				_armour = "Tartaros";
+			}
+			if (terminator <= 0){
+				if(scr_has_disadv("Poor Equipment")){
+					_armour = "MK6 Corvus";
+				} else {
+					_armour = "Artificer Armour"
+				}
+			}
+			var _spawn_unit = add_unit_to_company("marine", company, k, roles.techmarine, eROLE.Techmarine, "default","Storm Bolter","default","default",_armour);
 			if (_spawn_unit.armour() == "Terminator" || _spawn_unit.armour() == "Tartaros") {
 				man_size += 1;
 			} 
@@ -2586,20 +2625,34 @@ function scr_initialize_custom() {
 
 		k += 1; // 1st company Standard bearer
 		man_size += 1;
-		var _spawn_unit = add_unit_to_company("marine", company, k, roles.ancient, eROLE.Ancient, "default","Storm Bolter","default","default","default");
+		var _armour = "Terminator Armour";
+		if(scr_has_adv("Crafters")){
+			_armour = "Tartaros";
+		}
+		if (terminator <= 0){
+			_armour = "MK6 Corvus"
+		}
+		var _spawn_unit = add_unit_to_company("marine", company, k, roles.ancient, eROLE.Ancient, "default","Storm Bolter","default","default",_armour);
 		if (_spawn_unit.armour() == "Terminator" || _spawn_unit.armour() == "Tartaros") {
 			man_size += 1;
 		}
 
 		k += 1;
 		man_size += 1;
+		var _armour = "Terminator Armour";
+		if(scr_has_adv("Crafters")){
+			_armour = "Tartaros";
+		}
+		if (terminator <= 0){
+			_armour = "MK6 Corvus"
+		}
 		var _wep1 = "Thunder Hammer";
 		var _wep2 = "Storm Bolter";
 		if (global.chapter_name == "Dark Angels"){
 			_wep1 = "Heavy Thunder Hammer";
 			_wep2 = "";
 		}
-		var _spawn_unit = add_unit_to_company("marine", company, k, roles.champion, eROLE.Champion, _wep1,_wep2,"default","default","default");
+		var _spawn_unit = add_unit_to_company("marine", company, k, roles.champion, eROLE.Champion, _wep1,_wep2,"default","default",_armour);
 		if (_spawn_unit.armour() == "Terminator" || _spawn_unit.armour() == "Tartaros") {
 			man_size += 1;
 		}
@@ -3339,16 +3392,13 @@ function add_unit_to_company(ttrpg_name, company, slot, role_name, role_id, wep1
 	if(obj_ini.name[company][slot] == ""){
 		obj_ini.name[company][slot] = global.name_generator.generate_space_marine_name();
 	}
-
 	var spawn_unit = fetch_unit([company,slot]);
-
 	if(ttrpg_name == "marine" || ttrpg_name == "scout"){
 		spawn_unit.marine_assembling();
 	} else {
 		spawn_unit.roll_age();
 		spawn_unit.roll_experience();
 	}
-
 	if(wep1 != ""){
 		if(wep1 == "default"){
 			spawn_unit.update_weapon_one(obj_ini.wep1[obj_ini.defaults_slot][role_id], false, false);
@@ -3365,9 +3415,9 @@ function add_unit_to_company(ttrpg_name, company, slot, role_name, role_id, wep1
 	}
 	if(armour != ""){
 		if(armour == "default"){
-			var _msg = spawn_unit.random_update_armour();
+			spawn_unit.update_armour(obj_ini.armour[obj_ini.defaults_slot][role_id], false, false);
 		} else {
-			var _msg = spawn_unit.update_armour(armour, false, false);
+			spawn_unit.update_armour(armour, false, false);
 		}
 		
 		// show_debug_message($"updating coy {company}:{slot} {role_name} armour to {armour}: {_msg} : {spawn_unit.armour()} : {obj_ini.armour[company][slot]}");
@@ -3386,7 +3436,6 @@ function add_unit_to_company(ttrpg_name, company, slot, role_name, role_id, wep1
 			spawn_unit.update_mobility_item(mobi, false, false);
 		}
 	}
-
 	if(role_id == eROLE.HonourGuard){
 		spawn_unit.add_trait(choose("guardian", "champion", "observant", "perfectionist","natural_leader"));
 	}

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -2617,7 +2617,7 @@ function scr_initialize_custom() {
 				}
 			}
 			var _spawn_unit = add_unit_to_company("marine", company, k, roles.techmarine, eROLE.Techmarine, "default","Storm Bolter","default","default",_armour);
-			if (_spawn_unit.armour() == "Terminator" || _spawn_unit.armour() == "Tartaros") {
+			if (_spawn_unit.armour() == "Terminator Armour" || _spawn_unit.armour() == "Tartaros") {
 				man_size += 1;
 			} 
 		}
@@ -2633,7 +2633,7 @@ function scr_initialize_custom() {
 			_armour = "MK6 Corvus"
 		}
 		var _spawn_unit = add_unit_to_company("marine", company, k, roles.ancient, eROLE.Ancient, "default","Storm Bolter","default","default",_armour);
-		if (_spawn_unit.armour() == "Terminator" || _spawn_unit.armour() == "Tartaros") {
+		if (_spawn_unit.armour() == "Terminator Armour" || _spawn_unit.armour() == "Tartaros") {
 			man_size += 1;
 		}
 
@@ -2653,7 +2653,7 @@ function scr_initialize_custom() {
 			_wep2 = "";
 		}
 		var _spawn_unit = add_unit_to_company("marine", company, k, roles.champion, eROLE.Champion, _wep1,_wep2,"default","default",_armour);
-		if (_spawn_unit.armour() == "Terminator" || _spawn_unit.armour() == "Tartaros") {
+		if (_spawn_unit.armour() == "Terminator Armour" || _spawn_unit.armour() == "Tartaros") {
 			man_size += 1;
 		}
 	}


### PR DESCRIPTION
## Description of changes
- Revert the previous attempt to fix Terminator Armour randomization that caused bugs.
## Reasons for changes
- It started causing problems.
## Related links
- https://github.com/Adeptus-Dominus/ChapterMaster/pull/368
- https://discord.com/channels/714022226810372107/1325205717912916110
## How have you tested your changes?
- [x] Compile
- [x] New game
- [ ] Next turn
- [ ] Space Travel
- [ ] Ground Battle

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->

## Summary by Sourcery

Bug Fixes:
- Fixed a bug where Terminator Armour randomization was causing issues.