### PR TITLE
fix: Add safeguards and streamline adding ship to combat

### DIFF
--- a/scripts/scr_player_fleet_combat_functions/scr_player_fleet_combat_functions.gml
+++ b/scripts/scr_player_fleet_combat_functions/scr_player_fleet_combat_functions.gml
@@ -6,40 +6,41 @@ function add_fleet_ships_to_combat(fleet, combat){
 	var _ships = fleet_full_ship_array(fleet);
 	var _ship_array_length = array_length(_ships);
 	for (var i=0;i<_ship_array_length;i++){
-		if (i>=array_length(_ships)) then break;
-		_ship_id = _ships[i];
-		if (obj_ini.ship_hp[_ship_id]<=0 || obj_ini.ship[_ship_id]==""){
-			array_delete(_ships,i,1);
-			i--;
-			_ship_array_length--;
-			continue;
-		}
-        if (obj_ini.ship_size[_ship_id]>=3) then combat.capital++;
-        if (obj_ini.ship_size[_ship_id]==2) then combat.frigate++;
-        if (obj_ini.ship_size[_ship_id]==1) then combat.escort++;
-        
-        array_push(combat.ship_class, player_ships_class(_ship_id));
-        array_push(combat.ship, obj_ini.ship[_ship_id]);
-        array_push(combat.ship_id, _ship_id);
-        array_push(combat.ship_size, obj_ini.ship_size[_ship_id]);
-        array_push(combat.ship_leadership, 100);
-        array_push(combat.ship_hp, obj_ini.ship_hp[_ship_id]);
-        array_push(combat.ship_maxhp, obj_ini.ship_maxhp[_ship_id]);
-        array_push(combat.ship_conditions, obj_ini.ship_conditions[_ship_id]);
-        array_push(combat.ship_speed, obj_ini.ship_speed[_ship_id]);
-        array_push(combat.ship_turning, obj_ini.ship_turning[_ship_id]);
-        array_push(combat.ship_front_armour, obj_ini.ship_front_armour[_ship_id]);
-        array_push(combat.ship_other_armour, obj_ini.ship_other_armour[_ship_id]);
-        array_push(combat.ship_weapons, obj_ini.ship_weapons[_ship_id]);
-        
-        array_push(combat.ship_wep, obj_ini.ship_wep[_ship_id]);
-        array_push(combat.ship_wep_facing, obj_ini.ship_wep_facing[_ship_id]);
-        array_push(combat.ship_wep_condition, obj_ini.ship_wep_condition[_ship_id]);
-        
-        array_push(combat.ship_capacity, obj_ini.ship_capacity[_ship_id]);
-        array_push(combat.ship_carrying, obj_ini.ship_carrying[_ship_id]);
-        array_push(combat.ship_contents, obj_ini.ship_contents[_ship_id]);
-        array_push(combat.ship_turrets, obj_ini.ship_turrets[_ship_id]);		
+		try{
+			if (i>=array_length(_ships)) then break;
+			_ship_id = _ships[i];
+			if (obj_ini.ship_hp[_ship_id]<=0 || obj_ini.ship[_ship_id]==""){
+				continue;
+			}
+	        if (obj_ini.ship_size[_ship_id]>=3) then combat.capital++;
+	        if (obj_ini.ship_size[_ship_id]==2) then combat.frigate++;
+	        if (obj_ini.ship_size[_ship_id]==1) then combat.escort++;
+	        
+	        array_push(combat.ship_class, player_ships_class(_ship_id));
+	        array_push(combat.ship, obj_ini.ship[_ship_id]);
+	        array_push(combat.ship_id, _ship_id);
+	        array_push(combat.ship_size, obj_ini.ship_size[_ship_id]);
+	        array_push(combat.ship_leadership, 100);
+	        array_push(combat.ship_hp, obj_ini.ship_hp[_ship_id]);
+	        array_push(combat.ship_maxhp, obj_ini.ship_maxhp[_ship_id]);
+	        array_push(combat.ship_conditions, obj_ini.ship_conditions[_ship_id]);
+	        array_push(combat.ship_speed, obj_ini.ship_speed[_ship_id]);
+	        array_push(combat.ship_turning, obj_ini.ship_turning[_ship_id]);
+	        array_push(combat.ship_front_armour, obj_ini.ship_front_armour[_ship_id]);
+	        array_push(combat.ship_other_armour, obj_ini.ship_other_armour[_ship_id]);
+	        array_push(combat.ship_weapons, obj_ini.ship_weapons[_ship_id]);
+	        
+	        array_push(combat.ship_wep, obj_ini.ship_wep[_ship_id]);
+	        array_push(combat.ship_wep_facing, obj_ini.ship_wep_facing[_ship_id]);
+	        array_push(combat.ship_wep_condition, obj_ini.ship_wep_condition[_ship_id]);
+	        
+	        array_push(combat.ship_capacity, obj_ini.ship_capacity[_ship_id]);
+	        array_push(combat.ship_carrying, obj_ini.ship_carrying[_ship_id]);
+	        array_push(combat.ship_contents, obj_ini.ship_contents[_ship_id]);
+	        array_push(combat.ship_turrets, obj_ini.ship_turrets[_ship_id]);
+        } catch (_exception){
+        	handle_exception(_exception);
+        }		
 	}
 }
 


### PR DESCRIPTION
## Description of changes
- adds try catch on each loop item of add_fleet_ships_to_combat
- declutters and makes loop more streamline
## Reasons for changes
-  response to bug report
## Related links
- https://discord.com/channels/714022226810372107/1325673306145427479
## How have you tested your changes?
- [x] Compile
- [x] New game
- [x] Next turn
- [x] Space Travel
- [ ] Ground Battle

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->

## Summary by Sourcery

Bug Fixes:
- Fixed a bug that caused crashes when adding ships to combat.