### PR TITLE
fix: error handling to solve issue with sector name

### DIFF
--- a/objects/obj_controller/Draw_64.gml
+++ b/objects/obj_controller/Draw_64.gml
@@ -62,11 +62,7 @@ if (!zoomed && !zui){
     draw_set_font(fnt_menu);
     draw_set_halign(fa_center);
     // Draws the sector name
-    try{
-        var _sector_string = $"Sector {obj_ini.sector_name}";
-    } catch(_exception){
-        var _sector_string = "Terra Nova";
-    }
+    var _sector_string = $"Sector {obj_ini.sector_name ?? "Terra Nova"}";
     draw_text(775,17,_sector_string);
     draw_text(775.5,17.5,_sector_string);
     


### PR DESCRIPTION
## Description of changes
- defiantly can't crash from lack of sector_name value
## Reasons for changes
-
## Related links
-
## How have you tested your changes?
- [ ] Compile
- [ ] New game
- [ ] Next turn
- [ ] Space Travel
- [ ] Ground Battle

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->

## Summary by Sourcery

Bug Fixes:
- Prevent crashes when the sector name is not available.