### PR TITLE
fix: Typo making lava planet sprite not display

### DIFF
--- a/scripts/scr_system_search_helpers/scr_system_search_helpers.gml
+++ b/scripts/scr_system_search_helpers/scr_system_search_helpers.gml
@@ -313,7 +313,7 @@ function scr_faction_string_name(faction){
 
 function scr_planet_image_numbers(p_type){
 	var image =0;
-	image_map = ["","lava","lava", "Desert","Forge","Hive","Death","Agri","Feudal","Temperate","Ice","Dead","Daemon","Craftworld","","Space Hulk", "", "Shrine"];
+	image_map = ["","Lava","Lava", "Desert","Forge","Hive","Death","Agri","Feudal","Temperate","Ice","Dead","Daemon","Craftworld","","Space Hulk", "", "Shrine"];
 	for (var i=0;i<array_length(image_map);i++){
 		if (image_map[i] == p_type) then return i;
 	}


### PR DESCRIPTION
## Description of changes
- as title
## Reasons for changes
- make sprtie display correctly
## Related links
- https://discord.com/channels/714022226810372107/1120687959365128243
## How have you tested your changes?
- [x] Compile
- [x] New game
- [ ] Next turn
- [ ] Space Travel
- [ ] Ground Battle

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->

## Summary by Sourcery

Bug Fixes:
- Fixed a typo that prevented lava planet sprites from displaying correctly.