### PR TITLE
fix: Manage hot keys interrupting company naming 

### DIFF
--- a/scripts/scr_company_view/scr_company_view.gml
+++ b/scripts/scr_company_view/scr_company_view.gml
@@ -494,3 +494,31 @@ function company_manage_actions(){
     	switch_view_company(new_view)
     } 	 	 
 }
+
+function ui_manage_hotkeys(){
+	if (managing >=0){
+	    for (var i=1;i<10;i++){ 
+	    	if (press_exclusive(ord(string(i)))){
+	    		switch_view_company(i);
+	    	}
+	    }
+		if (press_exclusive(ord("0"))){
+			switch_view_company(10);
+		}
+		else if (press_exclusive(ord("Q"))){
+			switch_view_company(11);
+		} 
+		else if (press_exclusive(ord("E"))){
+			switch_view_company(12);
+		}
+		else if (press_exclusive(ord("R"))){
+			switch_view_company(13);
+		}
+		else if (press_exclusive(ord("T"))){
+			switch_view_company(14);
+		}
+		else if (press_exclusive(ord("Y"))){
+			switch_view_company(15);
+		}    		
+	}	
+}

--- a/scripts/scr_ui_manage/scr_ui_manage.gml
+++ b/scripts/scr_ui_manage/scr_ui_manage.gml
@@ -8,31 +8,9 @@ function scr_ui_manage() {
     	if((managing>0)){
     		company_manage_actions();
     	}
-    	if (managing >=0){
-		    for (var i=1;i<10;i++){ 
-		    	if (press_exclusive(ord(string(i)))){
-		    		switch_view_company(i);
-		    	}
-		    }
-			if (press_exclusive(ord("0"))){
-				switch_view_company(10);
-			}
-			else if (press_exclusive(ord("Q"))){
-				switch_view_company(11);
-			} 
-			else if (press_exclusive(ord("E"))){
-				switch_view_company(12);
-			}
-			else if (press_exclusive(ord("R"))){
-				switch_view_company(13);
-			}
-			else if (press_exclusive(ord("T"))){
-				switch_view_company(14);
-			}
-			else if (press_exclusive(ord("Y"))){
-				switch_view_company(15);
-			}    		
-    	}
+    	if (!text_bar){
+    		ui_manage_hotkeys();
+    	};
     }
     
 	if (menu==1) and (managing>0 || managing <0){
@@ -113,14 +91,14 @@ function scr_ui_manage() {
 	        draw_rectangle(xx+800-(bar_wid/2),yy+108,xx+800+(bar_wid/2),yy+100+string_h,1);
 	        click_check = scr_hit(xx+800-(bar_wid/2),yy+108,xx+800+(bar_wid/2),yy+100+string_h);
 	        obj_cursor.image_index=0;
-	        if (!click_check) and (mouse_left==1) and (cooldown<=0){
-	         text_bar=0;
+	        if (!click_check) and (mouse_left==1) and (!cooldown){
+	         text_bar=false;
 	        }else if(click_check){
 	            obj_cursor.image_index=2;
 
-	            if (cooldown<=0) and (mouse_left==1) and (text_bar=0){
+	            if (!cooldown) and (mouse_left==1) and (!text_bar){
 	                cooldown=8000;
-	                text_bar=1;
+	                text_bar=true;
 	                keyboard_string=obj_ini.company_title[managing];
 	            }
             


### PR DESCRIPTION
## Description of changes
- create hot keys function for ui_manage
- disable hotkeys when typing in company text bar
## Reasons for changes
- using manage hot keys was interrupting company naming 
## Related links
-
## How have you tested your changes?
- [x] Compile
- [x] New game
- [x] Next turn
- [ ] Space Travel
- [ ] Ground Battle

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->

## Summary by Sourcery

Disable UI management hotkeys when renaming a company.

Bug Fixes:
- Prevent hotkeys from interrupting company renaming.

Enhancements:
- Create a dedicated function for UI management hotkeys.