### PR TITLE
fix: Trying to call alarm on non existing object

### DIFF
--- a/objects/obj_popup/Keyboard_13.gml
+++ b/objects/obj_popup/Keyboard_13.gml
@@ -13,9 +13,13 @@ if (battle_special>0){
     cooldown=10;exit;
 }
 
-if (option1="") and (type<5){
+if (option1="" && type<5){
     obj_controller.cooldown=10;
-    if (number!=0) and (obj_controller.complex_event=false) then obj_turn_end.alarm[1]=4;
+    if (number!=0) and (obj_controller.complex_event=false){
+        if (instance_exists(obj_turn_end)){
+            obj_turn_end.alarm[1]=4;
+        }
+    }
     instance_destroy();
 }
 


### PR DESCRIPTION
## Description of changes
- obj_turn_end not being checked for existance before attempting to call alarm 4
## Reasons for changes
- was causing crash when doing exterminatus
## Related links
- https://discord.com/channels/714022226810372107/1120687959365128243/threads/1326451897615388673
## How have you tested your changes?
- [x] Compile
- [x] New game
- [x] Next turn
- [ ] Space Travel
- [ ] Ground Battle

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->

## Summary by Sourcery

Bug Fixes:
- Fixed a crash that occurred when performing exterminatus due to a missing check for the existence of `obj_turn_end` before calling its alarm.