### PR TITLE
fix: add default argument for adding items

### DIFF
--- a/scripts/scr_add_item/scr_add_item.gml
+++ b/scripts/scr_add_item/scr_add_item.gml
@@ -1,4 +1,4 @@
-function scr_add_item(item_name, number_of_items, quality="any", from_marine=false) {
+function scr_add_item(item_name, number_of_items=1, quality="any", from_marine=false) {
 	if (item_name=="") then exit;
 	var i, last_open, match_slot, open_slot=false, matched=false;
 	var ok=0;


### PR DESCRIPTION
## Description of changes
- adds a default of one to adding items with scr_add_item
## Reasons for changes
- convenience and stops a crash 
## Related links
- crash bug report link https://discord.com/channels/714022226810372107/1327030577911824497
## How have you tested your changes?
- [x] Compile
- [x] New game
- [x] Next turn
- [ ] Space Travel
- [ ] Ground Battle

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->

## Summary by Sourcery

Add a default value of 1 to the `number_of_items` argument of the `scr_add_item` function.

Bug Fixes:
- Fix a crash caused by calling `scr_add_item` without the `number_of_items` argument.

Enhancements:
- Improve the usability of the `scr_add_item` function by providing a default value for the `number_of_items` argument.