### PR TITLE
fix: typo in alarm7 obj_ncombat from earlier fix

### DIFF
--- a/objects/obj_ncombat/Alarm_7.gml
+++ b/objects/obj_ncombat/Alarm_7.gml
@@ -610,7 +610,7 @@ try {
         var shiyp=instance_nearest(battle_object.x,battle_object.y,obj_p_fleet);
         if (shiyp.x == battle_object.x && shiyp.y ==battle_object.y){
             shi = fleet_full_ship_array(shiyp)[0];
-            loc = obj_ini.ship(shi);
+            loc = obj_ini.ship[shi];
         }
         
         if (hulk_treasure=1){// Requisition


### PR DESCRIPTION
## Description of changes
-
## Reasons for changes
-
## Related links
-
## How have you tested your changes?
- [ ] Compile
- [ ] New game
- [ ] Next turn
- [ ] Space Travel
- [ ] Ground Battle

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->

## Summary by Sourcery

Bug Fixes:
- Correct the `obj_ncombat` object lookup to use array indexing instead of function call.