### PR TITLE
feat: Remove "Power Weapon" from the player side

### DIFF
--- a/objects/obj_controller/Alarm_5.gml
+++ b/objects/obj_controller/Alarm_5.gml
@@ -488,9 +488,7 @@ if (training_techmarine>0){
                 obj_ini.loc[0][g1]="Terra";
                 unit.planet_location=4;
                 unit.ship_location=-1;
-                if (unit.weapon_one()!="Power Weapon"){
-                    unit.update_weapon_one("");
-                }
+                unit.update_weapon_one("");
                 unit.update_weapon_two("");
                 unit.update_gear("");
                 unit.update_mobility_item("");

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -3306,7 +3306,7 @@ function scr_initialize_custom() {
 		scr_add_item("Bolt Pistol", 80);
 		scr_add_item("Heavy Bolter", 40);
 		scr_add_item("Lascannon", 40);
-		scr_add_item("Power Weapon", 12);
+		scr_add_item("Power Sword", 12);
 		scr_add_item("Rosarius", 4);
 	}
 	if (!scr_has_disadv("Sieged")) {

--- a/scripts/scr_ui_display_weapons/scr_ui_display_weapons.gml
+++ b/scripts/scr_ui_display_weapons/scr_ui_display_weapons.gml
@@ -132,7 +132,6 @@ function scr_ui_display_weapons(left_or_right, current_armor, equiped_weapon, cu
             "Force Staff":spr_weapon_frcstaff,
 			"Force Sword":spr_weapon_powswo,
 			"Force Axe":spr_weapon_powaxe,
-			"Power Weapon":spr_weapon_powswo,
             "Relic Blade":spr_weapon_relic_blade,
             "Eviscerator":spr_weapon_evisc,
             "Power Mace":spr_weapon_powmace,

--- a/scripts/scr_weapon/scr_weapon.gml
+++ b/scripts/scr_weapon/scr_weapon.gml
@@ -231,7 +231,7 @@ global.weapons = {
 			"master_crafted": 1.1,
 			"artifact": 1.1
 		},
-		"description": "An makeshift power weapon made by Astartes during long term deployment behind enemy lines or when cut from supply lines for long periods of time.",
+		// "description": "An makeshift power weapon made by Astartes during long term deployment behind enemy lines or when cut from supply lines for long periods of time.",
 		"melee_hands": 1.1,
 		"ranged_hands": 0,
 		"ammo": 0,


### PR DESCRIPTION
## Description of changes
- Remove "Power Weapon" from appearing at player side completely.
## Reasons for changes
- It's a rudimentary item, that is, from what I see, is used for enemies, to simulate some random power weapon type.
## Related links
- https://discord.com/channels/714022226810372107/1327496470122729502
## How have you tested your changes?
- [x] Compile
- [x] New game
- [ ] Next turn
- [ ] Space Travel
- [ ] Ground Battle

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->
