### PR TITLE
fix: Repair old guard armour distribution system

### DIFF
--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -3391,12 +3391,7 @@ function add_unit_to_company(ttrpg_name, company, slot, role_name, role_id, wep1
 		obj_ini.name[company][slot] = global.name_generator.generate_space_marine_name();
 	}
 	var spawn_unit = fetch_unit([company,slot]);
-	if(ttrpg_name == "marine" || ttrpg_name == "scout"){
-		spawn_unit.marine_assembling();
-	} else {
-		spawn_unit.roll_age();
-		spawn_unit.roll_experience();
-	}
+
 	if(wep1 != ""){
 		if(wep1 == "default"){
 			spawn_unit.update_weapon_one(obj_ini.wep1[obj_ini.defaults_slot][role_id], false, false);
@@ -3434,6 +3429,12 @@ function add_unit_to_company(ttrpg_name, company, slot, role_name, role_id, wep1
 			spawn_unit.update_mobility_item(mobi, false, false);
 		}
 	}
+    if(ttrpg_name == "marine" || ttrpg_name == "scout"){
+        spawn_unit.marine_assembling();
+    } else {
+        spawn_unit.roll_age();
+        spawn_unit.roll_experience();
+    }    
 	if(role_id == eROLE.HonourGuard){
 		spawn_unit.add_trait(choose("guardian", "champion", "observant", "perfectionist","natural_leader"));
 	}


### PR DESCRIPTION
## Description of changes
- armour variants will correctly spawn in at game start again
## Reasons for changes
- armour variants were not spawning on game start
## Related links
-
## How have you tested your changes?
- [x] Compile
- [x] New game
- [ ] Next turn
- [ ] Space Travel
- [ ] Ground Battle

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->

## Summary by Sourcery

Bug Fixes:
- Fixed an issue that prevented armor variants from spawning correctly at the beginning of the game.