### PR TITLE
fix(visual): Force Sword/Axe side flip

### DIFF
--- a/scripts/scr_ui_display_weapons/scr_ui_display_weapons.gml
+++ b/scripts/scr_ui_display_weapons/scr_ui_display_weapons.gml
@@ -320,17 +320,17 @@ function scr_ui_display_weapons(left_or_right, current_armor, equiped_weapon, cu
         hand_on_top[2]=true;
     }
 
-    if (array_contains(["Power Mace", "Mace of Absolution", "Power Axe", "Shock Maul", "Chainaxe"], equiped_weapon)) {
+    if (array_contains(["Power Mace", "Mace of Absolution", "Power Axe", "Shock Maul", "Chainaxe", "Force Axe"], equiped_weapon)) {
         hand_variant[left_or_right] = 3;
     }
 
-    if (array_contains(["Sniper Rifle", "Force Staff", "Power Sword", "Thunder Hammer", "Autocannon", "Combat Knife", "Power Spear", "Chainsword"], equiped_weapon)) {
+    if (array_contains(["Sniper Rifle", "Force Staff", "Power Sword", "Thunder Hammer", "Autocannon", "Combat Knife", "Power Spear", "Chainsword", "Force Sword"], equiped_weapon)) {
         hand_variant[left_or_right] = 2;
         hand_on_top[left_or_right] = true;
     }
 
     // New weapon draw method
-    if (array_contains(["Force Staff", "Mace of Absolution", "Power Mace", "Power Axe", "Power Sword", "Autocannon", "Combat Knife", "Power Spear", "Shock Maul", "Chainsword", "Chainaxe"], equiped_weapon)) {
+    if (array_contains(["Force Staff", "Mace of Absolution", "Power Mace", "Power Axe", "Power Sword", "Autocannon", "Combat Knife", "Power Spear", "Shock Maul", "Chainsword", "Chainaxe", "Force Sword", "Force Axe"], equiped_weapon)) {
         new_weapon_draw[left_or_right] = true;
     }
 


### PR DESCRIPTION
<!--- PR title format should be `commit type: Title` -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add `@sourcery-ai` into the title, so that the bot auto-generates a title -->
## Description of changes
<!--- Leverage the list functionality, if you have many changes -->
- When held in the left hand, these sprites were drawn in the right, due to not being included into the new draw method array.
## Reasons for changes
<!--- Leverage the list functionality, here as well -->
- Bugfix.
## Related links
<!--- Other PRs; Discord bug reports, messages, threads, etc.; outside docs, etc.; -->
- https://discord.com/channels/714022226810372107/1327939976603897896
