### PR TITLE
fix: wrong race variable on new recruits

### DIFF
--- a/scripts/scr_add_man/scr_add_man.gml
+++ b/scripts/scr_add_man/scr_add_man.gml
@@ -216,13 +216,14 @@ function scr_add_man(man_role, target_company, spawn_exp, spawn_name, corruption
 
 		if (!array_contains(non_marine_roles, man_role)) {
 			// Weapons
+			obj_ini.race[target_company][good] = eFACTION.Player;
 			if (man_role == obj_ini.role[100][12]) {
 				_gear = {
-					wep2 : obj_ini.wep2[100, 12],
-					wep1 : obj_ini.wep1[100, 12],
-					armour : obj_ini.armour[100, 12],
-					gear : obj_ini.gear[100, 12],
-					mobi : obj_ini.mobi[100, 12],
+					wep2 : obj_ini.wep2[100][12],
+					wep1 : obj_ini.wep1[100][12],
+					armour : obj_ini.armour[100][12],
+					gear : obj_ini.gear[100][12],
+					mobi : obj_ini.mobi[100][12],
 				}
 			};
 


### PR DESCRIPTION
## Description of changes
- make sure the race variable for new scouts is set to eFACTION.Player
## Reasons for changes
- stat data for new recruits not displaying and units never becoming available for recruitment as specialist
- stats being hidden
## Related links
- https://discord.com/channels/714022226810372107/1120687959365128243/threads/1328143775976915104
- https://discord.com/channels/714022226810372107/1328062590282371093
## How have you tested your changes?
- [ ] Compile
- [ ] New game
- [ ] Next turn
- [ ] Space Travel
- [ ] Ground Battle

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->

## Summary by Sourcery

Bug Fixes:
- Fixed a bug where new recruits' stats were not displayed and they could not be recruited as specialists.