### PR TITLE
fix: Redundant check causing early end game

### DIFF
--- a/objects/obj_ncombat/Alarm_7.gml
+++ b/objects/obj_ncombat/Alarm_7.gml
@@ -260,12 +260,6 @@ try {
     
     instance_activate_all();
     
-    if (scr_role_count("Chapter Master","")=0){
-        obj_controller.alarm[7]=1;
-        if (global.defeat<=1) then global.defeat=1;
-        if (enemy=1) or (enemy=2) or (enemy=5) then global.defeat=3;
-    }
-    
     
     if (turn_count < 20){
         if (defeat=0) and (threat>=4) then scr_recent("battle_victory", $"{battle_loc} {scr_roman(battle_id)}",enemy);

--- a/scripts/scr_kill_unit/scr_kill_unit.gml
+++ b/scripts/scr_kill_unit/scr_kill_unit.gml
@@ -8,7 +8,7 @@ function scr_kill_unit(company, unit_slot){
     if (obj_ini.role[company][unit_slot]="Chapter Master"){
         tek="c";
         alarm[7]=5;
-        global.defeat=3;
+        global.defeat=1;
     }
     _unit = fetch_unit([company, unit_slot]);
     if (_unit.weapon_one()=="Company Standard" || _unit.weapon_two()=="Company Standard"){

--- a/scripts/scr_role_count/scr_role_count.gml
+++ b/scripts/scr_role_count/scr_role_count.gml
@@ -42,29 +42,31 @@ function scr_role_count(target_role, search_location="", return_type="count") {
 	}
 
 
-	if (coom<0) then repeat(11){
-	    for (var i=0;i<array_length(obj_ini.TTRPG[com]);i++){
-			match=false;
-			unit=obj_ini.TTRPG[com][i];
-			if (unit.name()=="")then continue;
-	        if (unit.role()=target_role) and (search_location="") then match=true;
-	        if (unit.role()=target_role) and (obj_ini.loc[com][i]=obj_ini.home_name) and (search_location="home") then match=true;
-	        if (unit.role()=target_role) and (search_location="field") and ((obj_ini.loc[com][i]!=obj_ini.home_name) or (unit.ship_location>-1)) then match=true;
-        
-	        if (search_location!="home") and (search_location!="field"){
-	            if (unit.role()=target_role){
-	                var t1=string(obj_ini.loc[com][i])+"|"+string(unit.planet_location)+"|";
-	                if (search_location=t1) then match=true;
-	            }
-	        }
-	        if (match){
-	        	count++;
-	        	if (return_type=="units"){
-	        		array_push(units, unit);
-	        	}	        	
-	        }
-	    }    
-	    com+=1;
+	if (coom<0) {
+	for (var com=0;com<=obj_ini.companies;com++)
+		{
+		    for (var i=0;i<array_length(obj_ini.TTRPG[com]);i++){
+				match=false;
+				unit=fetch_unit([com, i]);
+				if (unit.name()=="")then continue;
+		        if (unit.role()=target_role) and (search_location="") then match=true;
+		        if (unit.role()=target_role) and (obj_ini.loc[com][i]=obj_ini.home_name) and (search_location="home") then match=true;
+		        if (unit.role()=target_role) and (search_location="field") and ((obj_ini.loc[com][i]!=obj_ini.home_name) or (unit.ship_location>-1)) then match=true;
+	        
+		        if (search_location!="home") and (search_location!="field"){
+		            if (unit.role()=target_role){
+		                var t1=string(obj_ini.loc[com][i])+"|"+string(unit.planet_location)+"|";
+		                if (search_location=t1) then match=true;
+		            }
+		        }
+		        if (match){
+		        	count++;
+		        	if (return_type=="units"){
+		        		array_push(units, unit);
+		        	}	        	
+		        }
+		    }    
+		}
 	}
 
 


### PR DESCRIPTION
## Description of changes
- causing an end game unintentionally
## Reasons for changes
- not good 
## Related links
- https://discord.com/channels/714022226810372107/1120687959365128243/threads/1328401611420340254
## How have you tested your changes?
- [x] Compile
- [x] New game
- [ ] Next turn
- [ ] Space Travel
- [ ] Ground Battle

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->

## Summary by Sourcery

Bug Fixes:
- Remove the redundant check for the absence of Chapter Masters, which was causing the game to end prematurely.