### PR TITLE
fix: odd bug from player being wiped out in battle

### DIFF
--- a/objects/obj_centerline/Step_0.gml
+++ b/objects/obj_centerline/Step_0.gml
@@ -1,4 +1,7 @@
 
 if (instance_exists(obj_pnunit)){
-    x=instance_nearest(-100,240,obj_pnunit).x;
+    var _nearest = instance_nearest(-100,240,obj_pnunit);
+    if (instance_exists(_nearest)){
+        x = _nearest.x;
+    }
 }


### PR DESCRIPTION
## Description of changes
- fixes crash from lack of valid obj_pnunits
## Reasons for changes
- was causing crash when all player being wiped out in battle
## Related links
-
## How have you tested your changes?
- [x] Compile
- [x] New game
- [x] Next turn
- [x] Space Travel
- [x] Ground Battle

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->

## Summary by Sourcery

Bug Fixes:
- Prevent a crash that occurred when the player lost all their units in battle.