### PR TITLE
fix: check inquisitor in array range

### DIFF
--- a/scripts/scr_inquisition_fleet_functions/scr_inquisition_fleet_functions.gml
+++ b/scripts/scr_inquisition_fleet_functions/scr_inquisition_fleet_functions.gml
@@ -170,7 +170,7 @@ function new_inquisitor_inspection(){
 function inquisition_inspection_logic(){
 	var inspec_alert_string = "";
 	var cur_star=instance_nearest(x,y,obj_star);
-
+    inquisitor = inquisitor<0 ? 0 : inquisitor;
 	var inquis_string = $"Inquisitor {obj_controller.inquisitor[inquisitor]}";
 	 if (string_count("fleet",trade_goods)==0){
             inspec_alert_string = $"{inquis_string} finishes inspection of {cur_star.name}";


### PR DESCRIPTION
## Description of changes
- fixes potential crash from inquisitor value being -1
## Reasons for changes
-
## Related links
- https://discord.com/channels/714022226810372107/1120687959365128243/threads/1328955749312761858
## How have you tested your changes?
- [ ] Compile
- [ ] New game
- [ ] Next turn
- [ ] Space Travel
- [ ] Ground Battle

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->

## Summary by Sourcery

Bug Fixes:
- Prevent a crash that could occur when the inquisitor value is -1.