### PR TITLE
fix: case typo on shrine for recruit data

### DIFF
--- a/scripts/scr_recruit_data/scr_recruit_data.gml
+++ b/scripts/scr_recruit_data/scr_recruit_data.gml
@@ -267,7 +267,7 @@ function scr_trial_data(wanted=-1){
 			train_time : {
 				base : [90, 108],
 				planets : {
-					shrine :[70, 108],
+					Shrine :[70, 108],
 				}
 			},
 			exp_bonus : {
@@ -286,7 +286,7 @@ function scr_trial_data(wanted=-1){
 			train_time : {
 				base : [66, 80],
 				planets : {
-					shrine :[70, 108],
+					Shrine :[70, 108],
 				}
 			},
 			exp_bonus : {
@@ -299,7 +299,7 @@ function scr_trial_data(wanted=-1){
 			train_time : {
 				base : [120, 140],
 				planets : {
-					shrine :[70, 108],
+					Shrine :[70, 108],
 				}
 			},
 			exp_bonus : {


### PR DESCRIPTION
## Description of changes
- change "shrine" to "Shrine"
## Reasons for changes
- stopping player getting recruit benefits for recruiting from shrine worlds
## Related links
- https://discord.com/channels/714022226810372107/1120687959365128243/threads/1329129356206936225
## How have you tested your changes?
- [ ] Compile
- [ ] New game
- [ ] Next turn
- [ ] Space Travel
- [ ] Ground Battle

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->

## Summary by Sourcery

Bug Fixes:
- Correct the "shrine" key to "Shrine" to ensure players receive recruit benefits.