### PR TITLE
fix: Wrong argument passed into system_feature_bool

### DIFF
--- a/scripts/scr_apothecary_ground/scr_apothecary_ground.gml
+++ b/scripts/scr_apothecary_ground/scr_apothecary_ground.gml
@@ -156,7 +156,7 @@ function apothecary_simple(){
 		}
 		if (!marines_present){
 			if (obj_controller.gene_seed == 0) and (obj_controller.recruiting > 0) {
-				var _training_ground = system_feature_bool(self, P_features.Recruiting_World);
+				var _training_ground = system_feature_bool(self.p_feature, P_features.Recruiting_World);
 				if (_training_ground){
                     obj_controller.recruiting = 0;
                     obj_controller.income_recruiting = 0;


### PR DESCRIPTION
## Description of changes
- made p_feature pass into system_feature_bool
## Reasons for changes
- causing crash  when 0 gene seed
## Related links 
- https://discord.com/channels/714022226810372107/1120687959365128243
## How have you tested your changes?
- [x] Compile
- [x] New game
- [ ] Next turn
- [ ] Space Travel
- [ ] Ground Battle

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->

## Summary by Sourcery

Bug Fixes:
- Fix crash when gene seed is 0.