### PR TITLE
feat: Ground combat overhaul (#352)

### DIFF
--- a/scripts/scr_equipment_struct/scr_equipment_struct.gml
+++ b/scripts/scr_equipment_struct/scr_equipment_struct.gml
@@ -173,11 +173,17 @@ function EquipmentStruct(item_data, core_type,quality="none") constructor{
                             array_push(special_properties_array, special_properties[k]);
                         }
                     }
-                    if (arp>0){
-                        array_push(special_properties_array, "Armour Piercing")
+                    if (arp=1){
+                        array_push(special_properties_array, "Anti Vehicle")
                     } 
-                    else if (arp<0){
+                    else if (arp=0){
                         array_push(special_properties_array, "Low Penetration")
+                    }
+					else if (arp=-1){
+                        array_push(special_properties_array, "Medium Penetration")
+                    }
+					else if (arp=-2){
+                        array_push(special_properties_array, "High Penetration")
                     }
                     if (array_length(second_profiles)>0){
                         for (var h = 0; h < array_length(second_profiles); h++) {

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -1379,16 +1379,19 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data={}) 
 				carry_string+=$"{mobility_item()}: {format_number_with_sign(mobility_carry)}#";
 			}						
 			return [melee_carrying,melee_hands_limit,carry_string]						
-		}		
-		static melee_attack = function(weapon_slot=0){
-			encumbered_melee=false;
-			melee_att = 100*(((weapon_skill/100) * (strength/20)) + (experience/1000)+0.1);
-			var explanation_string = string_concat("#Stats: ", format_number_with_sign(round(((melee_att/100)-1)*100)), "%#");
-			explanation_string += "  Base: +10%#";
-			explanation_string += string_concat("  WSxSTR: ", format_number_with_sign(round((((weapon_skill/100)*(strength/20))-1)*100)), "%#");
-			explanation_string += string_concat("  EXP: ", format_number_with_sign(round((experience/1000)*100)), "%#");
+		}
 
-			melee_carrying = melee_hands_limit();
+		static melee_attack = function(weapon_slot=0){
+			var _format_sign = function(_num) {
+				_num = format_number_with_sign(round(_num));
+				return _num;
+			}
+
+			encumbered_melee=false;
+			var _melee_mod = 1;
+			var explanation_string = "";
+
+			var melee_carrying = melee_hands_limit();
 			var _wep1 = get_weapon_one_data();
 			var _wep2 = get_weapon_two_data();
 			if (!is_struct(_wep1)) then _wep1 = new EquipmentStruct({},"");
@@ -1425,7 +1428,7 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data={}) 
 							secondary_weapon=highest;
 						} else {
 							primary_weapon=highest;
-							melee_att*=0.5;
+							_melee_mod += 0.5;
 							if (primary_weapon.has_tag("flame")){
 								explanation_string+=$"Primary is Flame: -50%#"
 							} else if primary_weapon.has_tag("pistol"){
@@ -1442,19 +1445,53 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data={}) 
 					primary_weapon=_wep2;
 				}
 			};
+
 			var basic_wep_string = $"{primary_weapon.name}: {primary_weapon.attack}#";
+			explanation_string = basic_wep_string + explanation_string;
+
+			_melee_mod += (weapon_skill / 100) + (experience / 500);
+			explanation_string += $"#Stats:#";
+			explanation_string += $"  WS: {_format_sign((weapon_skill / 100) * 100)}%#";
+			explanation_string += $"  EXP: {_format_sign((experience / 500) * 100)}%#";
+
+			if (primary_weapon.has_tag("martial") || primary_weapon.has_tag("savage")) {
+				var bonus_modifier = 0;  
+				var martial_bonus = 0;  
+				var savage_bonus = 0;  
+			
+				if (primary_weapon.has_tag("martial")) {  
+					martial_bonus = dexterity / 100;
+				}  
+				if (primary_weapon.has_tag("savage")) {  
+					savage_bonus = strength / 100;
+				}  
+			
+				bonus_modifier = martial_bonus + savage_bonus;
+				_melee_mod += bonus_modifier;
+			
+				if (martial_bonus != 0) {  
+					explanation_string += $"  DEX (Martial): {_format_sign(martial_bonus * 100)}%#";
+				}  
+				if (savage_bonus != 0) {  
+					explanation_string += $"  STR (Savage): {_format_sign(savage_bonus * 100)}%#";
+				}  
+			} else {
+				_melee_mod += (strength / 200) + (dexterity / 200);
+				explanation_string += $"  STR: {_format_sign((strength / 200) * 100)}%#";
+				explanation_string += $"  DEX: {_format_sign((dexterity / 200) * 100)}%#";  
+			}
+
 			if IsSpecialist("libs") or has_trait("warp_touched"){
-				if (primary_weapon.has_tag("force") ||_wep2.has_tag("force")){
-					var force_modifier = (((weapon_skill/100) * (psionic/10) * (intelligence/10)) + (experience/1000)+0.1);
-					primary_weapon.attack *= force_modifier;
-					basic_wep_string += $"Active Force Weapon: x{force_modifier}#  Base: 0.10#  WSxPSIxINT: x{(weapon_skill/100)*(psionic/10)*(intelligence/10)}#  EXP: x{experience/1000}#";
+				if (primary_weapon.has_tag("force")){
+					var force_modifier = (psionic * 3) * (intelligence/40);
+					_melee_mod += force_modifier / 100;
+					explanation_string += $"  PSYxINT (Force): {_format_sign(force_modifier)}%#";
 				}		
-			};
-			explanation_string = basic_wep_string + explanation_string
+			}
 
 			if (melee_carrying[0]>melee_carrying[1]){
 				encumbered_melee=true;	
-				melee_att*=0.6;
+				_melee_mod*=0.6;
 				explanation_string+=$"Encumbered: x0.6#"
 			}
 			if (!encumbered_melee){
@@ -1464,23 +1501,24 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data={}) 
 				total_gear_mod+=get_mobility_data("melee_mod");
 				total_gear_mod+=_wep1.melee_mod;
 				total_gear_mod+=_wep2.melee_mod;
-				melee_att+=total_gear_mod;
-				explanation_string+=$"#Gear Mod: {(total_gear_mod/100)*100}%#";
+				total_gear_mod/=100;
+				_melee_mod += total_gear_mod;
+				explanation_string+=$"#Gear Mod: {_format_sign(total_gear_mod * 100)}%#";
 				//TODO make trait data like this more structured to be able to be moddable
 				if (has_trait("feet_floor") && mobility_item()!=""){
-					melee_att*=0.9;
+					_melee_mod*=0.9;
 					explanation_string+=$"{global.trait_list.feet_floor.display_name}: x0.9#";
 				}
 				if (primary_weapon.has_tag("fist") && has_trait("brawler")){
-					melee_att*=1.1;
+					_melee_mod*=1.1;
 					explanation_string+=$"{global.trait_list.brawler.display_name}: x1.1#";
 				}
 				if (primary_weapon.has_tag("power") && has_trait("duelist")){
-					melee_att*=1.3;
+					_melee_mod*=1.3;
 					explanation_string+=$"{global.trait_list.duelist.display_name}: x1.3#";
 				}				
 			}
-			var final_attack =  floor((melee_att/100)*primary_weapon.attack);
+			var final_attack =  floor((_melee_mod)*primary_weapon.attack);
 			if (secondary_weapon!="none" && !encumbered_melee){
 				var side_arm_data="Standard: x0.5";
 				var secondary_modifier = 0.5;
@@ -1498,12 +1536,13 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data={}) 
 					secondary_modifier = 0.3;
 					side_arm_data="Flame: x0.3";
 				}
-				var side_arm = floor(secondary_modifier*((melee_att/100)*secondary_weapon.attack));
+				var side_arm = floor(secondary_modifier*(_melee_mod*secondary_weapon.attack));
 				if (side_arm>0){
 					final_attack+=side_arm;
-					explanation_string+=$"Side Arm: +{side_arm}({side_arm_data})#";
+					explanation_string+=$"Side Arm: +{side_arm} ({side_arm_data})#";
 				}
 			}
+
 			melee_damage_data=[final_attack,explanation_string,melee_carrying,primary_weapon, secondary_weapon];
 			return melee_damage_data;
 		};

--- a/scripts/scr_shoot/scr_shoot.gml
+++ b/scripts/scr_shoot/scr_shoot.gml
@@ -252,23 +252,28 @@ function scr_shoot(weapon_index_position, target_object, target_type, damage_dat
 						if (weapon_index_position = -52) {
 							wii = "Missile Launcher Emplacement";
 							at = 200;
-							armour_pierce = 1;
+							armour_pierce = -1;
 						}
 						if (weapon_index_position = -53) {
 							wii = "Missile Silo";
 							at = 250;
-							ar = 0;
+							armour_pierce = 0;
 						}
 					}
 
 					target_armour_value = target_object.dudes_ac[target_type];
 
+					// Calculate final armor value based on armor piercing (AP) rating against target type
 					if (target_object.dudes_vehicle[target_type]) {
+						if (armour_pierce = 1) then target_armour_value = 0;
 						if (armour_pierce = 0) then target_armour_value = target_armour_value * 6;
-						if (armour_pierce = -1) then target_armour_value = damage_per_weapon;
+						if (armour_pierce = -1) then target_armour_value = target_armour_value * 4 ;
+						if (armour_pierce = -2) then target_armour_value = target_armour_value * 2;
 					} else {
 						if (armour_pierce = 1) then target_armour_value = 0;
-						if (armour_pierce = -1) then target_armour_value = target_armour_value * 6;
+						if (armour_pierce = 0) then target_armour_value = target_armour_value * 4;
+						if (armour_pierce = -1) then target_armour_value = target_armour_value * 3;
+						if (armour_pierce = -2) then target_armour_value = target_armour_value * 1.5;
 					}
 
 					attack_count_mod = max(1, splash[weapon_index_position]);
@@ -358,11 +363,14 @@ function scr_shoot(weapon_index_position, target_object, target_type, damage_dat
 								target_armour_value2 = target_object.dudes_ac[godd];
 								if (target_object.dudes_vehicle[godd] = 0) {
 									if (ap2 = 1) then target_armour_value2 = 0;
-									if (ap2 = -1) then target_armour_value2 = target_armour_value2 * 6;
+									if (ap2 = 0) then target_armour_value2 = target_armour_value2 * 4;
+									if (ap2 = -1) then target_armour_value2 = target_armour_value2 * 3;
+									if (ap2 = -2) then target_armour_value2 = target_armour_value2 * 1.5;
 								}
 								if (target_object.dudes_vehicle[godd] = 1) {
 									if (ap2 = 0) then target_armour_value2 = target_armour_value2 * 6;
-									if (ap2 = -1) then target_armour_value2 = damage_per_weapon;
+									if (ap2 = -1) then target_armour_value2 = target_armour_value2 * 4;
+									if (ap2 = -2) then target_armour_value2 = target_armour_value2 * 2;
 								}
 								b2 = a2 - target_armour_value2;
 								if (b2 <= 0) then b2 = 0; // Average after armour

--- a/scripts/scr_weapon/scr_weapon.gml
+++ b/scripts/scr_weapon/scr_weapon.gml
@@ -48,17 +48,19 @@ global.weapons = {
 		"melee_hands": 0,
 		"ranged_hands": 0.5,
 		"ammo": 30,
-		"range": 3.1,
-		"spli": 1,
+
+		"range": 4.1,
+		"spli": 0,
 		"arp": 0,
 		"tags": ["pistol", "ancient", "las", "energy"],
 	},
+
 	"Combat Knife": {
 		"abbreviation": "CbKnf",
 		"attack": {
-			"standard": 25,
-			"master_crafted": 30,
-			"artifact": 35
+			"standard": 50,
+			"master_crafted": 75,
+			"artifact": 100
 		},
 		"description": "More of a sword than a knife, this tough and thick blade becomes a deadly weapon in the hand of an Astartes.",
 		"melee_hands": 0,
@@ -72,9 +74,9 @@ global.weapons = {
 	"Chainsword": {
 		"abbreviation": "ChSwrd",
 		"attack": {
-			"standard": 50,
-			"master_crafted": 60,
-			"artifact": 70
+			"standard": 130,
+			"master_crafted": 150,
+			"artifact": 200
 		},
 		"description": "A standard Chainsword. It is popular among Assault Marines due to their raw power while maintaining speed.",
 		"melee_hands": 1,
@@ -83,14 +85,14 @@ global.weapons = {
 		"range": 1,
 		"spli": 4,
 		"arp": 0,
-		"tags": ["chain", "sword"],
+		"tags": ["chain", "sword","savage", "boarding 1"],
 	},
 	"Chainaxe": {
 		"abbreviation": "ChAxe",
 		"attack": {
-			"standard": 90,
-			"master_crafted": 100,
-			"artifact": 110
+			"standard": 110,
+			"master_crafted": 130,
+			"artifact": 150
 		},
 		"melee_mod": {
 			"standard": 5,
@@ -104,7 +106,7 @@ global.weapons = {
 		"range": 1,
 		"spli": 6,
 		"arp": 0,
-		"tags": ["chain", "axe", "dual"],
+		"tags": ["chain", "axe", "dual", "savage", "boarding 2"],
 	},
 	"Company Standard": {
 		"abbreviation": "CmpStnd",
@@ -129,9 +131,9 @@ global.weapons = {
 	"Eviscerator": {
 		"abbreviation": "Evisc",
 		"attack": {
-			"standard": 180,
-			"master_crafted": 190,
-			"artifact": 200
+			"standard": 260,
+			"master_crafted": 290,
+			"artifact": 330
 		},
 		"melee_mod": {
 			"standard": 2,
@@ -143,16 +145,16 @@ global.weapons = {
 		"ranged_hands": 1,
 		"ammo": 0,
 		"range": 1,
-		"spli": 3,
-		"arp": 1,
-		"tags": ["chain", "sword"],
+		"spli": 6,
+		"arp": -1,
+		"tags": ["chain", "sword", "savage"],
 	},
 	"Power Sword": {
 		"abbreviation": "PwrSwrd",
 		"attack": {
-			"standard": 180,
-			"master_crafted": 200,
-			"artifact": 240
+			"standard": 225,
+			"master_crafted": 260,
+			"artifact": 300
 		},
 		"melee_mod": {
 			"standard": 1,
@@ -165,16 +167,16 @@ global.weapons = {
 		"ammo": 0,
 		"range": 1,
 		"spli": 4,
-		"arp": 1,
+		"arp": -1,
 		"special_properties": ["Parry"],
-		"tags": ["power", "sword"],
+		"tags": ["power", "sword", "martial", "boarding 1"],
 	},
 	"Power Spear": {
 		"abbreviation": "PwrSpear",
 		"attack": {
-			"standard": 200,
-			"master_crafted": 220,
-			"artifact": 260
+			"standard": 300,
+			"master_crafted": 375,
+			"artifact": 450
 		},
 		"melee_mod": {
 			"standard": 1,
@@ -187,9 +189,9 @@ global.weapons = {
 		"ammo": 0,
 		"range": 1,
 		"spli": 6,
-		"arp": 1,
+		"arp": -1,
 		"special_properties": ["Parry"],
-		"tags": ["power", "spear"],
+		"tags": ["power", "spear", "martial"],
 	},
 	"Chainfist": {
 		"abbreviation": "ChFst",
@@ -199,12 +201,12 @@ global.weapons = {
 			"artifact": 700
 		},
 		"description": "Created by mounting a chainsword to a power fist, this weapon is easily able to carve through armoured bulkheads.",
-		"melee_hands": 1.25,
-		"ranged_hands": 1,
+		"melee_hands": 3,
+		"ranged_hands": 0,
 		"range": 1,
-		"spli": 2,
-		"arp": 1,
-		"tags": ["power","boarding", "chain", "fist", "dual", "siege"],
+		"spli": 4,
+		"tags": ["power","boarding 3", "chain", "fist", "dual", "siege", "savage"],
+		"arp": -2,
 	},
 	"Lascutter": {
 		"abbreviation": "Lasct",
@@ -237,15 +239,15 @@ global.weapons = {
 		"ammo": 0,
 		"range": 1,
 		"spli": 3,
-		"arp": 1,
+		"arp": -2,
 		"tags": ["power"],
 	},
 	"Power Axe": {
 		"abbreviation": "PwrAxe",
 		"attack": {
-			"standard": 190,
-			"master_crafted": 220,
-			"artifact": 260
+			"standard": 200,
+			"master_crafted": 225,
+			"artifact": 300
 		},
 		"melee_mod": {
 			"standard": 1,
@@ -258,15 +260,15 @@ global.weapons = {
 		"ammo": 0,
 		"range": 1,
 		"spli": 5,
-		"arp": 1,
-		"tags": ["power", "axe", "dual"],
+		"arp": -1,
+		"tags": ["power", "axe", "dual","savage", "boarding 2"],
 	},
 	"Executioner Power Axe": {
 		"abbreviation": "ExPwrAxe",
 		"attack": {
-			"standard": 300,
-			"master_crafted": 350,
-			"artifact": 400
+			"standard": 800,
+			"master_crafted": 850,
+			"artifact": 925
 		},
 		"melee_mod": {
 			"standard": 10,
@@ -280,7 +282,7 @@ global.weapons = {
 		"range": 1,
 		"spli": 2,
 		"arp": 1,
-		"tags": ["power", "axe"],
+		"tags": ["power", "axe", "martial"],
 	},
 	"Power Fist": {
 		"abbreviation": "PwrFst",
@@ -300,8 +302,8 @@ global.weapons = {
 		"ammo": 0,
 		"range": 1,
 		"spli": 2,
-		"arp": 1,
-		"tags": ["power", "dual", "fist"],
+		"tags": ["power", "dual", "fist", "savage", "boarding 2"],
+		"arp": -2,
 	},
 	"Power Fists": {
 		"abbreviation": "PwrFsts",
@@ -316,8 +318,8 @@ global.weapons = {
 		"ammo": 0,
 		"range": 1,
 		"spli": 4,
-		"arp": 1,
-		"tags": ["power", "fist", "pair"],
+		"tags": ["power", "fist", "pair","savage" ,"boarding 2"],
+		"arp": -2,
 	},
 	"Servo-arm(M)": {
 		"abbreviation": "MchArm",
@@ -332,7 +334,7 @@ global.weapons = {
 		"ammo": 0,
 		"range": 1,
 		"spli": 2,
-		"arp": 1,
+		"arp": -2,
 		"tags": ["siege"],
 	},
 	"Boltstorm Gauntlet": {
@@ -348,9 +350,9 @@ global.weapons = {
 		"ammo": 0,
 		"range": 1,
 		"spli": 2,
-		"arp": 1,
+		"arp": -2,
 		"second_profiles": ["Integrated Bolter"],
-		"tags": ["power", "fist"],
+		"tags": ["power", "fist", "savage", "boarding 2"],
 	},
 	"Assault Chainfist": {
 		"abbreviation": "AssltChFst",
@@ -364,7 +366,7 @@ global.weapons = {
 		"ranged_hands": 1,
 		"range": 1,
 		"spli": 2,
-		"arp": 1,
+		"arp": -2,
 		"second_profiles": ["Assault Cannon"],
 		"tags": ["power","boarding", "chain", "fist", "dual", "siege"],
 	},
@@ -381,8 +383,8 @@ global.weapons = {
 		"ammo": 0,
 		"range": 1,
 		"spli": 5,
-		"arp": 1,
-		"tags": ["power", "dual", "fist"],
+		"tags": ["power", "dual", "fist", "boarding 2", "martial"],
+		"arp": -1,
 	},
 	"Dreadnought Lightning Claw": {
 		"abbreviation": "LghtClw",
@@ -402,7 +404,7 @@ global.weapons = {
 		"ammo": 0,
 		"range": 1,
 		"spli": 15,
-		"arp": 1,
+		"arp": -2,
 		"maintenance" : 0.1,
 		"tags": ["power", "vehicle", "dual", "dreadnought", "fist"],
 	},
@@ -424,17 +426,17 @@ global.weapons = {
 		"ammo": 0,
 		"range": 1,
 		"spli": 10,
-		"arp": 1,
-		"tags": ["power", "hammer", "siege"],
+		"arp": -2,
 		"maintenance" : 0.1,
 		"req_exp": 100,
+    "tags": ["power", "hammer", "siege", "savage", "boarding 2"],
 	},
 	"Heavy Thunder Hammer": {
 		"abbreviation": "HvyThndHmr",
 		"attack": {
-			"standard": 975,
-			"master_crafted": 1125,
-			"artifact": 1350,
+			"standard": 800,
+			"master_crafted": 950,
+			"artifact": 1100,
 		},
 		"melee_mod": {
 			"standard": 1.3,
@@ -446,11 +448,11 @@ global.weapons = {
 		"ranged_hands": 2,
 		"ammo": 0,
 		"range": 1,
+		"arp": -2,
 		"spli": 15,
-		"arp": 1,
-		"tags": ["heavy_melee", "power", "hammer", "siege"],
-		"maintenance" : 0.1,
+    "maintenance" : 0.1,
 		"req_exp": 100,
+    "tags": ["heavy_melee", "power", "hammer", "siege", "savage"],
 	},
 	"Power Mace": {
 		"abbreviation": "PwrMace",
@@ -469,9 +471,9 @@ global.weapons = {
 		"ranged_hands": 2,
 		"ammo": 0,
 		"range": 1,
+		"arp": -2,
 		"spli": 10,
-		"arp": 1,
-		"tags": ["power", "mace", "siege"],
+		"tags": ["power", "mace", "siege", "savage"],
 		"req_exp": 100,
 	},
 	"Mace of Absolution": {
@@ -493,8 +495,8 @@ global.weapons = {
 		"ammo": 0,
 		"range": 1,
 		"spli": 10,
-		"arp": 1,
-		"tags": ["power", "mace", "siege", "pious"],
+		"arp": -2,
+		"tags": ["power", "mace", "siege", "pious", "savage"],
 		"req_exp": 100,
 	},
 	"Tome": {
@@ -516,14 +518,14 @@ global.weapons = {
 		"range": 1,
 		"spli": 1,
 		"arp": 0,
-		"tags": ["arcane"],
+		"tags": ["arcane", "savage"],
 	},
 	"Crozius Arcanum": {
 		"abbreviation": "Crzus",
 		"attack": {
-			"standard": 220,
+			"standard": 200,
 			"master_crafted": 250,
-			"artifact": 300
+			"artifact": 325
 		},
 		"melee_mod": {
 			"standard": 1,
@@ -536,15 +538,15 @@ global.weapons = {
 		"ammo": 0,
 		"range": 1,
 		"spli": 4,
-		"arp": 1,
-		"tags": ["power", "mace", "pious"],
+		"arp": -1,
+		"tags": ["power", "mace", "pious", "savage", "boarding 2"],
 	},
 	"Relic Blade": {
 		"abbreviation": "RlcBld",
 		"attack": {
-			"standard": 700,
-			"master_crafted": 850,
-			"artifact": 1000
+			"standard": 850,
+			"master_crafted": 950,
+			"artifact": 1100
 		},
 		"melee_mod": {
 			"standard": 1,
@@ -557,26 +559,43 @@ global.weapons = {
 		"ammo": 0,
 		"range": 1,
 		"spli": 8,
-		"arp": 1,
+		"arp": -1,
 		"special_properties": ["Parry"],
-		"maintenance" : 0.1,
-		"tags": ["power", "sword"],
+    "maintenance" : 0.1,
+		"tags": ["power", "sword", "martial"],
+
 	},
 	"Bolt Pistol": {
 		"abbreviation": "BltPstl",
 		"attack": {
-			"standard": 30,
-			"master_crafted": 35,
-			"artifact": 40
+			"standard": 100,
+			"master_crafted": 120,
+			"artifact": 150
 		},
 		"description": "A smaller, more compact version of the venerable Boltgun. This model is produced in the standard Godwyn pattern.",
 		"melee_hands": 0,
 		"ranged_hands": 1,
 		"ammo": 18,
-		"range": 3.1,
-		"spli": 1,
+		"range": 4.1,
+		"spli": 3,
 		"arp": 0,
-		"tags": ["bolt", "pistol"],
+		"tags": ["bolt", "pistol", "boarding 1"],
+	},
+	"Wrist-Mounted Storm Bolter": { // TODO: Not used outside of this file atm;
+		"abbreviation": "WrstBlt",
+		"attack": {
+			"standard": 200,
+			"master_crafted": 240,
+			"artifact": 300
+		},
+		"description": "A smaller, more compact version of the venerable Boltgun. This model is produced in the standard Godwyn pattern.",
+		"melee_hands": 0,
+		"ranged_hands": 1,
+		"ammo": 18,
+		"range": 4.1,
+		"spli": 6,
+		"arp": 0,
+		"tags": ["bolt", "pistol", "boarding 2"],
 	},
 	"Webber": {
 		"abbreviation": "Webbr",
@@ -597,32 +616,49 @@ global.weapons = {
 	"Grav-Pistol": {
 		"abbreviation": "GrvPstl",
 		"attack": {
-			"standard": 150,
-			"master_crafted": 200,
-			"artifact": 250
+			"standard": 300,
+			"master_crafted": 350,
+			"artifact": 425
 		},
 		"description": "A smaller version of the Grav-Gun which utilises the gravitic reaction principle most commonly seen powering grav-vehicles such as the Land Speeder.",
 		"melee_hands": 0,
 		"ranged_hands": 1,
 		"ammo": 4,
-		"range": 2.1,
+		"range": 4.1,
 		"spli": 1,
 		"arp": 1,
+    "maintenance" : 0.8,
 		"tags": ["grav", "pistol"],
 		"maintenance" : 0.8,
+	},
+	"Integrated-Grav": {
+		"abbreviation": "IntGrv",
+		"attack": {
+			"standard": 500,
+			"master_crafted": 550,
+			"artifact": 625
+		},
+		"description": "",
+		"melee_hands": 0,
+		"ranged_hands": 0,
+		"ammo": 3,
+		"range": 5.1,
+		"spli": 1,
+		"arp": 1,
+		"tags": ["grav"]
 	},
 	"Grav-Gun": {
 		"abbreviation": "GrvGn",
 		"attack": {
-			"standard": 450,
-			"master_crafted": 475,
-			"artifact": 500
+			"standard": 500,
+			"master_crafted": 550,
+			"artifact": 625
 		},
 		"description": "A medium-sized weapon which utilises the gravitic reaction principle most commonly seen powering grav-vehicles such as the Land Speeder.",
 		"melee_hands": 1,
 		"ranged_hands": 2,
-		"ammo": 4,
-		"range": 4,
+		"ammo": 6,
+		"range": 5,
 		"spli": 3,
 		"arp": 1,
 		"tags": ["grav"],
@@ -633,13 +669,13 @@ global.weapons = {
 		"attack": {
 			"standard": 800,
 			"master_crafted": 850,
-			"artifact": 900
+			"artifact": 960
 		},
 		"description": "A bigger version of the Grav-Gun which utilises the gravitic reaction principle most commonly seen powering grav-vehicles such as the Land Speeder.",
 		"melee_hands": 1,
 		"ranged_hands": 2,
 		"ammo": 8,
-		"range": 8,
+		"range": 6,
 		"spli": 6,
 		"arp": 1,
 		"tags": ["grav", "heavy_weapon"],
@@ -648,9 +684,9 @@ global.weapons = {
 	"Underslung Bolter": {
 		"abbreviation": "UndBltr",
 		"attack": {
-			"standard": 60,
-			"master_crafted": 70,
-			"artifact": 80
+			"standard": 100,
+			"master_crafted": 125,
+			"artifact": 150
 		},
 		"description": "A compact, secondary Bolter weapon often attached under the barrel of a larger firearm. It allows for rapid fire in close quarters combat.",
 		"melee_hands": 0,
@@ -664,34 +700,34 @@ global.weapons = {
 	"Stalker Pattern Bolter": {
 		"abbreviation": "StlkBltr",
 		"attack": {
-			"standard": 100,
-			"master_crafted": 110,
-			"artifact": 120
+			"standard": 180,
+			"master_crafted": 200,
+			"artifact": 240
 		},
 		"description": "The Stalker Bolter is a scoped long-range variant of the standard Bolter. Depending on the specific modifications made by the wielder, the Stalker Bolter can serve as a precision battle rifle or a high-powered sniper weapon.",
 		"melee_hands": 0,
 		"ranged_hands": 2,
 		"ammo": 20,
-		"range": 15,
-		"spli": 1,
-		"arp": 1,
+		"range": 16,
+		"spli": 3,
+		"arp": -1,
 		"tags": ["bolt", "precision"]
 	},
 	"Bolter": {
 		"abbreviation": "Bltr",
 		"attack": {
-			"standard": 50,
-			"master_crafted": 55,
-			"artifact": 60
+			"standard": 150,
+			"master_crafted": 175,
+			"artifact": 200
 		},
 		"description": "A standard Bolter, a two-handed firearm that launches rocket propelled projectiles that detonate after penetrating the target. It is a versatile and iconic weapon of Adeptus Astartes, their resounding detonations carry the Emperor's Wrath.",
 		"melee_hands": 1,
 		"ranged_hands": 2,
 		"ammo": 16,
-		"range": 12,
-		"spli": 3,
+		"range": 10,
+		"spli": 5,
 		"arp": 0,
-		"tags": ["bolt"]
+		"tags": ["bolt", "boarding 1"]
 	},
 	"Heavy Flamer": {
 		"abbreviation": "HvyFlmr",
@@ -705,23 +741,23 @@ global.weapons = {
 		"ranged_hands": 2.25,
 		"ammo": 8,
 		"range": 2,
-		"spli": 5,
+		"spli": 20,
 		"arp": -1,
-		"tags": ["flame", "heavy_ranged"]
+		"tags": ["flame", "heavy_ranged", "boarding 3"]
 	},
 	"CCW Heavy Flamer": {
 		"abbreviation": "CCWHvyFlmr",
 		"attack": {
-			"standard": 250,
-			"master_crafted": 275,
-			"artifact": 300
+			"standard": 500,
+			"master_crafted": 550,
+			"artifact": 600
 		},
 		"description": "A powerful close combat weapon integrated with a flamer. Enemeies rarely expect a dreadnough claw to spew promethium.",
 		"melee_hands": 1,
 		"ranged_hands": 0,
 		"ammo": 6,
 		"range": 2.1,
-		"spli": 5,
+		"spli": 20,
 		"arp": -1,
 		"tags": ["dreadnought","heavy_ranged", "flame"]
 	},
@@ -758,66 +794,82 @@ global.weapons = {
 	"Inferno Cannon": {
 		"abbreviation": "InfCann",
 		"attack": {
-			"standard": 400,
-			"master_crafted": 440,
-			"artifact": 480
+			"standard": 750,
+			"master_crafted": 875,
+			"artifact": 1000
 		},
 		"description": "A huge vehicle-mounted flame weapon that fires with explosive force. The reservoir is liable to explode.",
 		"melee_hands": 0,
 		"ranged_hands": 3,
 		"ammo": 0,
-		"range": 3.1,
+		"range": 4.1,
 		"spli": 20,
 		"arp": -1,
 		"tags": ["vehicle","heavy_ranged", "flame", "dreadnought"]
 	},
+	"Integrated-Melta": {
+		"abbreviation": "IntMlt",
+		"attack": {
+			"standard": 400,
+			"master_crafted": 475,
+			"artifact": 600
+		},
+		"description": "",
+		"melee_hands": 0,
+		"ranged_hands": 0,
+		"ammo": 5,
+		"range": 2.1,
+		"spli": 1,
+		"arp": 1,
+		"tags": ["melta"]
+	},
 	"Meltagun": {
 		"abbreviation": "Mltgn",
 		"attack": {
-			"standard": 450,
+			"standard": 400,
 			"master_crafted": 475,
-			"artifact": 500
+			"artifact": 600
 		},
 		"description": "A loud weapon that roars with fury, this gun vaporizes flesh and armor alike. Due to heat dissipation, it has only a short range.",
 		"melee_hands": 1,
 		"ranged_hands": 2,
-		"ammo": 4,
+		"ammo": 6,
 		"range": 2.1,
-		"spli": 1,
-		"arp": 1,
-		"tags": ["melta","boarding"]
+		"spli": 6,
+		"arp": -2,
+		"tags": ["melta","boarding 3"]
 	},
 	"Multi-Melta": {
 		"abbreviation": "MltMelt",
 		"attack": {
-			"standard": 800,
-			"master_crafted": 850,
-			"artifact": 900
+			"standard": 700,
+			"master_crafted": 800,
+			"artifact": 950
 		},
 		"description": "Though bearing longer range than the Meltagun, this weapon's great size usually restricts it to vehicles though those with Power Armor can carry this cumbersome weapon into battle.",
 		"melee_hands": 1,
 		"ranged_hands": 2.25,
 		"ammo": 8,
 		"range": 4.1,
-		"spli": 1,
-		"arp": 1,
-		"tags": ["melta", "heavy_ranged", "dreadnought"]
+		"spli": 10,
+		"arp": -2,
+		"tags": ["melta", "heavy_ranged", "dreadnought", "boarding 1"]
 	},
 	"Plasma Pistol": {
 		"abbreviation": "PlsmPstl",
 		"attack": {
-			"standard": 115,
-			"master_crafted": 130,
-			"artifact": 150
+			"standard": 250,
+			"master_crafted": 290,
+			"artifact": 320
 		},
 		"description": "A pistol variant of the plasma gun, this dangerous-to-use weapon has exceptional armor-piercing capabilities.",
 		"melee_hands": 0,
 		"ranged_hands": 1,
 		"ammo": 0,
-		"range": 3.1,
-		"spli": 1,
-		"arp": 1,
-		"tags": ["plasma", "energy", "pistol"]
+		"range": 5.1,
+		"spli": 2,
+		"arp": -2,
+		"tags": ["plasma", "energy", "pistol", "boarding 1"]
 	},
 	"Plasma Cutter": { // Basically a dual-linked plasma pistol
 		"abbreviation": "PlsmCt",
@@ -830,17 +882,17 @@ global.weapons = {
 		"melee_hands": 0,
 		"ranged_hands": 0,
 		"ammo": 0,
-		"range": 3.1,
+		"range": 4.1,
 		"spli": 1,
-		"arp": 1,
+		"arp": -2,
 		"tags": ["plasma", "energy", "pistol"]
 	},
 	"Infernus Pistol": {
 		"abbreviation": "InfPstl",
 		"attack": {
-			"standard": 100,
-			"master_crafted": 110,
-			"artifact": 120
+			"standard": 250,
+			"master_crafted": 280,
+			"artifact": 325
 		},
 		"description": "The Infernus Pistol is a compact pistol varient of the melta gun. A brutal blast of heat to burn away the The Emperor's foes.",
 		"melee_hands": 0,
@@ -848,63 +900,79 @@ global.weapons = {
 		"ammo": 4,
 		"range": 2.1,
 		"spli": 3,
-		"arp": 1,
-		"tags": ["melta", "pistol"]
+		"arp": -2,
+		"tags": ["melta", "pistol", "boarding 2"]
+	},
+	"Integrated-Plasma": {
+		"abbreviation": "IntPls",
+		"attack": {
+			"standard": 350,
+			"master_crafted": 400,
+			"artifact": 475
+		},
+		"description": "",
+		"melee_hands": 0,
+		"ranged_hands": 0,
+		"ammo": 6,
+		"range": 10,
+		"spli": 2,
+		"arp": -1,
+		"tags": ["plasma"]
 	},
 	"Plasma Gun": {
 		"abbreviation": "PlsmGn",
 		"attack": {
-			"standard": 250,
-			"master_crafted": 275,
-			"artifact": 300
+			"standard": 350,
+			"master_crafted": 400,
+			"artifact": 475
 		},
 		"description": "A two-handed weapon that launches blobs of plasma at the target. They are considered both sacred and dangerous, overheating through rapid firing of the weapon. Overheating can result in detonation of the weapon, killing the wielder.",
 		"melee_hands": 0,
 		"ranged_hands": 2,
 		"ammo": 16,
-		"range": 12,
+		"range": 10,
 		"spli": 3,
-		"arp": 1,
-		"tags": ["plasma", "energy"]
+		"arp": -2,
+		"tags": ["plasma", "energy", "boarding 1"]
 	},
 	"Plasma Cannon": {
 		"abbreviation": "PlsmCan",
 		"attack": {
-			"standard": 500,
-			"master_crafted": 600,
-			"artifact": 750
+			"standard": 700,
+			"master_crafted": 800,
+			"artifact": 900
 		},
 		"description": "A heavy variant of the plasma gun, its power output is significantly higher and its damage capability shows. However, it maintains the overheating risk of the Plasma Gun",
 		"melee_hands": 1,
 		"ranged_hands": 3,
 		"ammo": 16,
-		"range": 14,
-		"spli": 2,
-		"arp": 1,
+		"range": 10,
+		"spli": 8,
+		"arp": -2,
 		"tags": ["plasma","energy","heavy_ranged", "dreadnought"]
 	},
 	"Sniper Rifle": {
 		"abbreviation": "SnprRfl",
 		"attack": {
-			"standard": 80,
-			"master_crafted": 88,
-			"artifact": 96
+			"standard": 120,
+			"master_crafted": 150,
+			"artifact": 200
 		},
 		"description": "The Sniper Rifle fires a solid shell over long range and boasts powerful telescopic sights to assist, allowing the user to target enemy weak points and distant foes.",
 		"melee_hands": 1,
 		"ranged_hands": 2,
 		"ammo": 20,
-		"range": 18,
+		"range": 14,
 		"spli": 1,
-		"arp": 0,
+		"arp": -1,
 		"tags": ["precision", "rifle"]
 	},
 	"Assault Cannon": {
 		"abbreviation": "AssCann",
 		"attack": {
-			"standard": 240,
-			"master_crafted": 264,
-			"artifact": 288
+			"standard": 400,
+			"master_crafted": 440,
+			"artifact": 500
 		},
 		"description": "A heavy rotary autocannon with a devastating fire rate that can be counted in the hundreds per minute. It is incredibly effective against infantry and light armored targets.",
 		"melee_hands": 2.1,
@@ -912,39 +980,39 @@ global.weapons = {
 		"ammo": 5,
 		"range": 12,
 		"spli": 20,
-		"arp": 1,
+		"arp": 0,
 		"tags": ["heavy_ranged", "dreadnought"]
 	},
 	"Autocannon": {
 		"abbreviation": "Autocnn",
 		"attack": {
-			"standard": 380,
-			"master_crafted": 400,
-			"artifact": 430
+			"standard": 450,
+			"master_crafted": 500,
+			"artifact": 600
 		},
 		"description": "A rapid-firing weapon able to use a wide variety of ammunition, from mass-reactive explosive to solid shells. It has been found to be incredibly effective against large groups of targets and even Traitor Astartes to an extent.",
 		"melee_hands": 0,
 		"ranged_hands": 2.25,
 		"ammo": 25,
-		"range": 18,
-		"spli": 15,
-		"arp": 1,
+		"range": 14,
+		"spli": 12,
+		"arp": -1,
 		"tags": ["heavy_ranged", "dreadnought"]
 	},
 	"Missile Launcher": {
 		"abbreviation": "MsslLnch",
 		"attack": {
-			"standard": 250,
-			"master_crafted": 275,
-			"artifact": 300
+			"standard": 300,
+			"master_crafted": 350,
+			"artifact": 425
 		},
-		"description": "This shoulder mounted weapon is capable of firing either armor-piercing or fragmentation rockets. It's ammunition is limited by what the bearer has carried with them.",
+		"description": "This shoulder fired weapon is capable of firing either armor-piercing or fragmentation rockets. It's ammunition is limited by what the bearer has carried with them.",
 		"melee_hands": 1,
 		"ranged_hands": 2,
 		"ammo": 6,
-		"range": 24,
-		"spli": 3,
-		"arp": 0,
+		"range": 15,
+		"spli": 10,
+		"arp": -1,
 		"tags": ["heavy_ranged", "dreadnought"]
 	},
 	"Lascannon": {
@@ -958,7 +1026,7 @@ global.weapons = {
 		"melee_hands": 1,
 		"ranged_hands": 2.25,
 		"ammo": 8,
-		"range": 24,
+		"range": 20,
 		"spli": 1,
 		"arp": 1,
 		"tags": ["heavy_ranged", "las", "energy"]
@@ -979,17 +1047,17 @@ global.weapons = {
 		"arp": 1,
 		"tags": ["heavy_ranged", "ancient"]
 	},
-	"Integrated Bolter": {
+	"Integrated-Bolter": {
 		"abbreviation": "IntgBltr",
 		"attack": {
-			"standard": 50,
-			"master_crafted": 55,
-			"artifact": 60
+			"standard": 150,
+			"master_crafted": 175,
+			"artifact": 200
 		},
 		"description": "A Bolter that can be built directly into the structure of the vehicle, armor, another weapon or Dreadnought. When used as a weapon, it leaves both hands free, allowing to use any, even a twohanded weapon, efficiently.",
 		"melee_hands": 0,
 		"ranged_hands": 0,
-		"ammo": 20,
+		"ammo": 8,
 		"range": 12,
 		"spli": 4,
 		"arp": 0,
@@ -998,25 +1066,25 @@ global.weapons = {
 	"Twin Linked Heavy Bolter": {
 		"abbreviation": "TwnHvyBltr",
 		"attack": {
-			"standard": 320,
-			"master_crafted": 352,
-			"artifact": 384
+			"standard": 450,
+			"master_crafted": 500,
+			"artifact": 650
 		},
 		"description": "Twin-linked Heavy Bolters are an upgraded version of the standard Heavy Bolter weapon, which is known for its high rate of fire and effectiveness against infantry and light vehicles.",
 		"melee_hands": 0,
 		"ranged_hands": 0,
 		"ammo": 20,
 		"range": 16,
-		"spli": 9,
-		"arp": 1,
+		"spli": 28,
+		"arp": 0,
 		"tags": ["bolt", "heavy_ranged", "vehicle", "dreadnought"]
 	},
 	"Twin Linked Lascannon": {
 		"abbreviation": "TwnLascnn",
 		"attack": {
-			"standard": 600,
-			"master_crafted": 700,
-			"artifact": 900
+			"standard": 800,
+			"master_crafted": 900,
+			"artifact": 1000
 		},
 		"description": "The Twin-Linked Lascannons is a powerful anti-armour weapons that fire highly focused and devastating duel energy beams capable of penetrating even the toughest armor.",
 		"melee_hands": 0,
@@ -1030,24 +1098,24 @@ global.weapons = {
 	"Heavy Bolter": {
 		"abbreviation": "HvyBltr",
 		"attack": {
-			"standard": 320,
-			"master_crafted": 352,
-			"artifact": 384
+			"standard": 300,
+			"master_crafted": 350,
+			"artifact": 390
 		},
 		"description": "The Heavy Bolter is a heavy weapon that fires larger and more powerful bolt shells compared to the standard Bolter.",
 		"melee_hands": 1,
 		"ranged_hands": 2,
 		"ammo": 10,
-		"range": 16,
-		"spli": 6,
-		"arp": 1,
+		"range": 14,
+		"spli": 12,
+		"arp": 0,
 		"tags": ["heavy_ranged", "bolt"]
 	},
 	"Whirlwind Missiles": {
 		"attack": {
-			"standard": 400,
-			"master_crafted": 440,
-			"artifact": 480
+			"standard": 600,
+			"master_crafted": 650,
+			"artifact": 800
 		},
 		"description": "The Whirlwind Missile Launcher is a vehicle-mounted artillery weapon that launches a barrage of powerful missiles at the enemy.",
 		"abbreviation": "WhrlMssl",
@@ -1055,8 +1123,8 @@ global.weapons = {
 		"ranged_hands": 0,
 		"ammo": 6,
 		"range": 20,
-		"spli": 25,
-		"arp": 1,
+		"spli": 40,
+		"arp": -1,
 		"tags": ["vehicle","heavy_ranged", "indirect"]
 	},
 	"HK Missile": {
@@ -1066,9 +1134,9 @@ global.weapons = {
 	},
 	"Twin Linked Heavy Bolter Mount": {
 		"attack": {
-			"standard": 240,
-			"master_crafted": 264,
-			"artifact": 288
+			"standard": 450,
+			"master_crafted": 550,
+			"artifact": 700
 		},
 		"description": "The Twin-linked Heavy Bolters are an upgraded version of the standard Heavy Bolter weapon. They are mounted onto vehicles to create effective fire support platforms.",
 		"abbreviation": "TwnHvyBltr",
@@ -1076,15 +1144,15 @@ global.weapons = {
 		"ranged_hands": 0,
 		"ammo": 20,
 		"range": 16,
-		"spli": 3,
-		"arp": 1,
+		"spli": 21,
+		"arp": 0,
 		"tags": ["vehicle", "dreadnought", "heavy_ranged", "bolt"]
 	},
 	"Twin Linked Lascannon Mount": {
 		"attack": {
-			"standard": 250,
-			"master_crafted": 275,
-			"artifact": 300
+			"standard": 800,
+			"master_crafted": 900,
+			"artifact": 1000
 		},
 		"description": "The Twin-Lascannons are powerful anti-armour weapons that fire highly focused and devastating energy beams capable of penetrating even the toughest armour. This version is mounted onto vehicles to incease anti-armor capabilities.",
 		"abbreviation": "TwnLascnn",
@@ -1092,15 +1160,15 @@ global.weapons = {
 		"ranged_hands": 0,
 		"ammo": 10,
 		"range": 20,
-		"spli": 3,
+		"spli": 2,
 		"arp": 1,
 		"tags": ["las", "energy", "vehicle", "heavy_ranged", "dreadnought"]
 	},
 	"Twin Linked Assault Cannon Mount": {
 		"attack": {
-			"standard": 240,
-			"master_crafted": 264,
-			"artifact": 288
+			"standard": 800,
+			"master_crafted": 900,
+			"artifact": 1100
 		},
 		"description": "A twin mount of rotary autocannons, boasting an incredible rate of fire numbering in the hundreds of shots fired per second.",
 		"abbreviation": "TwnAssCnn",
@@ -1108,15 +1176,15 @@ global.weapons = {
 		"ranged_hands": 0,
 		"ammo": 6,
 		"range": 12,
-		"spli": 30,
-		"arp": 1,
+		"spli": 40,
+		"arp": 0,
 		"tags": ["vehicle","heavy_ranged", "pintle", "dreadnought"]
 	},
 	"Reaper Autocannon Mount": {
 		"attack": {
-			"standard": 500,
-			"master_crafted": 550,
-			"artifact": 600
+			"standard": 700,
+			"master_crafted": 850,
+			"artifact": 1000
 		},
 		"description": "An archaic twin-linked autocannon design dating back to the Great Crusade. The Reaper Autocannon is effective against infantry and armored targets. This version is mounted onto vehicles.",
 		"abbreviation": "RprAtcnn",
@@ -1124,15 +1192,15 @@ global.weapons = {
 		"ranged_hands": 0,
 		"ammo": 25,
 		"range": 15,
-		"spli": 6,
-		"arp": 1,
+		"spli": 24,
+		"arp": -1,
 		"tags": ["vehicle","heavy_ranged", "pintle"]
 	},
 	"Quad Linked Heavy Bolter Sponsons": {
 		"attack": {
-			"standard": 320,
-			"master_crafted": 352,
-			"artifact": 384
+			"standard": 800,
+			"master_crafted": 900,
+			"artifact": 1100
 		},
 		"description": "Quad-linked Heavy Bolters are a significantly upgraded version of the standard Heavy Bolter mount; already punishing in a single mount, this quad mount is devastating against a variety of targets.",
 		"abbreviation": "QdHvyBltrs",
@@ -1140,15 +1208,15 @@ global.weapons = {
 		"ranged_hands": 0,
 		"ammo": 15,
 		"range": 16,
-		"spli": 5,
-		"arp": 1,
+		"spli": 50,
+		"arp": 0,
 		"tags": ["bolt","heavy_ranged", "vehicle", "sponson"]
 	},
 	"Twin Linked Lascannon Sponsons": {
 		"attack": {
-			"standard": 600,
-			"master_crafted": 700,
-			"artifact": 900
+			"standard": 800,
+			"master_crafted": 1000,
+			"artifact": 1200
 		},
 		"description": "The Twin-Linked Lascannons are powerful anti-armour weapons that fire highly focused and devastating energy beams capable of penetrating even the toughest armour. This version is mounted onto the sides of vehicles.",
 		"abbreviation": "TwnLascnns",
@@ -1156,15 +1224,15 @@ global.weapons = {
 		"ranged_hands": 0,
 		"ammo": 5,
 		"range": 20,
-		"spli": 3,
+		"spli": 4,
 		"arp": 1,
 		"tags": ["las", "energy", "vehicle", "heavy_ranged", "sponson", "twin_linked"]
 	},
 	"Lascannon Sponsons": {
 		"attack": {
-			"standard": 500,
-			"master_crafted": 600,
-			"artifact": 750
+			"standard": 700,
+			"master_crafted": 850,
+			"artifact": 1000
 		},
 		"description": "Lascannons are powerful anti-armour weapons that fire highly focused and devastating energy beams capable of penetrating even the toughest armour. This version is mounted onto the sides of vehicles.",
 		"abbreviation": "Lscnns",
@@ -1172,15 +1240,15 @@ global.weapons = {
 		"ranged_hands": 0,
 		"ammo": 8,
 		"range": 20,
-		"spli": 1,
+		"spli": 2,
 		"arp": 1,
 		"tags": ["las", "energy","heavy_ranged", "vehicle", "sponson"]
 	},
 	"Hurricane Bolter Sponsons": {
 		"attack": {
-			"standard": 50,
-			"master_crafted": 55,
-			"artifact": 60
+			"standard": 600,
+			"master_crafted": 700,
+			"artifact": 800
 		},
 		"description": "Hurricane Bolters are large hex-mount bolter arrays that are able to deliver a withering hail of anti-infantry fire at short ranges. This version is mounted onto the sides of vehicles.",
 		"abbreviation": "HrcBltrs",
@@ -1194,100 +1262,100 @@ global.weapons = {
 	},
 	"Flamestorm Cannon Sponsons": {
 		"attack": {
-			"standard": 600,
-			"master_crafted": 660,
-			"artifact": 720
+			"standard": 750,
+			"master_crafted": 850,
+			"artifact": 900
 		},
 		"description": "A huge vehicle-mounted flamethrower cannon, the heat produced by this terrifying weapon can melt armoured ceramite.",
 		"abbreviation": "FlmstCnns",
 		"melee_hands": 0,
 		"ranged_hands": 0,
 		"ammo": 6,
-		"range": 2,
-		"spli": 3,
-		"arp": 1,
+		"range": 4.1,
+		"spli": 30,
+		"arp": -2,
 		"tags": ["flame","heavy_ranged", "vehicle", "sponson"]
 	},
 	"Twin Linked Heavy Flamer Sponsons": {
 		"attack": {
-			"standard": 500,
-			"master_crafted": 550,
-			"artifact": 600
+			"standard": 600,
+			"master_crafted": 750,
+			"artifact": 900
 		},
 		"description": "A twin-linked significantly heavier flamer attached to the sponsons on a vehicle.",
 		"abbreviation": "TwnHvyFlmrs",
 		"melee_hands": 0,
 		"ranged_hands": 0,
 		"ammo": 8,
-		"range": 2.1,
-		"spli": 8,
+		"range": 4.1,
+		"spli": 40,
 		"arp": -1,
 		"tags": ["flame","heavy_ranged", "vehicle", "dreadnought", "sponson"]
 	},
 	"Twin Linked Bolters": {
 		"attack": {
-			"standard": 80,
-			"master_crafted": 140,
-			"artifact": 180
+			"standard": 225,
+			"master_crafted": 350,
+			"artifact": 450
 		},
 		"description": "A Twin-linked Bolter consists of two Bolter weapons mounted side by side, typically on a vehicle or a dedicated weapons platform.",
 		"abbreviation": "TwnBltrs",
 		"melee_hands": 1,
 		"ranged_hands": 2,
 		"ammo": 30,
-		"range": 12,
-		"spli": 6,
+		"range": 10,
+		"spli": 10,
 		"arp": 0,
 		"tags": ["bolt", "vehicle"]
 	},
 	"Twin Linked Multi-Melta Sponsons": {
 		"abbreviation": "TwnMltMelts",
 		"attack": {
-			"standard": 800,
-			"master_crafted": 850,
-			"artifact": 900
+			"standard": 1200,
+			"master_crafted": 1400,
+			"artifact": 1650
 		},
 		"description": "Though bearing longer range than the Meltagun, this weapon's great size usually restricts it to vehicles. In this case it is mounted to the sponsons on a vehicle.",
 		"melee_hands": 0,
 		"ranged_hands": 0,
 		"ammo": 8,
 		"range": 4.1,
-		"spli": 2,
-		"arp": 1,
+		"spli": 20,
+		"arp": -2,
 		"tags": ["vehicle","heavy_ranged", "Sponson", "melta"],
 		"maintenance" : 0.05,
 	},
 	"Twin Linked Volkite Culverin Sponsons": {
 		"abbreviation": "TwnVlkCulvs",
 		"attack": {
-			"standard": 480,
-			"master_crafted": 510,
-			"artifact": 540
+			"standard": 950,
+			"master_crafted": 1150,
+			"artifact": 1300
 		},
 		"description": "An advanced thermal weapon from a bygone era, Volkite Culverins are able to ignite entire formations of enemy forces. In this case it is mounted to the sponsons on a vehicle.",
 		"melee_hands": 0,
 		"ranged_hands": 0,
 		"ammo": 25,
 		"range": 18,
-		"spli": 9,
-		"arp": 0,
+		"spli": 12,
+		"arp": -2,
 		"tags": ["vehicle","heavy_ranged", "Sponson", "volkite", "ancient"]
 	},
 	"Heavy Bolter Sponsons": {
 		"abbreviation": "HvyBltrs",
 		"attack": {
-			"standard": 240,
-			"master_crafted": 264,
-			"artifact": 288
+			"standard": 450,
+			"master_crafted": 550,
+			"artifact": 750
 		},
 		"description": "Heavy Bolters are mounted in sponsons. They are known for high rates of fire and effectiveness against infantry and light vehicles.",
 		"melee_hands": 0,
 		"ranged_hands": 0,
 		"ammo": 20,
-		"range": 16,
-		"spli": 4,
-		"arp": 1,
-		"tags": ["heavy_ranged", "vehicle", "sponson", "bolt"],
+		"range": 14,
+		"spli": 28,
+		"arp": 0,
+		"tags": ["heavy_ranged", "vehicle", "sponson", "bolt"]
 	},
 	"Heavy Flamer Sponsons": {
 		"abbreviation": "HvyFlmrs",
@@ -1301,8 +1369,8 @@ global.weapons = {
 		"melee_hands": 0,
 		"ranged_hands": 0,
 		"ammo": 8,
-		"range": 2.1,
-		"spli": 4,
+		"range": 4.1,
+		"spli": 40,
 		"arp": -1,
 		"tags": ["flame","heavy_ranged", "vehicle", "sponson"],
 		"maintenance" : 0.05,
@@ -1311,66 +1379,67 @@ global.weapons = {
 		"abbreviation": "VlkClvs",
 		"attack": {
 			"standard": 480,
-			"master_crafted": 528,
-			"artifact": 576
+			"master_crafted": 600,
+			"artifact": 750
 		},
 		"description": "An advanced thermal weapon from a bygone era, Volkite Culverins are able to ignite entire formations of enemy forces. In this case it is mounted to the sponsons on a vehicle.",
 		"melee_hands": 0,
 		"ranged_hands": 0,
 		"ammo": 25,
 		"range": 18,
-		"spli": 5,
-		"arp": 1,
+		"spli": 6,
+		"arp": -2,
 		"tags": ["vehicle","heavy_ranged", "Sponson", "volkite", "ancient"]
 	},
 	"Autocannon Turret": {
 		"abbreviation": "Autocnn",
 		"attack": {
-			"standard": 380,
-			"master_crafted": 528,
-			"artifact": 576
+			"standard": 600,
+			"master_crafted": 700,
+			"artifact": 850
 		},
 		"description": "A Predator-compatible turret mounting a reliable all-purpose autocannon capable of doing effective damage to infantry and lightly armored targets.",
 		"melee_hands": 0,
 		"ranged_hands": 0,
-		"ammo": 25,
+		"ammo": 18,
 		"range": 18,
 		"spli": 15,
-		"arp": 0,
+		"arp": -1,
 		"tags": ["vehicle","heavy_ranged", "turret"]
 	},
 	"Storm Bolter": {
 		"abbreviation": "StrmBltr",
 		"attack": {
-			"standard": 80,
-			"master_crafted": 88,
-			"artifact": 96
+			"standard": 275,
+			"master_crafted": 300,
+			"artifact": 350
 		},
 		"description": "Compact and double-barreled, this bolt weapon is inaccurate but grants an enormous amount of firepower. Its psychological effect on the enemy should not be understated.",
-		"melee_hands": 1.1,
-		"ranged_hands": 1.1,
+		"melee_hands": 1,
+		"ranged_hands": 2,
 		"ammo": 10,
-		"range": 10,
-		"spli": 6,
+		"range": 8,
+		"spli": 8,
 		"arp": 0,
-		"tags": ["bolt"],
-		"maintenance" : 0.03,
+    "maintenance" : 0.03,
+		"tags": ["bolt", "boarding 2"]
+
 	},
 	"Hand Flamer": {
 		"abbreviation": "HndFlmr",
 		"attack": {
-			"standard": 125,
-			"master_crafted": 190,
-			"artifact": 210
+			"standard": 250,
+			"master_crafted": 275,
+			"artifact": 350
 		},
 		"description": "Along with using a lower-capacity fuel tank it has much reduced range, which makes it suited for assault and close-combat purposes, incinerating foes at short range. The weapon is often used by assault squads.",
 		"melee_hands": 0,
 		"ranged_hands": 1,
-		"ammo": 2,
-		"range": 1.1,
-		"spli": 2,
-		"arp": -1,
-		"tags": ["pistol", "flame"]
+		"ammo": 4,
+		"range": 2.1,
+		"spli": 8,
+		"arp": 0,
+		"tags": ["pistol", "flame", "boarding 2"]
 	},
 	"Flamer": {
 		"abbreviation": "Flmr",
@@ -1387,118 +1456,118 @@ global.weapons = {
 		"description": "Blackened at the tip, this weapon unleashes a torrent of burning promethium - all the better to cleanse sin and impurity with.",
 		"melee_hands": 1,
 		"ranged_hands": 2,
-		"ammo": 4,
-		"range": 2.1,
-		"spli": 4,
-		"arp": -1,
-		"tags": ["flame"],
-		"maintenance" : 0.01,
+		"ammo": 8,
+		"range": 4.1,
+		"spli": 14,
+		"arp": 0,
+    "maintenance" : 0.01,
+		"tags": ["flame", "boarding 2"]
 	},
-	"Underslung Flamer": {
+	"Integrated-Flamer": {
 		"attack": {
-			"standard": 200,
-			"master_crafted": 220,
-			"artifact": 240
+			"standard": 350,
+			"master_crafted": 385,
+			"artifact": 420
 		},
 		"description": "",
-		"abbreviation": "UndrFlmr",
+		"abbreviation": "IntFlmr",
 		"melee_hands": 0,
 		"ranged_hands": 0,
 		"ammo": 4,
-		"range": 2.1,
+		"range": 4.1,
 		"spli": 3,
-		"arp": -1,
+		"arp": 0,
 		"tags": ["flame", "attached"]
 	},
 	"Combiflamer": {
 		"abbreviation": "CmbFlmr",
 		"attack": {
-			"standard": 100,
-			"master_crafted": 130,
-			"artifact": 160
+			"standard": 150,
+			"master_crafted": 175,
+			"artifact": 200
 		},
 		"description": "A standard Bolter with an underbarrel Flamer for expanded tactical utility.",
 		"melee_hands": 1,
 		"ranged_hands": 2,
 		"ammo": 15,
 		"range": 10,
-		"spli": 3,
+		"spli": 5,
 		"arp": 0,
-		"second_profiles": ["Flamer"],
-		"tags": ["combi", "bolt"]
+		"second_profiles": ["Integrated-Flamer"],
+		"tags": ["combi", "bolt", "boarding 2"]
 	},
 	"Combiplasma": {
 		"abbreviation": "CmbPlsm",
 		"attack": {
-			"standard": 100,
-			"master_crafted": 130,
-			"artifact": 160
+			"standard": 150,
+			"master_crafted": 175,
+			"artifact": 200
 		},
 		"description": "A standard Bolter with an underbarrel Plasma Gun for expanded tactical utility.",
 		"melee_hands": 1,
 		"ranged_hands": 2,
-		"ammo": 15,
+		"ammo": 8,
 		"range": 10,
-		"spli": 3,
+		"spli": 5,
 		"arp": 0,
-		"second_profiles": ["Plasma Gun"],
+		"second_profiles": ["Integrated-Plasma"],
 		"tags": ["combi", "bolt"]
 	},
 	"Combigrav": {
 		"abbreviation": "CmbGrv",
 		"attack": {
-			"standard": 100,
-			"master_crafted": 130,
-			"artifact": 160
+			"standard": 150,
+			"master_crafted": 175,
+			"artifact": 200
 		},
 		"description": "A standard Bolter with an underbarrel Grav-Gun for expanded tactical utility.",
 		"melee_hands": 1,
 		"ranged_hands": 2,
-		"ammo": 15,
+		"ammo": 8,
 		"range": 10,
-		"spli": 3,
+		"spli": 5,
 		"arp": 0,
-		"second_profiles": ["Grav-Gun"],
+		"second_profiles": ["Integrated-Grav"],
 		"tags": ["combi", "bolt"]
 	},
 	"Combimelta": {
 		"abbreviation": "CmbMlt",
 		"attack": {
-			"standard": 100,
-			"master_crafted": 130,
-			"artifact": 160
+			"standard": 150,
+			"master_crafted": 175,
+			"artifact": 200
 		},
 		"description": "A standard Bolter with an underbarrel Meltagun for expanded tactical utility.",
 		"melee_hands": 1,
 		"ranged_hands": 2,
-		"ammo": 15,
+		"ammo": 8,
 		"range": 10,
-		"spli": 3,
+		"spli": 5,
 		"arp": 0,
-		"second_profiles": ["Meltagun"],
-		"tags": ["combi", "bolt"]
+		"second_profiles": ["Integrated-Melta"],
+		"tags": ["combi", "bolt", "boarding 3"]
 	},
 	"Incinerator": {
 		"attack": {
-			"standard": 200,
-			"master_crafted": 220,
-			"artifact": 240
+			"standard": 500,
+			"master_crafted": 550,
+			"artifact": 600
 		},
 		"description": "This flamer weapon utilizes psychically-charged promethium and blessed oils concoction to create an azure flame that bypasses psychich protections. It is particularly effective against Daemons and their ilk.",
 		"abbreviation": "Incnrtr",
 		"melee_hands": 1,
 		"ranged_hands": 1,
 		"ammo": 4,
-		"range": 2.1,
-		"spli": 3,
+		"range": 4.1,
+		"spli": 20,
 		"arp": -1,
-		"tags": ["flame"]
+		"tags": ["flame","boarding 3"]
 	},
 	"Force Staff": {
 		"attack": {
-			"standard": 200,
-			"master_crafted": 230,
-			"artifact": 270
+			"standard": 225,
+			"master_crafted": 270,
+			"artifact": 350
 		},
 		"melee_mod": {
 			"standard": 1,
@@ -1511,101 +1580,101 @@ global.weapons = {
 		"ranged_hands": 1,
 		"range": 1,
 		"spli": 5,
-		"arp": 1,
+		"arp": -1,
 		"special_description": "Spell Damage +100%",
-		"tags": ["force" ],
-		"maintenance" : 0.1,
+"maintenance" : 0.1,
+		"tags": ["force"]
 	},
 	"Force Sword": {
-		"abbreviation": "FrcSwrd",
 		"attack": {
-			"standard": 180,
-			"master_crafted": 200,
-			"artifact": 240
+			"standard": 225,
+			"master_crafted": 270,
+			"artifact": 350
 		},
 		"melee_mod": {
 			"standard": 1,
 			"master_crafted": 1.1,
 			"artifact": 1.2
 		},
+		"abbreviation": "FrcSwrd",
 		"description": "The Force Sword is a psychically-attuned close combat weapon that is only fully effective in the hands of a psyker.",
 		"melee_hands": 1,
 		"ranged_hands": 0,
 		"ammo": 0,
 		"range": 1,
 		"spli": 4,
-		"arp": 1,
+		"arp": -1,
 		"special_description": "Spell damage +25%",
 		"special_properties": ["Parry"],
-		"tags": ["force", "sword"],
-		"maintenance" : 0.1,
+    "maintenance" : 0.1,
+		"tags": ["force", "sword", "martial", "boarding 1"],
 	},
 	"Force Axe": {
-		"abbreviation": "FrcAxe",
 		"attack": {
-			"standard": 190,
-			"master_crafted": 220,
-			"artifact": 260
+			"standard": 200,
+			"master_crafted": 250,
+			"artifact": 350
 		},
 		"melee_mod": {
 			"standard": 1,
 			"master_crafted": 1.1,
 			"artifact": 1.2
 		},
+		"abbreviation": "FrcAxe",
 		"description": "The Force Axe is a psychically-attuned close combat weapon that is only fully effective in the hands of a psyker.",
 		"melee_hands": 1,
 		"ranged_hands": 0,
 		"ammo": 0,
 		"range": 1,
 		"spli": 5,
-		"arp": 1,
+		"arp": -1,
 		"special_description": "Able to be dual-wielded, Spell damage +25%",
-		"tags": ["force", "axe", "dual"],
+		"tags": ["force", "axe", "dual", "savage", "boarding 2"],
 	},
 	"Twin Linked Lascannon Turret": {
 		"attack": {
-			"standard": 600,
-			"master_crafted": 700,
-			"artifact": 900
+			"standard": 1000,
+			"master_crafted": 1100,
+			"artifact": 1300
 		},
 		"abbreviation": "TwnLscnn",
 		"description": "A Predator-compatible turret mounting a twin-linked lascannon.",
 		"arp": 1,
 		"range": 24,
 		"ammo": 5,
-		"spli": 2,
+		"spli": 1,
 		"tags": ["las", "energy", "twin_linked","heavy_ranged", "vehicle", "turret"]
 	},
 	"Twin Linked Assault Cannon Turret": {
 		"abbreviation": "TwnAssCnn",
 		"attack": {
-			"standard": 240,
-			"master_crafted": 264,
-			"artifact": 288
+			"standard": 800,
+			"master_crafted": 900,
+			"artifact": 1100
 		},
 		"description": "A heavy rotary autocannon with a devastating fire rate that can be counted in the hundreds per minute, in a twin mount. It is incredibly effective against infantry and lightly armored targets.",
 		"melee_hands": 2.1,
 		"ranged_hands": 2.25,
 		"ammo": 5,
 		"range": 12,
-		"spli": 30,
-		"arp": 1,
+		"spli": 40,
+		"arp": 0,
 		"tags": ["heavy_ranged", "twin_linked", "vehicle", "turret"]
 	},
 	"Flamestorm Cannon Turret": {
 		"abbreviation": "FlmstCnn",
 		"attack": {
-			"standard": 600,
-			"master_crafted": 660,
-			"artifact": 720
+			"standard": 700,
+			"master_crafted": 850,
+			"artifact": 900
 		},
 		"description": "A huge vehicle-mounted flamethrower cannon, the heat produced by this terrifying weapon can melt armoured ceramite.",
 		"melee_hands": 0,
 		"ranged_hands": 0,
 		"ammo": 12,
-		"range": 2,
-		"spli": 3,
-		"arp": 1,
+		"range": 4.1,
+		"spli": 25,
+		"arp": -2,
 		"tags": ["flame","heavy_ranged", "vehicle", "turret"]
 	},
 	"Magna-Melta Turret": {
@@ -1619,25 +1688,25 @@ global.weapons = {
 		"melee_hands": 0,
 		"ranged_hands": 0,
 		"ammo": 6,
-		"range": 5.1,
-		"spli": 2,
-		"arp": 1,
+		"range": 4.1,
+		"spli": 20,
+		"arp": -2,
 		"tags": ["vehicle","heavy_ranged", "turret", "melta"]
 	},
 	"Plasma Destroyer Turret": {
 		"abbreviation": "PlsmDestr",
 		"attack": {
-			"standard": 500,
-			"master_crafted": 600,
-			"artifact": 750
+			"standard": 800,
+			"master_crafted": 900,
+			"artifact": 1000
 		},
 		"description": "A heavy variant of the plasma gun, its power output is significantly higher and its damage capability shows. However, it is mounted in a tank turret.",
 		"melee_hands": 1,
 		"ranged_hands": 3,
 		"ammo": 16,
 		"range": 14,
-		"spli": 3,
-		"arp": 1,
+		"spli": 12,
+		"arp": -2,
 		"tags": ["plasma", "energy","heavy_ranged", "vehicle", "turret"]
 	},
 	"Heavy Conversion Beam Projector": {
@@ -1675,9 +1744,9 @@ global.weapons = {
 	"Volkite Saker Turret": {
 		"abbreviation": "VlkSkr",
 		"attack": {
-			"standard": 300,
-			"master_crafted": 333,
-			"artifact": 375
+			"standard": 1000,
+			"master_crafted": 1150,
+			"artifact": 1400
 		},
 		"description": "An advanced thermal weapon from a bygone era, Volkite sakers are optimized for spreading damage across swaths of enemy troops.",
 		"melee_hands": 0,
@@ -1685,7 +1754,7 @@ global.weapons = {
 		"ammo": 25,
 		"range": 18,
 		"spli": 30,
-		"arp": 0,
+		"arp": -2,
 		"tags": ["vehicle","heavy_ranged", "turret", "volkite", "ancient"]
 	},
 // Hireling weapons
@@ -1817,7 +1886,7 @@ global.weapons = {
 		"ammo": 0,
 		"range": 1,
 		"spli": 3,
-		"arp": 1,
+		"arp": -1,
 		"special_properties": ["Parry"],
 		"tags": ["power", "sword", "elder", "xenos"],
 	},


### PR DESCRIPTION
This PR migrated from here https://github.com/EttyKitty/ChapterMaster/pull/163.

As per [original description](https://discord.com/channels/714022226810372107/1287564418506293358/1287564418506293358):
### Intent:
- Create a definite Hierarchy for weapons including tiers and classes to ensure player has meaningful armament choice and progression in the Armamentarium for his marine's equipment.

- Rebalance damage and max kill values in line with the established hierarchy and class system.

- Balance durability for all ground units so that chapters can tackle targets as less than a doom stack.

- Create descriptive guide documentation for each weapon class so as to guide future additions. (Half way done)

### Desired End-state

- Weapons are tangible choices with trade-offs that affect battle outcomes.

- Squad loadouts are more indicative of intended battlefield role (Tank hunters and Horde breakers).

### Noticeable changes
- Heavy Bolter is no longer AP.
- Missile Launcher is now -1 AP. (Low Penetration)
- Add "martial" and "savage" weapon tags to enable custom stat scaling for melee attacks.
- Rewrite the melee damage formula, to account for the new tags and be less extreme in general.
- Adds functionality to boarding 1-3 tagged weapons.

### Notes
A related PR: https://github.com/ZAB909/ChapterMaster/pull/315
A structured doc with all said rebalance changes:
https://docs.google.com/spreadsheets/d/1ZMPRXjmd3tWvFmWiIYb-nQ9qT5PYPiu_75SJNhcYqvg/edit?gid=1993273333#gid=1993273333

## Summary by Sourcery

New Features:
- Introduced "martial" and "savage" weapon tags to customize melee attack scaling.