### PR TITLE
refactor: Memory safe drawing of components

### DIFF
--- a/scripts/scr_complex_colour_kit/scr_complex_colour_kit.gml
+++ b/scripts/scr_complex_colour_kit/scr_complex_colour_kit.gml
@@ -238,7 +238,8 @@ function ColourItem(xx,yy) constructor{
             draw_sprite(spr_mk7_left_trim, 0 , xx, yy);
             draw_sprite(spr_mk7_right_trim, 0 , xx, yy);
             draw_sprite(spr_mk7_leg_variants, 1, xx, yy);
-            draw_sprite(spr_mk7_chest_variants, 1, xx, yy);           	
+            draw_sprite(spr_mk7_chest_variants, 1, xx, yy);
+            draw_sprite(spr_mk7_head_variants, 1, xx, yy);         	
             draw_sprite(spr_mk7_mouth_variants, 1, xx, yy);
             draw_sprite(spr_mk7_thorax_variants, 1, xx, yy);
             draw_sprite(spr_gothic_numbers_right_pauldron,4,xx, yy);

--- a/scripts/scr_draw_unit_image/scr_draw_unit_image.gml
+++ b/scripts/scr_draw_unit_image/scr_draw_unit_image.gml
@@ -40,18 +40,15 @@ enum eARMOUR_SET {
 function ComplexSet() constructor{
     static add_to_area = function(area, add_sprite){
         if (!struct_exists(self, area)){
-            self.replace_area(area, add_sprite);
+            self[$ area] = sprite_duplicate(add_sprite);
         } else {
             sprite_merge(self[$ area], add_sprite);
         }
     }
 
-    static replace_area = function(area, add_sprite){
-        self[$ area] = sprite_duplicate(add_sprite);
-    }
-
     static remove_area = function(area){
         if (struct_exists(self, area)){
+            sprite_delete(self[$area]);
             struct_remove(self, area);
         }
     }
@@ -137,7 +134,7 @@ function get_complex_set(set = eARMOUR_SET.MK7){
             right_arm : spr_mk3_right_arm ,   
             head : spr_mk3_head_variants, 
             left_leg : spr_mk3_left_leg_variants,
-            right_leg : spr_mk3_left_leg_variants           
+            right_leg : spr_mk3_right_leg_variants           
         });    
     }else if (set == eARMOUR_SET.MK8){
         set_pieces.add_group({
@@ -1160,15 +1157,15 @@ function scr_draw_unit_image(_background=false){
                     complex_set.remove_area("mouth_variants");
                     if (armour_type == ArmourType.Terminator) {
                         if (unit_specialization == UnitSpecialization.WolfPriest) {
-                            complex_set.replace_area("head",spr_chaplain_wolfterm_helm);
+                            complex_set.add_or_replace("head",spr_chaplain_wolfterm_helm);
                         } else {
-                            complex_set.replace_area("head",spr_chaplain_term_helm);
+                            complex_set.add_or_replace("head",spr_chaplain_term_helm);
                         }
                     } else {
                         if (unit_specialization == UnitSpecialization.WolfPriest) {
-                            complex_set.replace_area("head",spr_chaplain_wolf_helm);
+                            complex_set.add_or_replace("head",spr_chaplain_wolf_helm);
                         } else {
-                            complex_set.replace_area("head",spr_chaplain_helm); 
+                            complex_set.add_or_replace("head",spr_chaplain_helm); 
                         }
                     }
                 }

--- a/scripts/scr_draw_unit_image/scr_draw_unit_image.gml
+++ b/scripts/scr_draw_unit_image/scr_draw_unit_image.gml
@@ -46,6 +46,13 @@ function ComplexSet() constructor{
         }
     }
 
+    static replace_area = function(area, add_sprite){
+        if (struct_exists(self, area)){
+            sprite_delete(self[$area]);
+        }
+        self[$ area] = sprite_duplicate(add_sprite);
+    }
+
     static remove_area = function(area){
         if (struct_exists(self, area)){
             sprite_delete(self[$area]);
@@ -60,14 +67,8 @@ function ComplexSet() constructor{
             add_to_area(_area, group[$_area]);
         }
     }
-
-    static add_or_replace = function(area, add_sprite){
-        if (struct_exists(self, area)){
-            sprite_delete(self[$area]);
-        }
-        self[$ area] = sprite_duplicate(add_sprite);
-    }
 }
+
 function get_complex_set(set = eARMOUR_SET.MK7){
     var set_pieces = new ComplexSet();
 
@@ -1157,15 +1158,15 @@ function scr_draw_unit_image(_background=false){
                     complex_set.remove_area("mouth_variants");
                     if (armour_type == ArmourType.Terminator) {
                         if (unit_specialization == UnitSpecialization.WolfPriest) {
-                            complex_set.add_or_replace("head",spr_chaplain_wolfterm_helm);
+                            complex_set.replace_area("head",spr_chaplain_wolfterm_helm);
                         } else {
-                            complex_set.add_or_replace("head",spr_chaplain_term_helm);
+                            complex_set.replace_area("head",spr_chaplain_term_helm);
                         }
                     } else {
                         if (unit_specialization == UnitSpecialization.WolfPriest) {
-                            complex_set.add_or_replace("head",spr_chaplain_wolf_helm);
+                            complex_set.replace_area("head",spr_chaplain_wolf_helm);
                         } else {
-                            complex_set.add_or_replace("head",spr_chaplain_helm); 
+                            complex_set.replace_area("head",spr_chaplain_helm); 
                         }
                     }
                 }
@@ -1274,12 +1275,12 @@ function scr_draw_unit_image(_background=false){
                 draw_unit_arms(x_surface_offset, y_surface_offset, armour_type, specialist_colours, hide_bionics, complex_set);
                 if (armour_type==ArmourType.Normal && complex_livery){
                     if (struct_exists(body[$ "right_leg"], "bionic")) {
-                        complex_set.add_or_replace("right_leg",spr_bionic_leg_right);
+                        complex_set.replace_area("right_leg",spr_bionic_leg_right);
                     }
                 }
                 if (armour_type==ArmourType.Normal && complex_livery){
                     if (struct_exists(body[$ "left_leg"], "bionic")) {
-                        complex_set.add_or_replace("left_leg",spr_bionic_leg_left);
+                        complex_set.replace_area("left_leg",spr_bionic_leg_left);
                     }
                 }                
                 // Draw torso


### PR DESCRIPTION
## Description of changes
- make sure temporary sprites are explicitly deleted when drawing components
- fix missing head on creation screen complex sprite
## Reasons for changes
- previous component replacement method would leave sprites in memory and cause memory leaks @EttyKitty  merged your method and mine to hopefully make safe method, feel free to change method names though
## Related links
-
## How have you tested your changes?
- [x] Compile
- [x] New game
- [ ] Next turn
- [ ] Space Travel
- [ ] Ground Battle

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->
