### PR TITLE
fix: Change error handling of NameGenerator

### DIFF
--- a/scripts/NameGenerator/NameGenerator.gml
+++ b/scripts/NameGenerator/NameGenerator.gml
@@ -1,80 +1,80 @@
 function NameGenerator() constructor {
-	try {
-		// TODO after save rework is finished, check if these static can be converted to instance versions
-		static LoadSimpleNames = function(file_name, fallback_value, json_names_property_name = "names") {
-			if (json_names_property_name == noone) {
-				json_names_property_name = "names";
-			}
+	// TODO after save rework is finished, check if these static can be converted to instance versions
+	static LoadSimpleNames = function(file_name, fallback_value, json_names_property_name = "names") {
+		if (json_names_property_name == noone) {
+			json_names_property_name = "names";
+		}
 
-			var file_loader = new JsonFileListLoader();
+		var file_loader = new JsonFileListLoader();
 
-			var load_result = file_loader.load_list_from_json_file($"main\\names\\{file_name}.json", [json_names_property_name]);
+		var load_result = file_loader.load_list_from_json_file($"main\\names\\{file_name}.json", [json_names_property_name]);
 
+		if (load_result.is_success) {
+			return load_result.values[$ json_names_property_name];
+		}
+
+		return [fallback_value];
+	};
+
+	static LoadCompositeNames = function(file_name, json_names_property_names = ["prefixes", "suffixes", "special"]) {
+		if (json_names_property_names == noone) {
+			json_names_property_names = ["prefixes", "suffixes", "special"];
+		}
+
+		var file_loader = new JsonFileListLoader();
+
+		var load_result = file_loader.load_list_from_json_file($"main\\names\\{file_name}.json", json_names_property_names);
+
+		var result = {};
+
+		for (var i = 0; i < array_length(json_names_property_names); i++) {
 			if (load_result.is_success) {
-				return load_result.values[$ json_names_property_name];
+				result[$ json_names_property_names[i]] = load_result.values[$ json_names_property_names[i]];
+			} else {
+				result[$ json_names_property_names[i]] = array_create(1, $"{json_names_property_names[i]} 1");
 			}
+		}
 
-			return [fallback_value];
-		};
+		return result;
+	};
 
-		static LoadCompositeNames = function(file_name, json_names_property_names = ["prefixes", "suffixes", "special"]) {
-			if (json_names_property_names == noone) {
-				json_names_property_names = ["prefixes", "suffixes", "special"];
-			}
+	// vars // TODO put these into a struct or dict or something
+	static sector_names = LoadSimpleNames("sector", "Sector 1");
+	static sector_used_names = [];
 
-			var file_loader = new JsonFileListLoader();
+	static star_names = LoadSimpleNames("star", "Star 1");
+	static star_used_names = [];
+	static star_names_generic_counter = 0; // TODO once we migrate Star data to proper structs and jsons, this can probably be removed
 
-			var load_result = file_loader.load_list_from_json_file($"main\\names\\{file_name}.json", json_names_property_names);
+	static space_marines_names = LoadSimpleNames("space_marine", "Space Marine 1");
+	static space_marines_used_names = [];
 
-			var result = {};
+	static imperial_names = LoadSimpleNames("imperial", "Imperial 1");
+	static imperial_used_names = [];
 
-			for (var i = 0; i < array_length(json_names_property_names); i++) {
-				if (load_result.is_success) {
-					result[$ json_names_property_names[i]] = load_result.values[$ json_names_property_names[i]];
-				} else {
-					result[$ json_names_property_names[i]] = array_create(1, $"{json_names_property_names[i]} 1");
-				}
-			}
+	static chaos_names = LoadSimpleNames("chaos", "Chaos 1");
+	static chaos_used_names = [];
 
-			return result;
-		};
+	static eldar_syllables = LoadCompositeNames("eldar", ["first_syllables", "second_syllables", "third_syllables"]);
 
-		// vars // TODO put these into a struct or dict or something
-		static sector_names = LoadSimpleNames("sector", "Sector 1");
-		static sector_used_names = [];
+	static ork_name_composites = LoadCompositeNames("ork", ["prefixes", "suffixes", "special"]);
 
-		static star_names = LoadSimpleNames("star", "Star 1");
-		static star_used_names = [];
-		static star_names_generic_counter = 0; // TODO once we migrate Star data to proper structs and jsons, this can probably be removed
+	static imperial_ship_names = LoadSimpleNames("imperial_ship", "Imperial Ship 1");
+	static imperial_ship_used_names = [];
 
-		static space_marines_names = LoadSimpleNames("space_marine", "Space Marine 1");
-		static space_marines_used_names = [];
+	static ork_ship_names = LoadSimpleNames("ork_ship", "Ork Ship 1");
+	static ork_ship_used_names = [];
 
-		static imperial_names = LoadSimpleNames("imperial", "Imperial 1");
-		static imperial_used_names = [];
+	static hulk_name_composites = LoadCompositeNames("hulk", ["prefixes", "suffixes"]);
 
-		static chaos_names = LoadSimpleNames("chaos", "Chaos 1");
-		static chaos_used_names = [];
+	static tau_name_composites = LoadCompositeNames("tau", ["prefixes", "suffixes"]);
 
-		static eldar_syllables = LoadCompositeNames("eldar", ["first_syllables", "second_syllables", "third_syllables"]);
+	static genestealer_cult_names = LoadCompositeNames("genestealercult", ["main", "embelishment", "title"]);
 
-		static ork_name_composites = LoadCompositeNames("ork", ["prefixes", "suffixes", "special"]);
+	// init
 
-		static imperial_ship_names = LoadSimpleNames("imperial_ship", "Imperial Ship 1");
-		static imperial_ship_used_names = [];
-
-		static ork_ship_names = LoadSimpleNames("ork_ship", "Ork Ship 1");
-		static ork_ship_used_names = [];
-
-		static hulk_name_composites = LoadCompositeNames("hulk", ["prefixes", "suffixes"]);
-
-		static tau_name_composites = LoadCompositeNames("tau", ["prefixes", "suffixes"]);
-
-		static genestealer_cult_names = LoadCompositeNames("genestealercult", ["main", "embelishment", "title"]);
-
-		// init
-
-		static SimpleNameGeneration = function(names, used_names, entity_name, reset_on_using_up_all_names = true) {
+	static SimpleNameGeneration = function(names, used_names, entity_name, reset_on_using_up_all_names = true) {
+		try {
 			if (array_length(names) == 0) {
 				var used_names_length = array_length(used_names);
 				if (reset_on_using_up_all_names) {
@@ -91,9 +91,14 @@ function NameGenerator() constructor {
 			var name = array_pop(names);
 			array_push(used_names, name);
 			return name;
-		};
+		} catch (_exception) {
+			handle_exception(_exception);
+			return "name_error";
+		}
+	};
 
-		static MultiSyllableNameGeneration = function(syllables, syllable_amount) {
+	static MultiSyllableNameGeneration = function(syllables, syllable_amount) {
+		try {
 			var random_first_syllable_list = syllables.first_syllables[irandom(array_length(syllables.first_syllables) - 1)];
 			var name = random_first_syllable_list[irandom(array_length(random_first_syllable_list) - 1)];
 
@@ -108,9 +113,14 @@ function NameGenerator() constructor {
 			}
 
 			return name;
-		};
+		} catch (_exception) {
+			handle_exception(_exception);
+			return "name_error";
+		}
+	};
 
-		static ComplexTitledName = function(mains, embelishments, titles) {
+	static ComplexTitledName = function(mains, embelishments, titles) {
+		try {
 			var require_embelishments = choose(true, false);
 			var require_titles = choose(true, false);
 			var name = array_random_element(array_random_element(mains));
@@ -121,9 +131,14 @@ function NameGenerator() constructor {
 				name += " " + array_random_element(array_random_element(titles));
 			}
 			return name;
-		};
+		} catch (_exception) {
+			handle_exception(_exception);
+			return "name_error";
+		}
+	};
 
-		static CompositeNameGeneration = function(composite_names, separate_components) {
+	static CompositeNameGeneration = function(composite_names, separate_components) {
+		try {
 			if (struct_exists(composite_names, "special") && is_array(composite_names.special) && array_length(composite_names.special) > 0) {
 				var use_special_name = irandom(200);
 				if (use_special_name == 0) {
@@ -143,71 +158,72 @@ function NameGenerator() constructor {
 			}
 
 			return $"{composite_one}{separator}{composite_two}";
-		};
+		} catch (_exception) {
+			handle_exception(_exception);
+			return "name_error";
+		}
+	};
 
-		// Functions
-		// TODO rework these functions to be more generic, parameterized, e.g. generate_character_name(eFACTION.Imperial) etc.
-		static generate_sector_name = function() {
-			return SimpleNameGeneration(sector_names, sector_used_names, "Sector");
-		};
+	// Functions
+	// TODO rework these functions to be more generic, parameterized, e.g. generate_character_name(eFACTION.Imperial) etc.
+	static generate_sector_name = function() {
+		return SimpleNameGeneration(sector_names, sector_used_names, "Sector");
+	};
 
-		static generate_star_name = function() {
-			return SimpleNameGeneration(star_names, star_used_names, "Star", false);
-		};
+	static generate_star_name = function() {
+		return SimpleNameGeneration(star_names, star_used_names, "Star", false);
+	};
 
-		static generate_space_marine_name = function() {
+	static generate_space_marine_name = function() {
+		return SimpleNameGeneration(space_marines_names, space_marines_used_names, "Space Marine");
+	};
+
+	static generate_imperial_name = function(is_male = true) {
+		if (is_male) {
 			return SimpleNameGeneration(space_marines_names, space_marines_used_names, "Space Marine");
-		};
+		} else {
+			return SimpleNameGeneration(imperial_names, imperial_used_names, "Imperial");
+		}
+	};
 
-		static generate_imperial_name = function(is_male = true) {
-			if (is_male) {
-				return SimpleNameGeneration(space_marines_names, space_marines_used_names, "Space Marine");
-			} else {
-				return SimpleNameGeneration(imperial_names, imperial_used_names, "Imperial");
-			}
-		};
+	static generate_genestealer_cult_name = function() {
+		return ComplexTitledName(genestealer_cult_names.main, genestealer_cult_names.embelishment, genestealer_cult_names.title);
+	};
 
-		static generate_genestealer_cult_name = function() {
-			return ComplexTitledName(genestealer_cult_names.main, genestealer_cult_names.embelishment, genestealer_cult_names.title);
-		};
+	static generate_chaos_name = function() {
+		return SimpleNameGeneration(chaos_names, chaos_used_names, "Chaos");
+	};
 
-		static generate_chaos_name = function() {
-			return SimpleNameGeneration(chaos_names, chaos_used_names, "Chaos");
-		};
+	static generate_eldar_name = function(syllable_amount = 2) {
+		return MultiSyllableNameGeneration(eldar_syllables, syllable_amount);
+	};
 
-		static generate_eldar_name = function(syllable_amount = 2) {
-			return MultiSyllableNameGeneration(eldar_syllables, syllable_amount);
-		};
+	static generate_ork_name = function() {
+		return CompositeNameGeneration(ork_name_composites, false);
+	};
 
-		static generate_ork_name = function() {
-			return CompositeNameGeneration(ork_name_composites, false);
-		};
+	static generate_imperial_ship_name = function() {
+		return SimpleNameGeneration(imperial_ship_names, imperial_ship_used_names, "Imperial Ship");
+	};
 
-		static generate_imperial_ship_name = function() {
-			return SimpleNameGeneration(imperial_ship_names, imperial_ship_used_names, "Imperial Ship");
-		};
+	static generate_ork_ship_name = function() {
+		var ork_ship_name_count = max(array_length(ork_ship_names), array_length(ork_ship_used_names));
 
-		static generate_ork_ship_name = function() {
-			var ork_ship_name_count = max(array_length(ork_ship_names), array_length(ork_ship_used_names));
+		if (irandom(ork_ship_name_count) == 0) {
+			// Rare, special name
+			return $"{generate_space_marine_name()}'s Revenge";
+		}
 
-			if (irandom(ork_ship_name_count) == 0) {
-				// Rare, special name
-				return $"{generate_space_marine_name()}'s Revenge";
-			}
+		return SimpleNameGeneration(ork_ship_names, ork_ship_used_names, "Ork Ship");
+	};
 
-			return SimpleNameGeneration(ork_ship_names, ork_ship_used_names, "Ork Ship");
-		};
+	static generate_hulk_name = function() {
+		return CompositeNameGeneration(hulk_name_composites, true);
+	};
 
-		static generate_hulk_name = function() {
-			return CompositeNameGeneration(hulk_name_composites, true);
-		};
-
-		static generate_tau_leader_name = function() {
-			return CompositeNameGeneration(tau_name_composites, true);
-		};
-	} catch (_exception) {
-		handle_exception(_exception);
-	}
+	static generate_tau_leader_name = function() {
+		return CompositeNameGeneration(tau_name_composites, true);
+	};
 }
 
 // Init


### PR DESCRIPTION
## Description of changes
- Move error handling in the NameGenerator constructor from trying the whole constructor to individual name generation functions.
## Reasons for changes
- The previous method was not catching the usual errors.
## Related links
- https://discord.com/channels/714022226810372107/1330236346580598855
## How have you tested your changes?
- [x] Compile
- [x] New game
- [x] Next turn

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->
