### PR TITLE
fix: custom_advisor splash images breaking game after save

### DIFF
--- a/scripts/scr_load/scr_load.gml
+++ b/scripts/scr_load/scr_load.gml
@@ -159,6 +159,7 @@ function scr_load(save_part, save_id) {
 	    var livery_picker = new ColourItem(0,0);
 		livery_picker.scr_unit_draw_data();
 	    obj_ini.full_liveries = return_json_from_ini("Ini", "full_liveries",array_create(21,DeepCloneStruct(livery_picker.map_colour)));
+	    obj_ini.custom_advisors = return_json_from_ini("Ini", "custom_advisors",{});
 	    obj_ini.home_name=ini_read_string("Ini","home_name","Error");
 	    obj_ini.home_type=ini_read_string("Ini","home_type","Error");
 	    obj_ini.recruiting_name=ini_read_string("Ini","recruiting_name","Error");

--- a/scripts/scr_save/scr_save.gml
+++ b/scripts/scr_save/scr_save.gml
@@ -265,6 +265,7 @@ function scr_save(save_part,save_id) {
 
 	    // obj_ini
 	    ini_encode_and_json("Ini", "full_liveries", obj_ini.full_liveries);
+	    ini_encode_and_json("Ini", "custom_advisors", obj_ini.custom_advisors);
 	    ini_write_string("Ini","home_name",obj_ini.home_name);
 	    ini_write_string("Ini","home_type",obj_ini.home_type);
 	    ini_write_string("Ini","recruiting_name",obj_ini.recruiting_name);


### PR DESCRIPTION
## Description of changes
- implemented save load to obj_ini.custom_advisor
## Reasons for changes
- game break
## Related links
- https://discord.com/channels/714022226810372107/1330393004673863763
## How have you tested your changes?
- [x] Compile
- [x] New game
- [ ] Next turn
- [ ] Space Travel
- [ ] Ground Battle

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->
