### PR TITLE
fix: add init of custom_advisors in obj_ini creation

### DIFF
--- a/objects/obj_ini/Create_0.gml
+++ b/objects/obj_ini/Create_0.gml
@@ -17,6 +17,7 @@ tolerant=0;
 companies=10;
 progenitor=ePROGENITOR.NONE;
 aspirant_trial = 0;
+obj_ini.custom_advisors  = {};
 
 //default sector name to prevent potential crash
 sector_name = "Terra Nova";


### PR DESCRIPTION
## Description of changes
- add init of custom_advisors in obj_ini creation
## Reasons for changes
- makes custom advisors even safer
## Related links
-
## How have you tested your changes?
- [ ] Compile
- [ ] New game
- [ ] Next turn
- [ ] Space Travel
- [ ] Ground Battle

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->
