### PR TITLE
fix: typo causing crash when destroying gene pods

### DIFF
--- a/scripts/scr_apothecarium/scr_apothecarium.gml
+++ b/scripts/scr_apothecarium/scr_apothecarium.gml
@@ -3,7 +3,7 @@
 
 function scr_destroy_gene_slave_batch(batch_id, recover_gene=true){
     var _cur_slave = obj_ini.gene_slaves[batch_id];
-    if (revover_gene){
+    if (recover_gene){
         obj_controller.gene_seed+=_cur_slave.num;
         scr_add_item("Gene Pod Incubator", _cur_slave.num);
     }
@@ -190,12 +190,7 @@ function scr_apothecarium(){
         draw_set_color(c_gray);
         draw_rectangle(xx + 659, yy + 788, xx + 838, yy + 811, 0);
         if (point_and_click(_destroy_button)){
-            if (_slave_length>0){
-                for (var i=_slave_length-1; i>=0; i--){
-                    scr_destroy_gene_slave_batch(i);
-                }
-                obj_ini.gene_slaves = [];
-            }
+            destroy_all_gene_slaves(true);
         }
     }
     draw_set_alpha(1);


### PR DESCRIPTION
## Description of changes
- change typo
## Reasons for changes
- typo causing crash when destroying gene pods
## Related links
- https://discord.com/channels/714022226810372107/1329827627233447956
## How have you tested your changes?
- [x] Compile
- [x] New game
- [x] Next turn
- [ ] Space Travel
- [ ] Ground Battle

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->
