### PR TITLE
fix: clean up a few bugs with new planet options

### DIFF
--- a/scripts/scr_creation_draw_slides/scr_creation_draw_slides.gml
+++ b/scripts/scr_creation_draw_slides/scr_creation_draw_slides.gml
@@ -1015,16 +1015,20 @@ function draw_chapter_homeworld_select(){
             draw_set_font(fnt_40k_30b);
             var _spawn_radio = buttons.home_spawn_loc_options;
             var _max_width = left_data_slate.width-100;
-            _spawn_radio.x1 = 70;
-            _spawn_radio.y1 =  60;
-            _spawn_radio.max_width = _max_width;
+            _spawn_radio.update({
+            	x1 : 70,
+            	y1 : 60,
+            	max_width : _max_width,
+            	allow_changes : custom
+            })
             _spawn_radio.draw();
 
             var _warp_lanes_radio = buttons.home_warp;
             _warp_lanes_radio.update({
             	x1 : 70,
             	y1 : _spawn_radio.y2,
-            	max_width : _max_width
+            	max_width : _max_width,
+            	allow_changes : custom
             });
             _warp_lanes_radio.draw();
 
@@ -1032,7 +1036,8 @@ function draw_chapter_homeworld_select(){
             _home_planets.update({
             	x1 : 70,
             	y1 : _warp_lanes_radio.y2,
-            	max_width : _max_width
+            	max_width : _max_width,
+            	allow_changes : custom
             });  
             _home_planets.draw();          
 

--- a/scripts/scr_system_spawn_functions/scr_system_spawn_functions.gml
+++ b/scripts/scr_system_spawn_functions/scr_system_spawn_functions.gml
@@ -101,15 +101,17 @@ function set_player_recruit_planet(recruit_planet){
 
 function set_player_homeworld_star(chosen_star){
 	with (chosen_star){
+		if (obj_ini.recruit_relative_loc==1 && obj_ini.home_planet_count ==0){
+			obj_ini.home_planet_count++;
+		}
 		planets = obj_ini.home_planet_count+1;
 		var _home_star = irandom_range(1,planets);
 
 		player_home_star(_home_star);
-
+		var _planet_types = ARR_planet_types;
 
 		if (obj_ini.recruit_relative_loc==1){
 	       var _possible_planets = [];
-	       var _planet_types = ARR_planet_types;
 	       for (var i=1;i<=planets;i++){
 		       	if (i!=_home_star){
 		       		array_push(_possible_planets, i);
@@ -129,6 +131,11 @@ function set_player_homeworld_star(chosen_star){
 	    	if (global.chapter_name!="Lamenters") then obj_controller.recruiting_worlds+=string(name)+" II|";
 	    } else if (obj_ini.recruit_relative_loc==2){
 	    	create_recruit_system(distance_removed_star(chosen_star.x, chosen_star.y));
+	    	for (var i=1;i<=planets;i++){
+		       	if (i!=_home_star){
+		       		p_type[i] = array_random_element(_planet_types);
+		       	}
+	       	}
 	    }
     }	
 }


### PR DESCRIPTION
## Description of changes
- fix bug where recruit world could not be spawned causing crash
- fixed custom chapters being able to alter setttings they should'nt have
- fixed _planet_types variable being initialised at wrong point causing a crash 
## Reasons for changes
- fix crashes
## Related links
- https://discord.com/channels/714022226810372107/1330777615883309117
- https://discord.com/channels/714022226810372107/1330749590038773821
## How have you tested your changes?
- [x] Compile
- [x] New game
- [ ] Next turn
- [ ] Space Travel
- [ ] Ground Battle

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->
