### PR TITLE
fix: Issue wrong  spawn name would spawn for home planet

### DIFF
--- a/objects/obj_controller/Alarm_1.gml
+++ b/objects/obj_controller/Alarm_1.gml
@@ -62,12 +62,9 @@ if (did){
         add_ship_to_fleet(f, fleet);
     }
     
-    var ii=0;
-    ii+=fleet.capital_number;
-    ii+=round((fleet.frigate_number/2));
-    ii+=round((fleet.escort_number/4));
-    if (ii<=1) then ii=1;
-    fleet.image_index=ii;
+    with (fleet){
+        set_player_fleet_image();
+    }
     
     if (obj_ini.load_to_ships[0]>0){
         scr_start_load(fleet,_current_system,obj_ini.load_to_ships);
@@ -92,7 +89,8 @@ if (did){
     
     _current_system=instance_nearest(px,py,obj_star);
     _current_system.star="white2";
-    _current_system.planet[1]=1;_current_system.planet[2]=1;
+    _current_system.planet[1]=1;
+    _current_system.planet[2]=1;
     _current_system.image_index=4;
     _current_system.p_type[1]="Forge";
     _current_system.p_type[2]="Ice";

--- a/scripts/scr_system_spawn_functions/scr_system_spawn_functions.gml
+++ b/scripts/scr_system_spawn_functions/scr_system_spawn_functions.gml
@@ -52,6 +52,7 @@ function find_player_spawn_star(){
     }
     name=obj_ini.recruiting_name;
 }*/
+
 function player_home_star(home_planet){
 
         p_type[home_planet]=obj_ini.home_type;
@@ -92,14 +93,16 @@ function player_home_star(home_planet){
 
 function set_player_recruit_planet(recruit_planet){
 	p_type[recruit_planet]=obj_ini.recruiting_type;
-	var recruit_name = obj_ini.recruiting_name;
-    if (recruit_name!="random"){
-        array_push(global.name_generator.star_used_names, recruit_name);
-        if (star_by_name(recruit_name) != "none" ){
-            star_by_name(recruit_name).name = global.name_generator.generate_star_name();
-        }
-        name=recruit_name;
-    } 	
+	if (obj_ini.recruit_relative_loc==2 || obj_ini.fleet_type!=ePlayerBase.home_world){
+		var recruit_name = obj_ini.recruiting_name;
+	    if (recruit_name!="random"){
+	        array_push(global.name_generator.star_used_names, recruit_name);
+	        if (star_by_name(recruit_name) != "none" ){
+	            star_by_name(recruit_name).name = global.name_generator.generate_star_name();
+	        }
+	        name=recruit_name;
+	    }
+	}
 	array_push(p_feature[recruit_planet], new NewPlanetFeature(P_features.Recruiting_World));//recruiting world
 	if (p_type[recruit_planet]=="random") then p_type[recruit_planet]=choose("Death","Temperate","Desert","Ice","Hive", "Fuedal");
 	if (global.chapter_name!="Lamenters") then obj_controller.recruiting_worlds+=string(name)+" II|";


### PR DESCRIPTION
## Description of changes
- fix issue where the wrong name would spawn for home planet making spawn troops inaccessible
## Reasons for changes
- make troops accessible
## Related links
-
## How have you tested your changes?
- [ ] Compile
- [ ] New game
- [ ] Next turn
- [ ] Space Travel
- [ ] Ground Battle

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->
