### PR TITLE
fix: `Ambushers`+`Lightning Warriors` crash

### DIFF
--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -2007,59 +2007,6 @@ function scr_initialize_custom() {
 				"formation_options": ["tactical", "assault", "devastator", "scout"],
 			}]
 		])
-
-		variable_struct_set(st, "tactical_squad", [
-			[roles.tactical, {
-				"max": 9,
-				"min": 4,
-				"loadout": {
-					"required": {
-						"wep1": [wep1[100, 8], 7],
-						"wep2": [wep2[100, 8], 7]
-					},
-					"option": {
-						"wep1": [
-							[
-								weapon_lists.special_weapons, 1
-							],
-							[
-								weapon_lists.heavy_weapons, 1, {
-									"wep2":"Combat Knife",
-									"mobi":"Heavy Weapons Pack",
-								}
-							]
-						],
-					}
-				}
-			}],
-			[roles.sergeant, {
-				"max": 1,
-				"min": 1,
-				"role": $"{roles.tactical} {roles.sergeant}",
-				"loadout": {
-					"required": {
-						"wep1": ["", 0],
-						"wep2": ["Chainsword", 1]
-					},
-					"option": {
-						"wep1": [
-							[
-								weapon_lists.pistols, 1
-							],
-						],
-						"wep2": [
-							[
-								weapon_lists.melee_weapons, 1
-							],
-						],
-					}
-				}
-			}],
-			["type_data", {
-				"display_data": $"{roles.tactical} {squad_name}",
-				"formation_options": ["tactical", "assault", "devastator", "scout"],
-			}]
-		])
 	}
 	if (scr_has_adv("Boarders")) {
 		variable_struct_set(st, "breachers", [


### PR DESCRIPTION
## Description of changes
- Removes duplicated Tactical Marine code in `Lightning Warriors` if statement.
## Reasons for changes
- Having both `Ambushers` and `Lightning Warriors` would crash the game on start.
## Related links
- https://discord.com/channels/714022226810372107/1333399348268109905
## How have you tested your changes?
- [x] Compile
- [x] New game
- [x] Next turn
- [x] Space Travel
- [x] Ground Battle

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->
