### PR TITLE
fix: Homeworld and recruiting world names mixing up

### DIFF
--- a/scripts/scr_system_spawn_functions/scr_system_spawn_functions.gml
+++ b/scripts/scr_system_spawn_functions/scr_system_spawn_functions.gml
@@ -93,7 +93,7 @@ function player_home_star(home_planet){
 
 function set_player_recruit_planet(recruit_planet){
 	p_type[recruit_planet]=obj_ini.recruiting_type;
-	if (obj_ini.fleet_type==ePlayerBase.home_world && obj_ini.recruit_relative_loc==2){
+	if (obj_ini.fleet_type==ePlayerBase.home_world && obj_ini.recruit_relative_loc==2){ // Possibly a temporary fix, Fleet-based Chapters use Homeworld names for the Recruiting stars for some reason
 		var recruit_name = obj_ini.recruiting_name;
 	    if (recruit_name!="random"){
 	        array_push(global.name_generator.star_used_names, recruit_name);

--- a/scripts/scr_system_spawn_functions/scr_system_spawn_functions.gml
+++ b/scripts/scr_system_spawn_functions/scr_system_spawn_functions.gml
@@ -93,7 +93,7 @@ function player_home_star(home_planet){
 
 function set_player_recruit_planet(recruit_planet){
 	p_type[recruit_planet]=obj_ini.recruiting_type;
-	if (obj_ini.recruit_relative_loc==2 || obj_ini.fleet_type!=ePlayerBase.home_world){
+	if (obj_ini.fleet_type==ePlayerBase.home_world && obj_ini.recruit_relative_loc==2){
 		var recruit_name = obj_ini.recruiting_name;
 	    if (recruit_name!="random"){
 	        array_push(global.name_generator.star_used_names, recruit_name);
@@ -101,6 +101,14 @@ function set_player_recruit_planet(recruit_planet){
 	            star_by_name(recruit_name).name = global.name_generator.generate_star_name();
 	        }
 	        name=recruit_name;
+	    }
+	} else {
+	    if (obj_ini.home_name!="random"){
+	        array_push(global.name_generator.star_used_names, obj_ini.home_name);
+	        if (star_by_name(obj_ini.home_name) != "none" ){
+	            star_by_name(obj_ini.home_name).name = global.name_generator.generate_star_name();
+	        }
+	        name=obj_ini.home_name;
 	    }
 	}
 	array_push(p_feature[recruit_planet], new NewPlanetFeature(P_features.Recruiting_World));//recruiting world


### PR DESCRIPTION
## Description of changes
- Changes if statement in the `set_player_recruit_planet` function to check for homeworld and separate recruiting star, and copies homeworld star name generation code in a else statement.
## Reasons for changes
- Fleet-based Chapters mixed up Homeworld and Recruiting world names causing troops to end up in a non-existent star.
## Related links
- https://discord.com/channels/714022226810372107/1333788875981852743
## How have you tested your changes?
- [x] Compile
- [x] New game
- [x] Next turn
- [x] Space Travel
- [x] Ground Battle

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->
