### PR TITLE
fix: Tech Heresy detection var in wrong scope

### DIFF
--- a/scripts/scr_specialist_point_handler/scr_specialist_point_handler.gml
+++ b/scripts/scr_specialist_point_handler/scr_specialist_point_handler.gml
@@ -65,7 +65,7 @@ function SpecialistPointHandler() constructor{
         };
         healing_and_point_use();
 
-        var _noticed_heresy=false, at_forge=0;
+        var at_forge=0;
         tech_locations=[]
         var _cur_tech;
         total_techs = array_length(techs);
@@ -199,6 +199,7 @@ function SpecialistPointHandler() constructor{
         try{
         var tech_test, charisma_test, piety_test, _met_non_heretic, heretics_persuade_chances;
         var _tester = global.character_tester;
+        var _noticed_heresy = false; // should this be in the for loop?
         if (array_length(heretics)>0 && obj_controller.turn>75){
             var _heretic_location, _same_location, _current_heretic, _current_tech;
             //iterate through tech heretics;


### PR DESCRIPTION
## Description of changes
- Move variable into scope.
## Reasons for changes
- Variable is initialized in a different scope/function from where it is called, causing `not set before reading it` errors when called.
## Related links
- https://discord.com/channels/714022226810372107/1337069225042251847
## How have you tested your changes?
- [x] Compile
- [x] New game
- [x] Next turn
- [x] Space Travel
- [x] Ground Battle

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->
