### PR TITLE
feat: Make Purge interaction with Cults more obvious

### DIFF
--- a/scripts/scr_bomb_world/scr_bomb_world.gml
+++ b/scripts/scr_bomb_world/scr_bomb_world.gml
@@ -270,12 +270,7 @@ function scr_bomb_world(star_system, planet_number, bombard_target_faction, bomb
 	        		obj_controller.disposition[3]-=7;
 	       		}
 	        }
-            if (
-                planet_feature_bool(
-                    star_system.p_feature[planet_number],
-                    P_features.Gene_Stealer_Cult
-                )
-            ) {
+            if (planet_feature_bool(star_system.p_feature[planet_number], P_features.Gene_Stealer_Cult)) {
                 delete_features(star_system.p_feature[planet_number], P_features.Gene_Stealer_Cult);
                 adjust_influence(eFACTION.Tyranids, -100, planet_number, star_system);
                 pip.text += " The xeno taint of the tyranids that was infesting the population has been completely eradicated with the planets cleansing";

--- a/scripts/scr_bomb_world/scr_bomb_world.gml
+++ b/scripts/scr_bomb_world/scr_bomb_world.gml
@@ -270,11 +270,18 @@ function scr_bomb_world(star_system, planet_number, bombard_target_faction, bomb
 	        		obj_controller.disposition[3]-=7;
 	       		}
 	        }
-	        if (planet_feature_bool(star_system.p_feature[planet_number], P_features.Gene_Stealer_Cult)){
-	        	delete_features(star_system.p_feature[planet_number], P_features.Gene_Stealer_Cult);
-	        	adjust_influence(eFACTION.Tyranids, -100, planet_number,star_system);
-	        }
-	        pip.text+= " The xenos taint of the tyranids infecting the population has been completely eradicated with the planets cleansing";
+            if (
+                planet_feature_bool(
+                    star_system.p_feature[planet_number],
+                    P_features.Gene_Stealer_Cult
+                )
+            ) {
+                delete_features(star_system.p_feature[planet_number], P_features.Gene_Stealer_Cult);
+                adjust_influence(eFACTION.Tyranids, -100, planet_number, star_system);
+                pip.text += " The xeno taint of the tyranids that was infesting the population has been completely eradicated with the planets cleansing";
+            } else {
+                pip.text += " Any xeno taint that was infesting the population has been completely eradicated with the planets cleansing";
+            }
 	    }
 	    if (bombard_target_faction=8) and (obj_controller.faction_status[eFACTION.Tau]!="War"){
 	        obj_controller.audiences+=1;

--- a/scripts/scr_purge_world/scr_purge_world.gml
+++ b/scripts/scr_purge_world/scr_purge_world.gml
@@ -161,10 +161,7 @@ function scr_purge_world(star, planet, action_type, action_score) {
 
 	        var nid_influence = star.p_influence[planet][eFACTION.Tyranids];
             if (planet_feature_bool(star.p_feature[planet], P_features.Gene_Stealer_Cult)) {
-                var cult = return_planet_features(
-                    star.p_feature[planet],
-                    P_features.Gene_Stealer_Cult
-                )[0];
+                var cult = return_planet_features(star.p_feature[planet], P_features.Gene_Stealer_Cult)[0];
                 if (cult.hiding) {}
             } else {
                 if (nid_influence > 25) {

--- a/scripts/scr_purge_world/scr_purge_world.gml
+++ b/scripts/scr_purge_world/scr_purge_world.gml
@@ -160,18 +160,21 @@ function scr_purge_world(star, planet, action_type, action_score) {
 	        if (pop_before>0) and (pop_after=0) then heres_after=0;
 
 	        var nid_influence = star.p_influence[planet][eFACTION.Tyranids];
-	        if (planet_feature_bool(star.p_feature[planet], P_features.Gene_Stealer_Cult)){
-				var cult = return_planet_features(star.p_feature[planet], P_features.Gene_Stealer_Cult)[0];
-				if (cult.hiding){
-					
-				}
-			} else {
-	        	if (nid_influence>25){
-	        		txt1 += "Scores of mutant offspring from a genestealer infestation are burnt, while the situation is grave the mutants appear to lack the organisation of a true cult";
-	        		adjust_influence(eFACTION.Tyranids, -10, planet, star);
-	        	}
-	        }
-	        if (star.p_large[planet]=0) then pop_after=round(pop_after);    
+            if (planet_feature_bool(star.p_feature[planet], P_features.Gene_Stealer_Cult)) {
+                var cult = return_planet_features(
+                    star.p_feature[planet],
+                    P_features.Gene_Stealer_Cult
+                )[0];
+                if (cult.hiding) {}
+            } else {
+                if (nid_influence > 25) {
+                    txt1 += " Scores of mutant offspring from a genestealer infestation are burnt, while we have damaged their influence over this world, the mutants appear to lack the organisation of a true cult";
+                    adjust_influence(eFACTION.Tyranids, -10, planet, star);
+                } else if (nid_influence > 0) {
+                    txt1 += " There are signs of a genestealer infestation but the cultists are too unorganized to do any real damage to their influence on this world";
+                }
+            }
+	        if (star.p_large[planet]=0) then pop_after=round(pop_after);
 	        if (pop_after<=0) and (pop_before>0) then heres_after=0;
 	        if (star.p_large[planet]=0) then txt1+="##The planet had a population of "+string(scr_display_number(floor(pop_before)))+" and "+string(scr_display_number(floor(kill)))+" were purged over the duration of the cleansing.##Heresy has fallen down to "+string(max(0,heres_after))+"%.";
 	        if (star.p_large[planet]=1) then txt1+="##The planet had a population of "+string(pop_before)+" billion and "+string(scr_display_number(action_score*12000))+" were purged over the duration of the cleansing.##Heresy has fallen down to "+string(max(0,heres_after))+"%.";


### PR DESCRIPTION
## Description of changes
- Make it more obvious that purging lowers Tyranid influence, when it doesn't and add some flavor text.
## Reasons for changes
- Players get confused if purging actually does anything.
## Related links
- https://discord.com/channels/714022226810372107/714023282780799028/1336280298438000680
## How have you tested your changes?
- [x] Compile
- [ ] New game
- [x] Next turn
- [x] Space Travel
- [x] Ground Battle

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->
