### PR TITLE
feat: if population equals zero then reset all influence

### DIFF
--- a/scripts/scr_PlanetData/scr_PlanetData.gml
+++ b/scripts/scr_PlanetData/scr_PlanetData.gml
@@ -81,6 +81,14 @@ function PlanetData(planet, system) constructor{
     requests_help = system.p_halp[planet];
 
     // current planet heresy
+    if (population == 0) {
+        system.p_heresy[planet] = 0;
+        system.p_heresy_secret[planet] = 0;
+        for (var i = 0; i < array_length(system.p_influence[planet]); ++i) {
+            system.p_influence[planet][i] = 0;
+        }
+    }
+
     corruption = system.p_heresy[planet];
 
     is_heretic = system.p_hurssy[planet];


### PR DESCRIPTION
## Description of changes
- Make influence and corruption reset to zero when population is zero.
## Reasons for changes
- So players don't spend 30+ turns purging on a planet with no population and 20+ turns dealing with Traitors and/or Tau spawning and contesting the planet.
## Related links
- Adds merit to https://github.com/Adeptus-Dominus/ChapterMaster/pull/467 bombard flavor text.
## How have you tested your changes?
- [x] Compile
- [x] New game
- [x] Next turn
- [x] Space Travel
- [x] Ground Battle

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->
