### PR TITLE
fix: Corruption for new recruits

### DIFF
--- a/scripts/scr_recruit_data/scr_recruit_data.gml
+++ b/scripts/scr_recruit_data/scr_recruit_data.gml
@@ -79,7 +79,7 @@ function planet_training_sequence(local_apothecary_points){
 
 	        var recruit_chance = 999;
 	        var aspirant = 0;
-	        var new_recruit_corruption = 10;
+	        var new_recruit_corruption = 0;
 	        var months_to_neo = 72;
 	        var dista = 0;
 	        var onceh = 0;


### PR DESCRIPTION


## Description of changes
- This update resolves the issue where the new scout's base corruption value was incorrectly set to 10 instead of 0. The corruption is now properly initialized at 0 and hopefully can be reduced as intended.
## Reasons for changes
- The base 10 does not make sense since it's for all types of recruits and cannot be reduced.
## Related links
-
## How have you tested your changes?
- [X] Compile
- [X] New game
- [X] Next turn
- [X] Space Travel
- [X] Ground Battle

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->
