### PR TITLE
fix: Rhino missing HK missile armament

### DIFF
--- a/scripts/scr_get_item_names/scr_get_item_names.gml
+++ b/scripts/scr_get_item_names/scr_get_item_names.gml
@@ -262,6 +262,15 @@ function push_rhino_weapons_item_names(_item_names) {
     _item_names[@ index++] = "HK Missile"; // 5
 }
 
+function push_rhino_side_item_names(_item_names) {
+    var item_count = 1;
+    var initial_size = array_length(_item_names);
+    array_resize(_item_names, initial_size + item_count);
+
+    var index = initial_size;
+    _item_names[@ index++] = "HK Missile";
+}
+
 /// @description This function appends the list of predator turret weapons to the given list.
 /// @param {array} _item_names - The list to append to.
 /// @returns {void}
@@ -545,6 +554,7 @@ function get_slot_name(_role, _slot) {
         case eROLE.Rhino:
             switch (_slot) {
                 case 1: return "Weapon";
+                case 2: return "Side";
                 case 4: return "Upgrade";
                 case 5: return "Accessory";
                 default: return "Unknown";
@@ -845,9 +855,9 @@ function scr_get_item_names(_item_names, _role, _slot, _engagement, _include_com
             get_none_or_any_item_names(_item_names, _with_none_if_not_skip, false);
             switch (_slot) {
                 case 1: push_rhino_weapons_item_names(_item_names); break;
+                case 2: push_rhino_side_item_names(_item_names); break;
                 case 4: push_tank_upgrade_item_names(_item_names, false); break;
                 case 5: push_tank_accessory_item_names(_item_names, false, false); break;
-                case 2:
                 case 3:
                     // Rhino doesn't have these slots, but empty lists are shown in the UI
                     break;


### PR DESCRIPTION

## Description of changes
- Adds the missing option to add HK missiles after being initialized.
## Reasons for changes
- It was only initialized before but you could not arm them.
## Related links
-
## How have you tested your changes?
- [X] Compile
- [X] New game
- [X] Next turn
- [X] Space Travel
- [X] Ground Battle

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->
