### PR TITLE
fix: Garrison fixes and minor changes

### DIFF
--- a/scripts/scr_PlanetData/scr_PlanetData.gml
+++ b/scripts/scr_PlanetData/scr_PlanetData.gml
@@ -7,7 +7,7 @@ function PlanetData(planet, system) constructor{
 //safeguards // TODO LOW DEBUG_LOGGING // Log when tripped somewhere
     //disposition
     if (system.dispo[planet] < 0 && system.dispo[planet] > -1000 && system.p_owner[planet] != eFACTION.Player ) { // Personal Rule code be doing some interesting things
-        system.dispo[planet] = 0; // Maybe change to -100 if we are allowing negative numbers like for factions
+        system.dispo[planet] = -100; // TODO LOW DISPOSITION_REVAMP // Consider revamping the disposition system
     } else if (system.dispo[planet] > 100) {
         system.dispo[planet] = 100;
     }

--- a/scripts/scr_PlanetData/scr_PlanetData.gml
+++ b/scripts/scr_PlanetData/scr_PlanetData.gml
@@ -4,6 +4,15 @@
 #macro ARR_strength_descriptions ["none", "Minimal", "Sparse", "Moderate", "Numerous", "Very Numerous", "Overwhelming"];
 
 function PlanetData(planet, system) constructor{
+//safeguards // TODO LOW DEBUG_LOGGING // Log when tripped somewhere
+    //disposition
+    if (system.dispo[planet] < 0 && system.dispo[planet] > -1000 && system.p_owner[planet] != eFACTION.Player ) { // Personal Rule code be doing some interesting things
+        system.dispo[planet] = 0; // Maybe change to -100 if we are allowing negative numbers like for factions
+    } else if (system.dispo[planet] > 100) {
+        system.dispo[planet] = 100;
+    }
+//
+
 	self.planet = planet;
 	self.system = system;
 	player_disposition = system.dispo[planet];

--- a/scripts/scr_garrison/scr_garrison.gml
+++ b/scripts/scr_garrison/scr_garrison.gml
@@ -1,23 +1,28 @@
-function disposition_description_chart(dispo){
-	if (dispo<10){
-		return "Very Hostile";
-	} else if (dispo<30){
-		return "Hostile";
-	}else if (dispo<50){
-		return "Uneasy";
-	}else if (dispo<60){
-		return "Neutral";
-	}else if (dispo<70){
-		return "Friendly";
-	}else if (dispo<80){
-		return "Very Friendly";
-	}else if (dispo<90){
-		return "Excellent";
-	}else {
-		return "Unquestionable";
-	}
+function disposition_description_chart(dispo) {
+    if (dispo < 0) {
+        return "DEBUG: Negative numbers detected, this shouldn't happen!";
+    } else if (dispo == 0) {
+        return "Extremely Hostile";
+    } else if (dispo < 10) {
+        return "Very Hostile";
+    } else if (dispo < 30) {
+        return "Hostile";
+    } else if (dispo < 50) {
+        return "Uneasy";
+    } else if (dispo < 60) {
+        return "Neutral";
+    } else if (dispo < 70) {
+        return "Friendly";
+    } else if (dispo < 80) {
+        return "Very Friendly";
+    } else if (dispo < 90) {
+        return "Excellent";
+    } else if (dispo <= 100) {
+        return "Unquestionable";
+    } else {
+        return "DEBUG: Numbers higher than 100, this shouldn't happen!";
+    }
 }
-
 
 function GarrisonForce(planet_operatives, turn_end=false, type="garrison") constructor{
 	garrison_squads=[];
@@ -147,14 +152,15 @@ function GarrisonForce(planet_operatives, turn_end=false, type="garrison") const
 		} else {report_string+="The garrison is comprised of a single squad,"}
 
 		report_string+= $" with a total man count of {total_garrison}.#"
-		if (system.dispo[planet]>-1){
-			var disposition = disposition_description_chart(system.dispo[planet]);
-			report_string+=$"Our Relationship with the Rulers of the planet is {disposition}#";
-		} else if(system.dispo[planet]<-1000 && system.p_owner[planet] = eFACTION.Player){
-			report_string+=$"Rule of the planet is going well";
-		} else {
-			report_string+=$"There is no clear chain of command on the planet we suspect the existence of Xenos or Heretic Forces";
-		}
+        if (system.p_owner[planet] != eFACTION.Player) {
+            var disposition = disposition_description_chart(system.dispo[planet]);
+            report_string += $"Our Relationship with the Rulers of the planet is {disposition}#";
+        } else if (system.dispo[planet] < -1000 && system.p_owner[planet] == eFACTION.Player) {
+            report_string += $"Rule of the planet is going well";
+        } else {
+            report_string += $"DEBUG: planet owner check failed";
+            //report_string+=$"There is no clear chain of command on the planet we suspect the existence of Xenos or Heretic Forces"; // TODO LOW GARRISON_XENO // Readd when this actually gets implented
+        }
 
 		return report_string;
 	}
@@ -180,19 +186,25 @@ function GarrisonForce(planet_operatives, turn_end=false, type="garrison") const
 				}
 			} else {
 				var charisma_test = global.character_tester.standard_test(garrison_leader, "charisma", final_modifier);
-				if (!charisma_test[0]){
-					if (garrison_leader.has_trait("honorable")){
-						dispo_change = "none";
-					}else {
-						if (planet_disposition<obj_controller.disposition[star.p_owner[planet]]){
-							dispo_change = charisma_test[1]/10;
-						} else {
-							dispo_change=0;
-						}
-					}
-				} else {
-					dispo_change=charisma_test[1]/10;
-				}
+                if (!charisma_test[0]) {
+                    if (garrison_leader.has_trait("honorable")) {
+                        dispo_change = "none";
+                    } else {
+                        if (planet_disposition > obj_controller.disposition[star.p_owner[planet]]) {
+                            dispo_change = charisma_test[1] / 10;
+                            if (planet_disposition < abs(dispo_change)) {
+                                dispo_change = -planet_disposition;
+                            }
+                        } else {
+                            dispo_change = 0;
+                        }
+                    }
+                } else {
+                    dispo_change = charisma_test[1] / 10;
+                    if (planet_disposition + dispo_change >= 100) {
+                        dispo_change = abs(planet_disposition - 100);
+                    }
+                }
 			}
 		} else {
 			dispo_change = "none";

--- a/scripts/scr_garrison/scr_garrison.gml
+++ b/scripts/scr_garrison/scr_garrison.gml
@@ -188,10 +188,12 @@ function GarrisonForce(planet_operatives, turn_end=false, type="garrison") const
 				var charisma_test = global.character_tester.standard_test(garrison_leader, "charisma", final_modifier);
                 if (!charisma_test[0]) {
                     var _diplomatic_leader = false;
-                    if (is_struct(garrison_leader)){
+                    if (is_struct(garrison_leader)) {
                         _diplomatic_leader = garrison_leader.has_trait("honorable");
                     } else {
-                        scr_event_log("purple",$"DEBUG: Garrison Leader on {star.name} {planet} couldn't be found!");
+                        scr_alert("yellow", "DEBUG", $"DEBUG: Garrison Leader on {star.name} {planet} couldn't be found!", 0, 0);
+                        scr_event_log("yellow", $"DEBUG: Garrison Leader on {star.name} {planet} couldn't be found!");
+                        log_error($"DEBUG: Garrison Leader on {star.name} {planet} couldn't be found!");
                     }
 
                     if (_diplomatic_leader) {

--- a/scripts/scr_garrison/scr_garrison.gml
+++ b/scripts/scr_garrison/scr_garrison.gml
@@ -1,7 +1,7 @@
 function disposition_description_chart(dispo) {
-    if (dispo < 0) {
-        return "DEBUG: Negative numbers detected, this shouldn't happen!";
-    } else if (dispo == 0) {
+    if (dispo < -100) {
+        return "DEBUG: Numbers lower than -100 detected, this shouldn't happen!";
+    } else if (dispo <= 0) {
         return "Extremely Hostile";
     } else if (dispo < 10) {
         return "Very Hostile";
@@ -187,13 +187,20 @@ function GarrisonForce(planet_operatives, turn_end=false, type="garrison") const
 			} else {
 				var charisma_test = global.character_tester.standard_test(garrison_leader, "charisma", final_modifier);
                 if (!charisma_test[0]) {
-                    if (garrison_leader.has_trait("honorable")) {
+                    var _diplomatic_leader = false;
+                    if (is_struct(garrison_leader)){
+                        _diplomatic_leader = garrison_leader.has_trait("honorable");
+                    } else {
+                        scr_event_log("purple",$"DEBUG: Garrison Leader on {star.name} {planet} couldn't be found!");
+                    }
+
+                    if (_diplomatic_leader) {
                         dispo_change = "none";
                     } else {
                         if (planet_disposition > obj_controller.disposition[star.p_owner[planet]]) {
                             dispo_change = charisma_test[1] / 10;
-                            if (planet_disposition < abs(dispo_change)) {
-                                dispo_change = -planet_disposition;
+                            if (planet_disposition + dispo_change >= -100) {
+                                dispo_change = planet_disposition + 100;
                             }
                         } else {
                             dispo_change = 0;


### PR DESCRIPTION
## Description of changes
- Add some debug code and another disposition chart item, disallow garrisons from making disposition going into the negatives and flip a comparison.
## Reasons for changes
- Garrisons could make relations go into the negative which could take forever to get out and with the incorrect comparison direction would take away relations if the charsima check failed and relations with the faction owner was higher.
## How have you tested your changes?
- [x] Compile
- [x] New game
- [x] Next turn
- [x] Space Travel
- [x] Ground Battle

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->
