### PR TITLE
feat: custom and more event colors

### DIFF
--- a/objects/obj_event_log/Draw_0.gml
+++ b/objects/obj_event_log/Draw_0.gml
@@ -42,12 +42,18 @@ if (__b__) {
                 }
                 cur_event = event[t];
                 if (cur_event.text != "") { // 1554
-                    draw_set_color(38144);
-                    if (cur_event.colour = "red") {
+                    if (cur_event.colour == "" || cur_event.colour == "green") {
+                        draw_set_color(38144);
+                    } else if (cur_event.colour == "red") {
                         draw_set_color(c_red);
-                    }
-                    if (cur_event.colour = "purple") {
+                    } else if (cur_event.colour == "yellow") {
+                        draw_set_color(57586);
+                    } else if (cur_event.colour == "purple") {
                         draw_set_color(c_purple);
+                    } else if (cur_event.colour != "") {
+                        draw_set_color(cur_event.colour);
+                    } else {
+                        debugl("DEBUG: color fallthrough in obj_event_log/Draw_0.gml!");
                     }
                     draw_text_ext(xx + 25, yy + 120 + (p * 26), $"{cur_event.date}  (Turn {cur_event.turn}) - {cur_event.text}", -1, 1554);
                     if (cur_event.event_target != "none") {

--- a/objects/obj_turn_end/Draw_64.gml
+++ b/objects/obj_turn_end/Draw_64.gml
@@ -15,10 +15,19 @@ if (alerts>0) and (popups_end=1){
     repeat(alerts){
         i+=1;
 
-        draw_set_color(38144);
-        if (alert_color[i] == "red") then draw_set_color(c_red);
-        if (alert_color[i] == "yellow") then draw_set_color(57586);
-        // if (alert_color[i]="purple") then draw_set_color(c_red);
+        if (alert_color[i] == "" || alert_color[i] == "green") {
+            draw_set_color(38144);
+        } else if (alert_color[i] == "red") {
+            draw_set_color(c_red);
+        } else if (alert_color[i] == "yellow") {
+            draw_set_color(57586);
+        } else if (alert_color[i] == "purple") {
+            draw_set_color(c_purple);
+        } else if (alert_color[i] != "") {
+            draw_set_color(alert_color[i]);
+        } else {
+            debugl("DEBUG: color fallthrough in obj_turn_end/Draw_64.gml!");
+        }
         draw_set_alpha(min(1,alert_alpha[i]));
         
         if (obj_controller.zoomed=0){

--- a/scripts/scr_alert/scr_alert.gml
+++ b/scripts/scr_alert/scr_alert.gml
@@ -12,7 +12,7 @@ function scr_alert(colour, alert_type, alert_text, xx=00, yy=00) {
 	    if (obj_turn_end.alert_type[obj_turn_end.alerts]!="-"+string(alert_text)) and (alert_type!="blank") and (colour!="blank"){
 	        obj_turn_end.alerts+=1;
 	        obj_turn_end.alert[obj_turn_end.alerts]=1;
-	        obj_turn_end.alert_color[obj_turn_end.alerts]=colour;
+	        obj_turn_end.alert_color[obj_turn_end.alerts]=colour; // takes green, red, purple, default GM colorcodes(with c_ prefix), decimal, hexadecimal(with $ prefix, 6 or 8 digits) and CSS(with # prefix)
 	        // if (colour="purple") then obj_turn_end.alert_color[obj_turn_end.alerts]="red";
 	        obj_turn_end.alert_type[obj_turn_end.alerts]=alert_type;
 	        obj_turn_end.alert_text[obj_turn_end.alerts]="-"+string(alert_text);

--- a/scripts/scr_event_log/scr_event_log.gml
+++ b/scripts/scr_event_log/scr_event_log.gml
@@ -7,7 +7,7 @@ function scr_event_log(event_colour, event_text, target = "none") {
 	    if (obj_controller.year_fraction>=100) then yf=string(obj_controller.year_fraction);
 
 		var new_event = {
-			colour :event_colour,
+			colour :event_colour, // takes green, red, purple, default GM colorcodes(with c_ prefix), decimal, hexadecimal(with $ prefix, 6 or 8 digits) and CSS(with # prefix)
 			turn : obj_controller.turn,
 	    	date:string(obj_controller.check_number)+" "+string(yf)+" "+string(obj_controller.year)+".M"+string(obj_controller.millenium),
 	   	 	text:event_text,


### PR DESCRIPTION
## Description of changes
- Unify alert and event colors and allow custom colors, this will crash if a non-color gets put into it though.
## Reasons for changes
- Because we need more event colors in our lives.
## How have you tested your changes?
- [x] Compile
- [ ] New game
- [x] Next turn
- [x] Space Travel
- [x] Ground Battle

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->
