### PR TITLE
fix: Boarders experience out of range

### DIFF
--- a/objects/obj_p_assra/Step_0.gml
+++ b/objects/obj_p_assra/Step_0.gml
@@ -311,8 +311,7 @@ if (boarding=true) and (board_cooldown>=0) and (instance_exists(target)) and (in
         if (experience>0){
             var o=0,co=0,i=0;
             var new_exp, unit_exp, exp_roll;
-            repeat(boarders){
-                o+=1;
+            for (var o=0;o<array_length(origin.board_co);o++){
                 co=origin.board_co[o];
                 i=origin.board_id[o];               
                 unit = obj_ini.TTRPG[co][i];


### PR DESCRIPTION
## Description of changes
- Replace `repeat` for a `for` loop.
## Reasons for changes
- Out of range crash.
## Related links
- https://discord.com/channels/714022226810372107/1340346439531888650
## How have you tested your changes?
- [x] Compile
- [ ] New game
- [x] Next turn
- [x] Space Travel
- [ ] Ground Battle

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->
