### PR TITLE
fix: Condemnor bolter

### DIFF
--- a/objects/obj_controller/Mouse_50.gml
+++ b/objects/obj_controller/Mouse_50.gml
@@ -364,18 +364,18 @@ if (menu==20) and (diplomacy>0) or ((diplomacy<-5) and (diplomacy>-6)) and (cool
             // Inquisition trade goods
             if (diplomacy==4){
                 cooldown=8;
-                trade_theirs[1]="Condemnor Boltgun";
-                trade_theirs[2]="Hellrifle";
-                trade_theirs[3]="Incinerator";
-                trade_theirs[4]="Crusader";
-                trade_theirs[5]="Exterminatus";
-                trade_theirs[6]="Cyclonic Torpedo";
-                trade_disp[1]=20;
-                trade_disp[2]=30;
-                trade_disp[3]=20;
-                trade_disp[4]=25;
-                trade_disp[5]=40;
-                trade_disp[6]=60;
+                // trade_theirs[1]="Condemnor Boltgun";
+                trade_theirs[1]="Hellrifle";
+                trade_theirs[2]="Incinerator";
+                trade_theirs[3]="Crusader";
+                trade_theirs[4]="Exterminatus";
+                trade_theirs[5]="Cyclonic Torpedo";
+                // trade_disp[1]=20;
+                trade_disp[1]=30;
+                trade_disp[2]=20;
+                trade_disp[3]=25;
+                trade_disp[4]=40;
+                trade_disp[5]=60;
             }
             // Ecclesiarchy trade goods
             if (diplomacy==5){

--- a/scripts/scr_trade/scr_trade.gml
+++ b/scripts/scr_trade/scr_trade.gml
@@ -56,7 +56,7 @@ function scr_trade(argument0) {
 	    if (trade_take[i]="Skitarii") then their_worth+=trade_tnum[i]*15;
 	    if (trade_take[i]="Techpriest") then their_worth+=trade_tnum[i]*150;
     
-	    if (trade_take[i]="Condemnor Boltgun") then their_worth+=trade_tnum[i]*15;
+	    // if (trade_take[i]="Condemnor Boltgun") then their_worth+=trade_tnum[i]*15;
 	    if (trade_take[i]="Hellrifle") then their_worth+=trade_tnum[i]*20;
 	    if (trade_take[i]="Incinerator") then their_worth+=trade_tnum[i]*20;
 	    if (trade_take[i]="Crusader") then their_worth+=trade_tnum[i]*20;

--- a/scripts/scr_trade_add/scr_trade_add.gml
+++ b/scripts/scr_trade_add/scr_trade_add.gml
@@ -36,7 +36,7 @@ function scr_trade_add(argument0) {
 	        if (string_count("Useful Info",woj)>1){trade_tnum[thinz]=0;tomp1=0;trade_take[thinz]="";}
 	    }
     
-	    if (argument0="Condemnor Boltgun"){get_diag_integer("Condemnor Boltguns wanted?",20,"t"+string(thinz),"Condemnor Boltgun");}
+	    // if (argument0="Condemnor Boltgun"){get_diag_integer("Condemnor Boltguns wanted?",20,"t"+string(thinz),"Condemnor Boltgun");}
 	    if (argument0="Hellrifle"){get_diag_integer("Hellrifles wanted?",3,"t"+string(thinz),"Hellrifle");}
 	    if (argument0="Incinerator"){get_diag_integer("Incinerators wanted?",10,"t"+string(thinz),"Incinerator");}
 	    if (argument0="Crusader"){get_diag_integer("Crusaders wanted?",5,"t"+string(thinz),"Crusader");}


### PR DESCRIPTION
## Description of changes
- Comments out condemnor bolter in the inquisition faction's trade screen.
## Reasons for changes
- Players attempting to buy condemnor bolters experience crashes to desktop, as this bolter does not exist elsewhere. This fixes it.
## Related links
- https://discord.com/channels/714022226810372107/1340752494766067795
## How have you tested your changes?
- [ ] Compile
- [ ] New game
- [ ] Next turn
- [ ] Space Travel
- [ ] Ground Battle

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->
