### PR TITLE
feat: Setter method for PlanetData adding new planet features

### DIFF
--- a/scripts/scr_PlanetData/scr_PlanetData.gml
+++ b/scripts/scr_PlanetData/scr_PlanetData.gml
@@ -141,8 +141,12 @@ function PlanetData(planet, system) constructor{
     static has_feature = function(feature){
     	return planet_feature_bool(features, feature);
     }
-    
-    static has_upgrade= function(feature){
+
+    static add_feature = function(feature_type){
+    	array_push(system.p_feature[planet], new NewPlanetFeature(feature_type));
+    }
+
+    static has_upgrade = function(feature){
     	return planet_feature_bool(upgrades, feature);
     }
 


### PR DESCRIPTION
## Description of changes
- adds a Setter method for new planet features using the PlanetData object
## Reasons for changes
- more convenient and makes cleaner code 
## Related links
-
## How have you tested your changes?
- [x] Compile
- [ ] New game
- [ ] Next turn
- [ ] Space Travel
- [ ] Ground Battle

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->
