### PR TITLE
fix: Refactor obj_bomb alarm 1 array length bug

### DIFF
--- a/objects/obj_bomb_select/Alarm_1.gml
+++ b/objects/obj_bomb_select/Alarm_1.gml
@@ -37,7 +37,7 @@ if (p_data.guardsmen>0){
     imp=p_data.guard_score_calc();
 }
 var _pdf_count=p_data.pdf;
-if (pdf >= 50000000) {
+if (_pdf_count >= 50000000) {
     pdf = 6;
 } else if (_pdf_count >= 15000000) {
     pdf = 5;

--- a/objects/obj_bomb_select/Alarm_1.gml
+++ b/objects/obj_bomb_select/Alarm_1.gml
@@ -1,43 +1,24 @@
 // Sets which target is in planet and its strenght
-for(var i=0; i<31; i++){
-    ship[i]="";
-    ship_all[i]=0;
-    ship_use[i]=0;
-    ship_max[i]=0;
-    ship_ide[i]=-1;
-}
+ship=[];
+ship_all=[];
+ship_use=[];
+ship_max=[];
+ship_ide=[];
 
-max_ships=sh_target.capital_number+sh_target.frigate_number+sh_target.escort_number;
+var _ships = fleet_full_ship_array(sh_target);
+max_ships = array_length(_ships);
+bomb_a = calculate_fleet_bombard_score(_ships);
+var _total_fleet_loaded = calculate_fleet_content_size(_ships);
+bomb_b = _total_fleet_loaded;
+bomb_c = _total_fleet_loaded;
 
-var tump=0;
-
-var i=-1;
-for(var b=0; b<array_length(sh_target.capital); b++){
-    if (sh_target.capital[b]!=""){
-        i+=1;
-        ship[i]=sh_target.capital[i];
-        
-        ship_use[i]=0;
-        tump=sh_target.capital_num[i];
-        ship_max[i]=obj_ini.ship_carrying[tump];
-        ship_ide[i]=tump;
-        
-        bomb_a+=3;
-        bomb_b+=ship_max[i];bomb_c+=ship_max[i];
-    }
-}
-for(var q=0; q<array_length(sh_target.frigate); q++){
-    if (sh_target.frigate[q]!=""){
-        i+=1;
-        ship[i]=sh_target.frigate[q];
-        
-        ship_use[i]=0;
-        tump=sh_target.frigate_num[q];
-        ship_max[i]=obj_ini.ship_carrying[tump];
-        ship_ide[i]=tump;
-        
-        bomb_a+=1;
-        bomb_b+=ship_max[i];bomb_c+=ship_max[i];
+for (var i=0;i<array_length(_ships);i++){
+    if (ship_bombard_score(_ships[i]) > 0){
+        array_push(ship_ide, _ships[i]);
+        array_push(ship_max, obj_ini.ship_carrying[_ships[i]]);
+        array_push(ship, obj_ini.ship[_ships[i]]);
+        array_push(ship_use, 0);
+        array_push(ship_all, 0);
     }
 }
 
@@ -52,23 +33,24 @@ traitors=p_target.p_traitors[obj_controller.selecting_planet];
 necrons=p_target.p_necrons[obj_controller.selecting_planet];
 
 var onceh=0;
-imp=p_target.p_guardsmen[obj_controller.selecting_planet];
-if (onceh == 0) {
-    if (imp >= 50000000) {
-        imp = 6;
-    } else if (imp >= 15000000) {
-        imp = 5;
-    } else if (imp >= 6000000) {
-        imp = 4;
-    } else if (imp >= 1000000) {
-        imp = 3;
-    } else if (imp >= 100000) {
-        imp = 2;
-    } else if (imp >= 2000) {
-        imp = 1;
-    }
-    onceh = 1;
+if (p_data.guardsmen>0){
+    imp=p_data.guard_score_calc();
 }
+var _pdf_count=p_data.pdf;
+if (pdf >= 50000000) {
+    pdf = 6;
+} else if (_pdf_count >= 15000000) {
+    pdf = 5;
+} else if (_pdf_count >= 6000000) {
+    pdf = 4;
+} else if (_pdf_count >= 1000000) {
+    pdf = 3;
+} else if (_pdf_count >= 100000) {
+    pdf = 2;
+} else if (_pdf_count >= 2000) {
+    pdf = 1;
+}    
+
 
 onceh=0;
 pdf=p_target.p_pdf[obj_controller.selecting_planet];

--- a/scripts/scr_player_fleet_functions/scr_player_fleet_functions.gml
+++ b/scripts/scr_player_fleet_functions/scr_player_fleet_functions.gml
@@ -599,7 +599,26 @@ function get_nearest_player_fleet(nearest_x, nearest_y, is_static=false, is_movi
 	return chosen_fleet;	
 }
 
+function calculate_fleet_content_size(ship_array){
+	var total_content = 0;
+	for (var i=0;i<array_length(ship_array);i++){
+		var _ship_id  = ship_array[i];
+		if (_ship_id<array_length(obj_ini.ship)){
+			total_content += obj_ini.ship_carrying[_ship_id];
+		}
+	}
+	return total_content;	
+}
 
 
-
+function calculate_fleet_bombard_score(ship_array){
+	var bomb_score = 0;
+	for (var i=0;i<array_length(ship_array);i++){
+		var _ship_id  = ship_array[i];
+		if (_ship_id<array_length(obj_ini.ship)){
+			bomb_score += ship_bombard_score(_ship_id);
+		}
+	}
+	return bomb_score;
+}
 

--- a/scripts/scr_player_ship_functions/scr_player_ship_functions.gml
+++ b/scripts/scr_player_ship_functions/scr_player_ship_functions.gml
@@ -244,6 +244,7 @@ function loose_ship_to_warp_event(){
 	}	
 }
 
+//TODO make method for setting ship weaponry
 function new_player_ship(type, start_loc="home", new_name=""){
     var ship_names="",index=0;
     var index = new_player_ship_defaults();
@@ -379,20 +380,20 @@ function new_player_ship(type, start_loc="home", new_name=""){
         obj_ini.ship_weapons[index]=4;
         obj_ini.ship_shields[index]=24;
         obj_ini.ship_wep[index,1]="Lance Battery";
-        ship_wep_facing[index,1]="most";
+        obj_ini.ship_wep_facing[index,1]="most";
         obj_ini.ship_wep_condition[index,1]="";
         obj_ini.ship_wep[index,2]="Lance Battery";
-		ship_wep_facing[index,2]="most";
+		obj_ini.ship_wep_facing[index,2]="most";
         obj_ini.ship_wep_condition[index,2]="";
         obj_ini.ship_wep[index,3]="Lance Battery";
-        ship_wep_facing[index,3]="most";
+        obj_ini.ship_wep_facing[index,3]="most";
         obj_ini.ship_wep_condition[index,3]="";
         obj_ini.ship_wep[index,4]="Plasma Cannon";
-        ship_wep_facing[index,4]="front";
-        obj_ini.ship_wep[index,5]="Macro Bombardment Cannons";
-        obj_ini.ship_wep_facing[index,4]="most";
-        obj_ini.ship_wep_condition[index,4]="";               
+        obj_ini.ship_wep_facing[index,4]="front";
         obj_ini.ship_wep_condition[index,4]="";
+        obj_ini.ship_wep[index,5]="Macro Bombardment Cannons";
+        obj_ini.ship_wep_facing[index,5]="most";
+        obj_ini.ship_wep_condition[index,5]="";               
         obj_ini.ship_capacity[index]=800;
         obj_ini.ship_carrying[index]=0;
         obj_ini.ship_contents[index]="";

--- a/scripts/scr_player_ship_functions/scr_player_ship_functions.gml
+++ b/scripts/scr_player_ship_functions/scr_player_ship_functions.gml
@@ -285,7 +285,7 @@ function new_player_ship(type, start_loc="home", new_name=""){
         obj_ini.ship_wep[index,4]="Torpedo Tubes";
         obj_ini.ship_wep_facing[index,4]="front";
         obj_ini.ship_wep_condition[index,4]="";
-        obj_ini.ship_wep[index,5]="Bombardment Cannons";
+        obj_ini.ship_wep[index,5]="Macro Bombardment Cannons";
         obj_ini.ship_wep_facing[index,5]="most";
         obj_ini.ship_wep_condition[index,5]="";
         obj_ini.ship_capacity[index]=600;
@@ -389,6 +389,9 @@ function new_player_ship(type, start_loc="home", new_name=""){
         obj_ini.ship_wep_condition[index,3]="";
         obj_ini.ship_wep[index,4]="Plasma Cannon";
         ship_wep_facing[index,4]="front";
+        obj_ini.ship_wep[index,5]="Macro Bombardment Cannons";
+        obj_ini.ship_wep_facing[index,4]="most";
+        obj_ini.ship_wep_condition[index,4]="";               
         obj_ini.ship_wep_condition[index,4]="";
         obj_ini.ship_capacity[index]=800;
         obj_ini.ship_carrying[index]=0;
@@ -403,6 +406,7 @@ function ship_class_name(index){
 	var _ship_class = obj_ini.ship_class[index];	
 	return $"{_ship_class} '{_ship_name}'";
 }
+
 function player_ships_class(index){
 	var _escorts = ["Escort", "Hunter", "Gladius"];
 	var _capitals = ["Gloriana", "Battle Barge", "Capital"];
@@ -416,4 +420,30 @@ function player_ships_class(index){
 		return "frigate";
 	}
 	return _ship_name_class;
+}
+
+function ship_bombard_score(ship_id){
+	var _bomb_score = 0;
+	static weapon_bomb_scores = {
+		"Bombardment Cannons" : {
+			value : 1,
+		},
+		"Macro Bombardment Cannons" : {
+			value : 2,
+		},
+		"Plasma Cannon" : {
+			value : 4
+		},
+		"Torpedo Tubes" : {
+			value : 1
+		}
+	}
+	for (var b=0;b<array_length(obj_ini.ship_wep[ship_id]);b++){
+		var _wep = obj_ini.ship_wep[ship_id][b];
+		if (struct_exists(weapon_bomb_scores, _wep)){
+			_bomb_score += weapon_bomb_scores[$ _wep].value;
+		}
+	}
+
+	return _bomb_score;	
 }


### PR DESCRIPTION
## Description of changes
- make obj_bomb use variable array lengths in lione with player ship updates
- make functions to determine ship and fleets bombard scores
- make bombard capabilities logged to ship weapons as opposed to ablative
- this means in the furture bombard capabilities of ships can be upgradable or degradeable
## Reasons for changes
- in response to bug report
## Related links
- https://discord.com/channels/714022226810372107/1120687959365128243
## How have you tested your changes?
- [x] Compile
- [x] New game
- [x] Next turn
- [x] Space Travel
- [ ] Ground Battle

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->
