### PR TITLE
feat: Rework and show all specialist potentials

### DIFF
--- a/scripts/scr_draw_management_unit/scr_draw_management_unit.gml
+++ b/scripts/scr_draw_management_unit/scr_draw_management_unit.gml
@@ -8,12 +8,19 @@ function scr_draw_management_unit(selected, yy=0, xx=0, draw=true){
 	jailed = false;
 	var impossible = (!is_struct(display_unit[selected]) && !is_array(display_unit[selected]));
 	var is_man=false;
-	if (draw){
-		var spec_tips = [string("{0} Potential",obj_ini.role[100][16]),		
-						string("{0} Potential",obj_ini.role[100][15]),
-						string("{0} Potential",obj_ini.role[100][14]),
-						string("{0} Potential",obj_ini.role[100][17])];
-	}
+    if (draw) {
+        var spec_tips = [
+            string("{0} Potential", obj_ini.role[100][16]),
+            string("{0} Potential", obj_ini.role[100][15]),
+            string("{0} Potential", obj_ini.role[100][14]),
+            string("{0} Potential", obj_ini.role[100][17]),
+            string("{0} Applicant", obj_ini.role[100][16]),
+            string("{0} Applicant", obj_ini.role[100][15]),
+            string("{0} Applicant", obj_ini.role[100][14]),
+            string("{0} Applicant", obj_ini.role[100][17]),
+            string("Promote to Marine")
+        ];
+    }
     if (man[selected]=="man" && is_struct(display_unit[selected])){
     	is_man = true;
 		unit = display_unit[selected];
@@ -149,27 +156,77 @@ function scr_draw_management_unit(selected, yy=0, xx=0, draw=true){
 		draw_set_color(c_gray);
 		draw_set_alpha(1);
 		draw_rectangle(xx+25,yy+64,xx+974,yy+85,1);
-	    if (man[selected]="man"  && is_struct(display_unit[selected])){
-	    	if (!unit_specialist){
-		        if (unit.technology>=35){
-		        	 //if unit has techmarine potential
-		        	unit_specialism_option=true;
-		        	spec_tip = spec_tips[0];
-		        //if unit has librarian potential
-		    	} else if (unit.psionic>7){
-		    		spec_tip = spec_tips[3];
-		    		unit_specialism_option=true;
-		    	}else if (unit.piety>=35) and (unit.charisma>=30){  //if unit has chaplain potential
-		    		spec_tip = spec_tips[2];
-		    		unit_specialism_option=true;
-		    	}else if (unit.technology>=30) and (unit.intelligence>=45){ //if unit has apothecary potential
-		    		spec_tip = spec_tips[1];
-		    		unit_specialism_option=true;
-		    	}
-	    	}
-		}
-		if (unit_specialism_option) then array_push(potential_tooltip, [spec_tip, [xx+232,yy+64,xx+246,yy+85]]);
-	
+        if (man[selected] == "man" && is_struct(display_unit[selected])) {
+            if (!unit_specialist) {
+                var _role = unit.role();
+                var _experience = unit.experience;
+                var specialistfunct = function(specialist, unit_role, unit_exp, req_exp, spec_tips) {
+                    var tips_list = [0, 0, spec_tips[8]];
+                    var spec_tip;
+                    switch (specialist) {
+                        case "Techmarine":
+                            tips_list[0] = spec_tips[0];
+                            tips_list[1] = spec_tips[4];
+                            break;
+
+                        case "Librarian":
+                            tips_list[0] = spec_tips[3];
+                            tips_list[1] = spec_tips[7];
+                            break;
+
+                        case "Chaplain":
+                            tips_list[0] = spec_tips[2];
+                            tips_list[1] = spec_tips[6];
+                            break;
+
+                        case "Apothecary":
+                            tips_list[0] = spec_tips[1];
+                            tips_list[1] = spec_tips[5];
+                            break;
+                    }
+
+                    if (unit_exp > req_exp) {
+                        if (!(unit_role == obj_ini.role[100][12])) {
+                            spec_tip = tips_list[1];
+                        } else {
+                            spec_tip = tips_list[2];
+                        }
+                    } else {
+                        spec_tip = tips_list[0];
+                    }
+                    return spec_tip;
+                };
+
+                //if unit has techmarine potential
+                if (unit.technology >= 35) {
+                    unit_specialism_option = true;
+                    spec_tip = specialistfunct("Techmarine", _role, _experience, 30, spec_tips);
+                    array_push(potential_tooltip, [spec_tip, [xx + 234 - 3, yy + 76 - 3, xx + 234 + 3, yy + 76 + 4]]);
+                }
+
+                //if unit has librarian potential
+                if (unit.psionic > 7) {
+                    unit_specialism_option = true;
+                    spec_tip = specialistfunct("Librarian", _role, _experience, 30, spec_tips);
+                    array_push(potential_tooltip, [spec_tip, [xx + 234 - 3, yy + 76 - 7 - 3, xx + 234 + 3, yy + 76 - 7 + 4]]);
+                }
+
+                //if unit has chaplain potential
+                if ((unit.piety >= 35) && (unit.charisma >= 30)) {
+                    unit_specialism_option = true;
+                    spec_tip = specialistfunct("Chaplain", _role, _experience, 60, spec_tips);
+                    array_push(potential_tooltip, [spec_tip, [xx + 234 + 7 - 3, yy + 76 - 7 - 3, xx + 234 + 7 + 3, yy + 76 - 7 + 4]]);
+                }
+
+                //if unit has apothecary potential
+                if ((unit.technology >= 30) && (unit.intelligence >= 45)) {
+                    unit_specialism_option = true;
+                    spec_tip = specialistfunct("Apothecary", _role, _experience, 60, spec_tips);
+                    array_push(potential_tooltip, [spec_tip, [xx + 234 + 7 - 3, yy + 76 - 3, xx + 234 + 7 + 3, yy + 76 + 4]]);
+                }
+            }
+        }
+
 	    // Squads
 	    var sqi="";
 	    draw_set_color(c_black);
@@ -236,20 +293,64 @@ function scr_draw_management_unit(selected, yy=0, xx=0, draw=true){
 		}
 		// Draw the health value with the defined colors
 		draw_text_color(hpText[0], hpText[1], hpText[2], hpColor, hpColor, hpColor, hpColor, 1);
-	
-		// Handle potential indication
-		if (unit_specialism_option){
-			if (unit.technology>=35){	//if unit has techmarine potential
-				specialismColors = [c_dkgray, c_red];
-			} else if (unit.psionic>7){	//if unit has librarian potential
-				specialismColors = [c_white, c_aqua];
-			}else if (unit.piety>=35 && unit.charisma>=30){	//if unit has chaplain potential
-				specialismColors = [c_black, c_yellow];
-			}else if (unit.technology>=30 && unit.intelligence>=45){	//if unit has apothecary potential
-				specialismColors = [c_red, c_white];
-			}
-			draw_circle_colour(xx+238, yy+73, 6, specialismColors[0],specialismColors[1], 0);
-		}
+        // Handle potential indication
+        if (unit_specialism_option) {
+            var _role = unit.role();
+            var _experience = unit.experience;
+            var specialistfunct = function(specialist, unit_role, unit_exp, req_exp) {
+                var colors;
+                switch (specialist) {
+                    case "Techmarine":
+                        colors = [c_dkgray, c_red];
+                        break;
+
+                    case "Librarian":
+                        colors = [c_white, c_aqua];
+                        break;
+
+                    case "Chaplain":
+                        colors = [c_black, c_yellow];
+                        break;
+
+                    case "Apothecary":
+                        colors = [c_red, c_white];
+                        break;
+                }
+
+                if (unit_role == obj_ini.role[100][12]) {
+                    colors[0] = c_fuchsia;
+                }
+
+                if (unit_exp < req_exp) {
+                    colors = array_reverse(colors);
+                }
+                return colors;
+            };
+
+            //if unit has techmarine potential
+            if (unit.technology >= 35) {
+                specialismColors = specialistfunct("Techmarine", _role, _experience, 30, specialismColors);
+                draw_circle_colour(xx + 234, yy + 76, 3, specialismColors[0], specialismColors[1], 0);
+            }
+
+            //if unit has librarian potential
+            if (unit.psionic > 7) {
+                specialismColors = specialistfunct("Librarian", _role, _experience, 30, specialismColors);
+                draw_circle_colour(xx + 234, yy + 76 - 7, 3, specialismColors[0], specialismColors[1], 0);
+            }
+
+            //if unit has chaplain potential
+            if (unit.piety >= 35 && unit.charisma >= 30) {
+                specialismColors = specialistfunct("Chaplain", _role, _experience, 60, specialismColors);
+                draw_circle_colour(xx + 234 + 7, yy + 76 - 7, 3, specialismColors[0], specialismColors[1], 0);
+            }
+
+            //if unit has apothecary potential
+            if (unit.technology >= 30 && unit.intelligence >= 45) {
+                specialismColors = specialistfunct("Apothecary", _role, _experience, 60, specialismColors);
+                draw_circle_colour(xx + 234 + 7, yy + 76, 3, specialismColors[0], specialismColors[1], 0);
+            }
+        }
 	
 		// Draw the name
 	    draw_set_color(c_gray);


### PR DESCRIPTION
## Description of changes
- Shows all specialist UI elements, change first color to `c_fuchsia` if scout, reverse colors when under experience requirement and add more `spectips` to show when marine is pickable.
## Reasons for changes
- Marines could be picked for multiple specialist roles but only showed one.
## How have you tested your changes?
- [x] Compile
- [x] New game
- [ ] Next turn
- [ ] Space Travel
- [ ] Ground Battle

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->
