### PR TITLE
fix: index error with roster causing raid/purge issues

### DIFF
--- a/scripts/scr_roster/scr_roster.gml
+++ b/scripts/scr_roster/scr_roster.gml
@@ -344,9 +344,11 @@ function Roster() constructor{
             array_push(company_buttons,_button);
         }
         var _ships = get_player_ships(roster_location);
+        var _ship_index;
         for (var s=0;s<array_length(_ships);s++){
-            if (obj_ini.ship_carrying[s]>0){
-                new_ship_button(obj_ini.ship[_ships[s]],_ships[s]);
+            _ship_index = _ships[s];
+            if (obj_ini.ship_carrying[_ship_index]>0){
+                new_ship_button(obj_ini.ship[_ship_index],_ship_index);
             }
         }
     }


### PR DESCRIPTION
## Description of changes
- After certain turns, your ship may not be able to be selected in the raid/attack/purge, thus you can not start your attack by these method, but only load and unload repeatly
## Reasons for changes
- bug report issue found by user
## Related links
- https://discord.com/channels/714022226810372107/1340995217871999046
## How have you tested your changes?
- [ ] Compile
- [ ] New game
- [ ] Next turn
- [ ] Space Travel
- [ ] Ground Battle

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->
