### PR TITLE
fix: hand flamer

### DIFF
--- a/scripts/scr_weapon/scr_weapon.gml
+++ b/scripts/scr_weapon/scr_weapon.gml
@@ -1367,10 +1367,11 @@ global.weapons = {
 		"melee_hands": 0,
 		"ranged_hands": 1,
 		"ammo": 2,
-		"range": 1.1,
-		"spli": 2,
+		"range": 2.1, // Infernus pistol has 2 range, so
+		"spli": 2, // This should probably be increased to at least 3, but maybe even 5 or 10
 		"arp": -1,
-		"tags": ["pistol", "flame"]
+		"tags": ["pistol", "flame"] //,
+		// "maintenance" : 0.01, - decide on the value you prefer
 	},
 	"Flamer": {
 		"abbreviation": "Flmr",


### PR DESCRIPTION
#### Purpose of the PR
Hand flamer had 1.1 range value, which made it a melee weapon. This PR fixes it to have the same range value as infernus pistol.

#### Describe the solution
Increase a number of a value.

#### Describe alternatives you've considered
Removing hand flamer entirely.
Increasing range values of other pistol weapons.

#### Testing done
- [ ] Compile;
- [ ] Purchase in armamentarium;
- [ ] Combat.

#### Related links
https://discord.com/channels/714022226810372107/1342886304609996870