### PR TITLE
feat: Lower techmarine threshold when at war

### DIFF
--- a/scripts/scr_specialist_training/scr_specialist_training.gml
+++ b/scripts/scr_specialist_training/scr_specialist_training.gml
@@ -318,7 +318,13 @@ function techmarine_training(){
 	if (training_techmarine>0){
 	    recruit_count=scr_role_count(novice_type,"");
 
-	    if (tech_points>=360){
+    if (obj_controller.faction_status[eFACTION.Mechanicus] != "War") {
+        var _threshold = 360
+    } else {
+        var _threshold = 252
+    }
+
+	    if (tech_points>=_threshold){
 	        if (recruit_count>0){
 	            random_marine=scr_random_marine(novice_type,0);
 	            if (random_marine != "none"){


### PR DESCRIPTION
#### Purpose of the PR
Lower Techmarine training threshold when at war with Mechanicus.

#### Why
Cuz less space travel, and maybe expand into tiers or something.

#### Testing done
New game, wait 18-27 turns.

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->
<!--- "Inspired" by the CDDA PR template -->
