### PR TITLE
fix: Unequipping and destroying artifacts causes loop

### DIFF
--- a/scripts/scr_add_artifact/scr_add_artifact.gml
+++ b/scripts/scr_add_artifact/scr_add_artifact.gml
@@ -345,16 +345,16 @@ function ArtifactStruct(Index) constructor{
 			var unit = fetch_unit(bearer);
 			if (_b_type=="weapon"){
 				if (unit.weapon_one(true) == index){
-					unit.update_weapon_one("", false, false);
+					unit.update_weapon_one("", false, true);
 				} else if (unit.weapon_two(true) == index){
-					unit.update_weapon_two("", false, false);
+					unit.update_weapon_two("", false, true);
 				} 
 			} else if (_b_type=="gear"){
-				unit.update_gear("", false, false);
+				unit.update_gear("", false, true);
 			} else if (_b_type=="armour"){
-				unit.update_armour("", false, false);
+				unit.update_armour("", false, true);
 			} else if (_b_type=="mobility"){
-				unit.update_mobility_item("", false, false);
+				unit.update_mobility_item("", false, true);
 			}
 			bearer = false;
 			obj_ini.artifact_equipped[index] = false;
@@ -368,10 +368,10 @@ function ArtifactStruct(Index) constructor{
 					for (var i=0;i<array_length(obj_ini.role[co]);i++){
 						_unit = fetch_unit([co,i]);
 						if (_unit.weapon_one(true) == index){
-							_unit.update_weapon_one("", false, false);
+							_unit.update_weapon_one("", false, true);
 							_bearer_found = true
 						} else if (_unit.weapon_two(true) == index){
-							_unit.update_weapon_two("", false, false);
+							_unit.update_weapon_two("", false, true);
 							_bearer_found = true
 						}
 						if (_bearer_found){
@@ -399,7 +399,7 @@ function ArtifactStruct(Index) constructor{
 						for (var i=0;i<array_length(obj_ini.role[co]);i++){
 							var _unit = fetch_unit([co,i]);
 							if (_unit[$_find_function](true) == index){
-								_unit[$_update_function]("", false, false);
+								_unit[$_update_function]("", false, true);
 								_bearer_found = true
 							}
 							if (_bearer_found){

--- a/scripts/scr_unit_equip_functions/scr_unit_equip_functions.gml
+++ b/scripts/scr_unit_equip_functions/scr_unit_equip_functions.gml
@@ -77,7 +77,7 @@ function scr_update_unit_armour(new_armour, from_armoury=true, to_armoury=true, 
 				}
 			} else {
 				if (!is_string(armour(true))){
-					delete_artifact(armour(true));
+					delete_artifact(armour(true)); // This code path along with the other functions causes a feedback loop as delete_artifact calls unequip_from_unit which calls all functions in this file
 				}
 			}
 		}


### PR DESCRIPTION
#### Purpose of the PR
Fix unequipping or destroying artifacts that are equipped from causing a feedback loop.

#### Describe the solution
Sets the third argument in all functions to true.

#### Testing done
Load game, unequip or destroy a equipped artifact, check marine.

#### Related links
https://discord.com/channels/714022226810372107/1343963760494383117

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->
<!--- "Inspired" by the CDDA PR template -->
