### PR TITLE
fix: Move Retinue of Renown to modern syntax

### DIFF
--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -2484,12 +2484,7 @@ function scr_initialize_custom() {
 
 	// Honour Guard
 	var _honour_guard_count = 0, unit;
-	o = 0;
-	chapter_option = 0;
-	repeat(4) {
-		o += 1;
-		if (obj_creation.adv[o] = "Retinue of Renown") then chapter_option = 1;
-	}
+    chapter_option = scr_has_adv("Retinue of Renown");
 	if (chapter_option = 1) then _honour_guard_count += 10;
 	if (progenitor == ePROGENITOR.DARK_ANGELS && obj_creation.custom = 0) { _honour_guard_count += 6; }
 	if (_honour_guard_count == 0) {


### PR DESCRIPTION
#### Purpose of the PR
Make "Retinue of Renown" work in slots larger than slot 4
#### Describe the solution
move to modern syntax using scr_has_adv


#### Testing done
load game select Retinue of Renown in slot 5 or larger

#### Related links
<!--- Other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
https://discord.com/channels/714022226810372107/1343967977665728604

