### PR TITLE
feat: Obliterated disadvantage edits

### DIFF
--- a/objects/obj_controller/Create_0.gml
+++ b/objects/obj_controller/Create_0.gml
@@ -1461,7 +1461,7 @@ loyalty_hidden=100;// Updated when inquisitors do an inspection
 // ** Sets up gene seed **
 gene_seed=20;
 if scr_has_disadv("Sieged") then gene_seed=floor(random_range(250,400));
-if scr_has_disadv("Obliterated") then gene_seed=floor(random_range(50,200));
+if scr_has_disadv("Obliterated") then gene_seed=floor(random_range(300,500));
 if scr_has_disadv("Serpents Delight") then gene_seed=floor(random_range(50,250)); 
 if scr_has_disadv("Enduring Angels") then gene_seed=floor(random_range(50,250)); 
 if (global.chapter_name=="Lamenters") then gene_seed=30;

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -3229,11 +3229,14 @@ function scr_initialize_custom() {
 	}
 	
 	if(scr_has_disadv("Sieged")){
+		scr_add_item("Servo-arm", 4);
+		scr_add_item(wep1[defaults_slot, eROLE.Techmarine], 4);
+		scr_add_item(wep2[defaults_slot,  eROLE.Techmarine], 4);
 		scr_add_item("Narthecium", 4);
 		scr_add_item(wep1[defaults_slot, eROLE.Apothecary], 4);
 		scr_add_item(wep2[defaults_slot,  eROLE.Apothecary], 4);
 		scr_add_item("Psychic Hood", 4);
-		scr_add_item("Force Staff", 4);
+		scr_add_item("Force Staff", 4); // These more or less cover the librarians
 		scr_add_item("Plasma Pistol", 4);
 		scr_add_item("Company Standard", 4);
 
@@ -3252,6 +3255,8 @@ function scr_initialize_custom() {
 		scr_add_item("Lascannon", 40);
 		scr_add_item("Power Sword", 12);
 		scr_add_item("Rosarius", 4);
+		scr_add_item(wep1[defaults_slot, eROLE.Chaplain], 4);
+		scr_add_item(wep2[defaults_slot,  eROLE.Chaplain], 4); // With Crozius arcanum added, we want to add these
 	}
 	if (!scr_has_disadv("Sieged")) {
 		scr_add_item("Dreadnought", 6);
@@ -3260,6 +3265,34 @@ function scr_initialize_custom() {
 	if (scr_has_adv("Venerable Ancients")) {
 		scr_add_item("Dreadnought", 4);
 		scr_add_item("Close Combat Weapon", 4);
+	}
+
+	if(scr_has_disadv("Obliterated")){
+		scr_add_item("Servo-arm", 5);
+		scr_add_item(wep1[defaults_slot, eROLE.Techmarine], 5);
+		scr_add_item(wep2[defaults_slot,  eROLE.Techmarine], 5);
+		scr_add_item("Narthecium", 5);
+		scr_add_item(wep1[defaults_slot, eROLE.Apothecary], 5);
+		scr_add_item(wep2[defaults_slot,  eROLE.Apothecary], 5);
+		scr_add_item("Psychic Hood", 5);
+		scr_add_item("Force Staff", 5); // These more or less cover the librarians
+		scr_add_item("Plasma Pistol", 5);
+		scr_add_item("Company Standard", 5);
+
+		// Pretend that if crafters, terminator armor gets lost/stolen?
+
+		scr_add_item("MK7 Aquila", 200);
+		scr_add_item("Scout Armour", 100);
+		scr_add_item("Bolter", 200);
+		scr_add_item("Chainsword", 200);
+		scr_add_item("Jump Pack", 100);
+		scr_add_item("Bolt Pistol", 100);
+		scr_add_item("Heavy Bolter", 50);
+		scr_add_item("Lascannon", 50);
+		scr_add_item("Power Sword", 15);
+		scr_add_item("Rosarius", 5);
+		scr_add_item(wep1[defaults_slot, eROLE.Chaplain], 5);
+		scr_add_item(wep2[defaults_slot,  eROLE.Chaplain], 5); // With crozius arcanum added, we want to add these
 	}
 
 	// man_size+=80;// bikes


### PR DESCRIPTION
#### Purpose of the PR
`Sieged` disadvantage provides high stock of spare equipment and gene-seed on game start.
`Obliterated` disadvantage however, does not. This PR focuses on addressing this.

#### Describe the solution
Copy, paste and modify lines of code from `sieged` to `obliterated`.
Also tweak the current `sieged` disadvantage to also include techmarine and chaplain equipment.
Implementing this ensures that `obliterated` disadvantage properly becomes a more extreme version of `sieged`.

#### Describe alternatives you've considered
Create more advantages/disadvantages covering more situations and circumstances of player's starting situation in the game, such as:
Add a `depleted armamentarium` disadvantage which lowers or removes the additional starting equipment associated with `sieged` and now possibly `obliterated`.
Add a `depleted gene-seed stocks` disadvantage which lowers or removes the additional starting gene-seed associated with `sieged` and `obliterated`.

#### Testing done
- [x] Compilation;
- [x] Chapter Creation;
- [x] Armamentarium visit;
- [x] Passing a turn.

#### Related links
https://discord.com/channels/714022226810372107/1272865272159535114/1344229545875738697

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Adjusted in-game mechanics so that challenges involving the "Obliterated" disadvantage now yield a heightened effect, influencing outcomes.
  - Expanded equipment allocation to provide additional specialized items when players face the "Sieged" or "Obliterated" conditions, enhancing tactical options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->