### PR TITLE
fix: force exit combat when enter is pressed with 0 enemies

### DIFF
--- a/objects/obj_ncombat/Create_0.gml
+++ b/objects/obj_ncombat/Create_0.gml
@@ -15,6 +15,7 @@ if (nope!=1){audio_sound_gain(snd_battle,0.25*obj_controller.master_volume*obj_c
 
 
 //limit on the size of the players forces allowed
+enter_pressed = 0
 man_size_limit = 0;
 man_limit_reached = false;
 man_size_count = 0;

--- a/objects/obj_ncombat/KeyPress_13.gml
+++ b/objects/obj_ncombat/KeyPress_13.gml
@@ -15,7 +15,9 @@ if __b__
 // 135;
 // instance_activate_object(obj_cursor);
 
-
+if (enemy_forces<=0) { // Combat for whatever reason sometimes bugs out when there are no enemies, so if enter is pressed 6 times at this state it will set started to 2
+    enter_pressed++
+}
 
 if (started>=2) then instance_activate_object(obj_pnunit);
 
@@ -38,7 +40,7 @@ if (started=3){
 
 
 
-if (turn_count >= 50){
+if (turn_count >= 50 || enter_pressed > 5) {
     started=2;
 }
 if ((started=2) or (started=4)){


### PR DESCRIPTION
#### Purpose of the PR
Prevent a softlock when there are no enemies and state hasn't properly shifted.

#### Describe the solution
When enter is pressed 6 times when there are no enemies it will set `started` to `2`.

#### Testing done
Get into state, press enter 6 times.

#### Related links
https://discord.com/channels/714022226810372107/1304941011893747862
