### PR TITLE
fix: Wrong case search

### DIFF
--- a/objects/obj_event/Step_0.gml
+++ b/objects/obj_event/Step_0.gml
@@ -321,10 +321,10 @@ if (ticked=1){// Select a random marine and have them perform an action
         
         
         if (attend_corrupted[ide]=0){
-            if (array_contains(obj_ini.artifact_tags[obj_controller.fest_display], "Chaos")){
+            if (array_contains(obj_ini.artifact_tags[obj_controller.fest_display], "chaos")){
                 unit.corruption+=choose(1,2,3,4);
             }
-            if (array_contains(obj_ini.artifact_tags[obj_controller.fest_display], "Daemon")){
+            if (array_contains(obj_ini.artifact_tags[obj_controller.fest_display], "daemonic")){
                 unit.corruption+=choose(6,7,8,9);
             }
             attend_corrupted[ide]=1;

--- a/objects/obj_popup/Draw_0.gml
+++ b/objects/obj_popup/Draw_0.gml
@@ -932,7 +932,7 @@ try {
 					}
 
 					unit = obj_ini.TTRPG[target_comp][obj_controller.ide[i]];
-					if (arti.has_tag("Daemonic") || arti.has_tag("Chaos")) {
+					if (arti.has_tag("daemonic") || arti.has_tag("chaos")) {
 						unit.corruption += irandom(10 + 2);
 						if (unit.role() == "Chapter Master") {
 							dwarn = true;

--- a/objects/obj_popup/Step_0.gml
+++ b/objects/obj_popup/Step_0.gml
@@ -403,10 +403,10 @@ try {
 					repeat (700) {
 						ide += 1;
 						if ((attend_corrupted[ide] == 0) && (attend_id[ide] > 0)) {
-							if (string_count("Chaos", obj_ini.artifact_tags[obj_controller.fest_display]) > 0) {
+							if (string_count("chaos", obj_ini.artifact_tags[obj_controller.fest_display]) > 0) {
 								obj_ini.TTRPG[attend_co[ide], attend_id[ide]].corruption += choose(1, 2, 3, 4);
 							}
-							if (string_count("Daem", obj_ini.artifact_tags[obj_controller.fest_display]) > 0) {
+							if (string_count("daemonic", obj_ini.artifact_tags[obj_controller.fest_display]) > 0) {
 								obj_ini.TTRPG[attend_co[ide], attend_id[ide]].corruption += choose(6, 7, 8, 9);
 							}
 							attend_corrupted[ide] = 1;

--- a/scripts/scr_arti_descr/scr_arti_descr.gml
+++ b/scripts/scr_arti_descr/scr_arti_descr.gml
@@ -145,8 +145,8 @@ function scr_arti_descr() {
 	}
 
 	if (has_tag("MINOR")){other_data+="It is more crude and utilitarian than one might expect from an artifact.";}
-	if (has_tag("Chaos")){p4="It bears the taint of Chaos.";}
-	if (has_tag("Daemonic")){p4="It is infested with a Daemonic entity.";}
+	if (has_tag("chaos")){p4="It bears the taint of Chaos.";}
+	if (has_tag("daemonic")){p4="It is infested with a Daemonic entity.";}
 
 	final_description+=mission_data;
 	if (basic_asthetic!="") then final_description+=$"  {basic_asthetic}";


### PR DESCRIPTION
#### Purpose of the PR
Chaos and daemonic artifacts tags are lowercased, some checks search for uppercase.

#### Describe the solution
Lowercase checks.

#### Testing done
Scuff Space Hulk code, Load game, raid Space Hulk, get Chaos artifact.

#### Related links
https://discord.com/channels/714022226810372107/1121959429546455050/1344716240270131261

Daemonic artifacts will still be broken as the code appends random bits to the tag.
<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->
<!--- "Inspired" by the CDDA PR template -->
