### PR TITLE
feat: Add "Depleted Gene-seed Stocks" disadvantage

### DIFF
--- a/objects/obj_controller/Create_0.gml
+++ b/objects/obj_controller/Create_0.gml
@@ -1465,6 +1465,7 @@ if scr_has_disadv("Sieged") then gene_seed=floor(random_range(250,400));
 if scr_has_disadv("Obliterated") then gene_seed=floor(random_range(50,200));
 if scr_has_disadv("Serpents Delight") then gene_seed=floor(random_range(50,250)); 
 if scr_has_disadv("Enduring Angels") then gene_seed=floor(random_range(50,250)); 
+if scr_has_disadv("Depleted Gene-seed Stocks") then gene_seed=0;
 if (global.chapter_name=="Lamenters") then gene_seed=30;
 if (global.chapter_name=="Soul Drinkers") then gene_seed=60;
 

--- a/objects/obj_creation/Create_0.gml
+++ b/objects/obj_creation/Create_0.gml
@@ -876,6 +876,11 @@ var all_disadvantages = [
         value : 50,
     },
     {
+        name : "Depleted Gene-seed Stocks",
+        description : "Your chapter has lost it's gene-seed stocks in recent engagement. You start with no gene-seed.",
+        value : 20,
+    },
+    {
         name : "Fresh Blood",
         description : "Due to being newly created your chapter has little special wargear or psykers.",
         value : 30,


### PR DESCRIPTION
#### Purpose of the PR
Adds a new disadvantage option for custom chapters

#### Describe the solution
Makes the created chapters start with no gene-seed.

#### Describe alternatives you've considered
Add another trait, which divides the starting gene-seed by half.

#### Testing done
- [ ] Compilation;
- [ ] Chapter creation;
- [ ] Making to the game;
- [ ] Ending a turn.

#### Related links
Tied to #519 and #521 .