### PR TITLE
feat: Adds Depleted Armamentarium Stocks trait

### DIFF
--- a/objects/obj_creation/Create_0.gml
+++ b/objects/obj_creation/Create_0.gml
@@ -880,6 +880,11 @@ var all_disadvantages = [
         value : 50,
     },
     {
+        name : "Depleted Armamentarium Stocks",
+        description : "Your chapter has lost its equipment stocks in recent engagement.",
+        value : 10,
+    },
+    {
         name : "Fresh Blood",
         description : "Due to being newly created your chapter has little special wargear or psykers.",
         value : 30,

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -3229,6 +3229,8 @@ function scr_initialize_custom() {
 		}
 	}
 	
+	// I need advice on how to implement "Depleted Armamentarium Stocks" properly
+	
 	if(scr_has_disadv("Sieged")){
 		scr_add_item("Narthecium", 4);
 		scr_add_item(wep1[defaults_slot, eROLE.Apothecary], 4);


### PR DESCRIPTION
#### Purpose of the PR
Adds Depleted Armamentarium Stocks disadvantage option for custom chapters.

#### Describe the solution
Makes the created custom chapters spawn with no equipment in stock.

#### Describe alternatives you've considered
Due to value of this trait, no easy alternatives are seen.
Adding another trait which halves the starting equipment may be an option, but this requires reviewing the trait costs.

#### Testing done
- [ ] Compilation;
- [ ] Chapter Creation;
- [ ] Making to the game;
- [ ] Ending a turn.

#### Related links
Part of #521 and #519 .