### PR TITLE
feat: "Lost Fleet" disadvantage

### DIFF
--- a/objects/obj_creation/Create_0.gml
+++ b/objects/obj_creation/Create_0.gml
@@ -886,6 +886,12 @@ var all_disadvantages = [
         meta : ["Status"],
     }, 
     {
+        name : "Lost Fleet",
+        description : "Your chapter has seen most of it's fleet lost during a recent engagement.",
+        value : 30,
+        meta : ["Naval"],
+    },
+    {
         name : "Never Forgive",
         description : "In the past traitors broke off from your chapter.  They harbor incriminating secrets or heritical beliefs, and as thus, must be hunted down whenever possible.",
         value : 15,

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -726,7 +726,7 @@ function scr_initialize_custom() {
 
 	if (scr_has_adv ("Kings of Space")) {battle_barges += 1;}
 	if (scr_has_adv("Boarders")){ strike_cruisers += 2;}
-	if (scr_has_disadv("Obliterated")) {battle_barges = 0; strike_cruisers = 1; gladius = 2; hunters = 0;}
+	if (scr_has_disadv("Lost Fleet")) {battle_barges = 0; strike_cruisers = 1; gladius = 2; hunters = 0;}
 
 	var ship_summary_str = $"Ships: bb: {battle_barges} sc: {strike_cruisers} g: {gladius} h: {hunters}"
 	// log_message(ship_summary_str);


### PR DESCRIPTION
#### Purpose of the PR
Make `obliterated` disadvantage more viable by creating a separate trait governing the starting status of the chapter's fleet.

#### Describe the solution
Replace the `Obliterated` with `Lost Fleet` in relevant checks.

#### Describe alternatives you've considered
Make the trait subtract from the starting pool of ships, instead of determining the starting amount of ships.

#### Testing done
- [x] Compilation;
- [x] Chapter creation;
- [x] Making to the game;
- [x] Ending a turn.

#### Related links
Related to #519 and #521 .