### PR TITLE
fix: Damage taken when boarding

### DIFF
--- a/objects/obj_p_assra/Step_0.gml
+++ b/objects/obj_p_assra/Step_0.gml
@@ -284,8 +284,8 @@ if (boarding=true) and (board_cooldown>=0) and (instance_exists(target)) and (in
                 
                     
                     // End, do the damage
-                    if (arp=1) then hurt=max(0,attack*dr);
-                    if (arp=0) then hurt=max(0,(attack-ac)*dr);
+                    if (arp=1) then hurt=max(0,attack*(1-dr));
+                    if (arp=0) then hurt=max(0,(attack-ac)*(1-dr));
                     
                     repeat(hits){
                         unit.add_or_sub_health(-hurt);


### PR DESCRIPTION
#### Purpose of the PR
Units with higher damage resistance used to take higher damage.

#### Describe the solution
Corrected damage calculation logic to properly handle damage resistance.

#### Describe alternatives you've considered

#### Testing done

#### Related links
