### PR TITLE
feat: Obliterated Buff

### DIFF
--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -726,8 +726,18 @@ function scr_initialize_custom() {
 
 	if (scr_has_adv ("Kings of Space")) {battle_barges += 1;}
 	if (scr_has_adv("Boarders")){ strike_cruisers += 2;}
-	if (scr_has_disadv("Obliterated")) {battle_barges = 0; strike_cruisers = 1; gladius = 2; hunters = 0;}
-
+	if (scr_has_disadv("Obliterated")){ if (obj_creation.fleet_type == ePlayerBase.home_world) {
+		battle_barges = 0;
+		strike_cruisers = 2;
+		gladius = 1;
+		hunters = 0;
+		} else {
+		battle_barges = 1;
+		strike_cruisers = 0;
+		gladius = 2;
+		hunters = 0;
+		}
+	}
 	var ship_summary_str = $"Ships: bb: {battle_barges} sc: {strike_cruisers} g: {gladius} h: {hunters}"
 	// log_message(ship_summary_str);
 	// show_debug_message(ship_summary_str);
@@ -1019,7 +1029,7 @@ function scr_initialize_custom() {
 	if (obj_creation.custom != 0) {
 		var bonus_marines = 0;
 		if (obj_creation.strength > 5) then bonus_marines = (obj_creation.strength - 5) * 50;
-		if scr_has_disadv("Obliterated") then bonus_marines = (obj_creation.strength - 5) * 10;
+		if scr_has_disadv("Obliterated") then bonus_marines = (obj_creation.strength - 1) * 10;
 		var i = 0;
 		while (bonus_marines >= 5) {
 			switch (i % 10) {


### PR DESCRIPTION


#### Purpose of changes
<!-- With a few sentences, describe your reasons for making these changes. -->
Address glaring issues with the Obliterated disadvantage that made Fleet-Based chapters suboptimal when compared to Homeworld counterparts, additionally adjusted fleet composition for Homeworld chapters.

#### Describe the solution
<!-- How does the feature work, or how does this fix a bug? -->
Added an else statement to the if statement for Obliterated that properly checks if a chapter is Homeworld based or not and changes the Fleet composition.

#### Describe alternatives you've considered
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
None

#### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
Compiled, new game with Str 1 and fleet based , new game with Str 2 and Homeworld based.

#### Player notes
<!-- This will be added to the PR description in the release notes. List changes that players may be interested in, in simple words. -->
Obliterated buff as discussed and decided in the "Obliterated Chapter rework" thread started by Werwolf

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->
<!--- "Inspired" by the CDDA PR template -->
