### PR TITLE
feat: Trait Removal

### DIFF
--- a/objects/obj_controller/Create_0.gml
+++ b/objects/obj_controller/Create_0.gml
@@ -1464,8 +1464,6 @@ gene_seed=20;
 if scr_has_disadv("Sieged") then gene_seed=floor(random_range(250,400));
 if scr_has_disadv("Obliterated") then gene_seed=floor(random_range(50,200));
 if scr_has_disadv("Serpents Delight") then gene_seed=floor(random_range(50,250)); 
-if scr_has_disadv("Enduring Angels") then gene_seed=floor(random_range(50,250)); 
-if scr_has_disadv("Depleted Gene-seed Stocks") then gene_seed=0;
 if (global.chapter_name=="Lamenters") then gene_seed=30;
 if (global.chapter_name=="Soul Drinkers") then gene_seed=60;
 

--- a/objects/obj_creation/Create_0.gml
+++ b/objects/obj_creation/Create_0.gml
@@ -880,11 +880,6 @@ var all_disadvantages = [
         value : 50,
     },
     {
-        name : "Depleted Gene-seed Stocks",
-        description : "Your chapter has lost its gene-seed stocks in recent engagement. You start with no gene-seed.",
-        value : 20,
-    },
-    {
         name : "Fresh Blood",
         description : "Due to being newly created your chapter has little special wargear or psykers.",
         value : 30,
@@ -951,12 +946,6 @@ var all_disadvantages = [
         description : "Whether due to being cut off from forge worlds or bad luck, your chapter no longer has enough high quality gear to go around. Your elite troops will have to make do with standard armour.",
         value: 10,
         meta : ["Gear Quality"]
-    },
-    {
-        name : "Enduring Angels",
-        description : "The Chapter's journey thus far has been arduous & unforgiving leaving them severely understrength yet not out of the fight. You begin with 5 fewer company's",
-        value : 50,
-        meta : ["Status"],
     },
     {
         name : "Serpents Delight",


### PR DESCRIPTION
#### Purpose of changes
After discussing that certain traits do not have weight in the game and that there already are traits that function in a similar way, a simple and straightforward solution is to remove them.

#### Describe the solution
Remove traits.

#### Describe alternatives you've considered
Upgrade chapter customization options with a larger scale rework of chapter creation screen.

#### Testing done
- [ ] Compilation;
- [ ] Making to the game;
- [ ] Ending a turn.

#### Related links
#491 and #527 .

#### Player notes
Remove `Depleted Gene-seed stocks` and `Enduring Angels`. `Sieged` already does what the EA was doing.