### PR TITLE
fix: Disposition change related to fortification

### DIFF
--- a/scripts/scr_PlanetData/scr_PlanetData.gml
+++ b/scripts/scr_PlanetData/scr_PlanetData.gml
@@ -456,7 +456,7 @@ function PlanetData(planet, system) constructor{
         draw_rectangle(xx+349,yy+175,xx+717,yy+192,1);
         draw_set_color(c_white);
         
-        var player_dispo = player_disposition;
+        var player_dispo = system.dispo[planet];
         if (!_succession){
             if (player_dispo>=0) and (origional_owner<=5) and (current_owner<=5) and (population>0) then draw_text(xx+534,yy+176,"Disposition: "+string(min(100,player_dispo))+"/100");
             if (player_dispo>-30) and (player_dispo<0) and (current_owner<=5) and (population>0){
@@ -573,8 +573,8 @@ function PlanetData(planet, system) constructor{
                         obj_controller.requisition-=improve_cost;
                         alter_fortification(1);
                         
-                        if (player_disposition>0) and (player_disposition<=100){
-                            player_disposition=min(100,player_disposition+(9-fortification_level));
+                        if (system.dispo[planet]>0) and (system.dispo[planet]<=100){
+                            system.dispo[planet]=min(100,system.dispo[planet]+(9-fortification_level));
                         }
                     }
                     


### PR DESCRIPTION
#### Purpose of changes
<!-- With a few sentences, describe your reasons for making these changes. -->
Fortifying a planet increases the planet's disposition, but the increase isn't carried into the next turn.
#### Describe the solution
<!-- How does the feature work, or how does this fix a bug? -->
The change wasn't added to planet disposition, but instead to "player_disposition" which was reset every time.

#### Describe alternatives you've considered
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
None

#### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
Success in multiple new games.
#### Related links
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
None

#### Player notes
<!-- This will be added to the PR description in the release notes. List changes that players may be interested in, in simple words. -->
None

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->
<!--- "Inspired" by the CDDA PR template -->
