### PR TITLE
fix: Gift faction buttons disposition display

### DIFF
--- a/objects/obj_popup/Draw_0.gml
+++ b/objects/obj_popup/Draw_0.gml
@@ -65,9 +65,9 @@ try {
 				draw_set_alpha(1);
 			}
 			spacer = iter * 40;
-			ch = obj_controller.disposition[i] > 0 ? "+" : "-";
+			ch = obj_controller.disposition[i] > 0 ? "+" : "";
 			if (obj_controller.known[i] > 1) {
-				draw_text(xx + 740, yy + 140 + spacer, $"{scr_faction_string_name(i)} ({ch}{obj_controller.disposition[2]})");
+				draw_text(xx + 740, yy + 140 + spacer, $"{scr_faction_string_name(i)} ({ch}{obj_controller.disposition[i]})");
 				// draw_text(xx+740,yy+140+spacer,$"{obj_controller.faction_title[i]}");
 				iter++;
 			} else {


### PR DESCRIPTION
#### Purpose of changes
<!-- With a few sentences, describe your reasons for making these changes. -->
Fix the same disposition value displaying for all gift destination faction buttons.

#### Describe the solution
<!-- How does the feature work, or how does this fix a bug? -->
Fixes a typo that used `2`, instead of the loop variable `i`.

#### Describe alternatives you've considered
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
None

#### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
Checked this in the game.

#### Related links
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
None

#### Player notes
<!-- This will be added to the PR description in the release notes. List changes that players may be interested in, in simple words. -->
Faction disposition value on gift buttons is no longer broken.

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->
<!--- "Inspired" by the CDDA PR template -->
