### PR TITLE
fix: Stop Soul Drinkers from using custom squad names

### DIFF
--- a/datafiles/main/chapters/16.JSON
+++ b/datafiles/main/chapters/16.JSON
@@ -206,31 +206,7 @@
         * `custom_roles` should be used for specialist/leadership type roles, 
         * To affect an entire squad, see `custom_squads` below
         */
-        "custom_roles": {
-            "terminator": {
-                "name": "Red Brother"
-            },
-            "captain": {
-                "name": "Company Master",
-                "wep1": "Eviscerator"
-            },
-            "veteran_sergeant": {
-                "name": "Veteran Strike Leader",
-                "wep1": "Power Axe"
-            },
-            "tactical": {
-                "name": "Void Brother",
-                "wep2": "Chainaxe"
-            },
-            "assault": {
-                "name": "Devourer",
-                "wep1": "Chainaxe"
-            },
-            "sergeant": {
-                "name": "Strike Leader",
-                "wep1": "Chainaxe"
-            }
-        },
+
         /**
         * * Custom squad roles, loadouts and formations
         * When companies are made, squads are formed based on these rules: 


### PR DESCRIPTION
#### Purpose of changes
<!-- With a few sentences, describe your reasons for making these changes. -->
Stop Soul Drinkers from using custom squad names, as I couldn't find any references to them using them. I'm not sure if that's a typo.

#### Describe the solution
<!-- How does the feature work, or how does this fix a bug? -->
Removed custom squad names from their json file.

#### Describe alternatives you've considered
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
None

#### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
New game as Soul Drinkers.

#### Related links
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
None

#### Player notes
<!-- This will be added to the PR description in the release notes. List changes that players may be interested in, in simple words. -->
Soul Drinkers will use default squad names.

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->
<!--- "Inspired" by the CDDA PR template -->
