### PR TITLE
fix: Saved chapters are properly marked custom

### DIFF
--- a/scripts/scr_chapter_new/scr_chapter_new.gml
+++ b/scripts/scr_chapter_new/scr_chapter_new.gml
@@ -214,7 +214,7 @@ function scr_chapter_new(argument0) {
 	world_feature = array_create(20, "");
 	
 
-	points=100;maxpoints=100;custom=0;
+	points=100;maxpoints=100;
 	
 	function load_default_gear(_role_id, _role_name, _wep1, _wep2, _armour, _mobi, _gear){
 		for(var i = 100; i <=102; i++){

--- a/scripts/scr_chapter_random/scr_chapter_random.gml
+++ b/scripts/scr_chapter_random/scr_chapter_random.gml
@@ -88,7 +88,7 @@ function scr_chapter_random(argument0) {
 	    cooperation=choose(2,3,4,5,6,7,8);if (stability<5) then cooperation+=2;
 	    founding=10;found_secret=floor(random(10))+1;
     
-	    custom=1;points=100;maxpoints=100;
+	    points=100;maxpoints=100;
 	    battle_cry="For the Emperor";
     
 	    discipline=choose("default","default","default","default","biomancy","pyromancy","telekinesis");

--- a/scripts/scr_creation_draw_slides/scr_creation_draw_slides.gml
+++ b/scripts/scr_creation_draw_slides/scr_creation_draw_slides.gml
@@ -232,6 +232,7 @@ function draw_chapter_select(){
 					global.chapter_id = chap.id;
 					change_slide = 1;
 					goto_slide = 2;
+					custom = 2;
 					scr_chapter_new(chap.id);
 				} else {
 					global.chapter_id = chap.id;
@@ -299,7 +300,7 @@ function draw_chapter_select(){
 	grid.new_cell();
 
 	i = 1001;
-	repeat (2) {
+    for (var c = 1001; c < 1003; c++) {
 		grid.new_cell();
 
 		draw_sprite(spr_creation_icon, 0, grid.x1, grid.y1);
@@ -321,12 +322,12 @@ function draw_chapter_select(){
 				icon_name = "da";
 				change_slide = 1;
 				goto_slide = 2;
-				if (i == 1001) {
-					custom = 2;
+				if (c == 1001) {
+                    custom = 2;
 					scr_chapter_random(0);
 				}
-				if (i == 1002) {
-					custom = 1;
+				if (c == 1002) {
+                    custom = 1;
 					scr_chapter_random(1);
 				}
 			}


### PR DESCRIPTION
#### Purpose of changes
Mark saved chapters properly.

#### Describe the solution
By removing overwriting variables.

#### Testing done
New game.

#### Related links
https://discord.com/channels/714022226810372107/1272865272159535114/1346740600476798987

#### Player notes
This also restores random and has a side effect of being able to edit saved custom chapters, i don't know if this was intended.

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->
<!--- "Inspired" by the CDDA PR template -->
