### PR TITLE
fix: Bike integrated bolter addition

### DIFF
--- a/scripts/scr_weapon/scr_weapon.gml
+++ b/scripts/scr_weapon/scr_weapon.gml
@@ -2448,6 +2448,7 @@ global.gear = {
 		"Bike": {
 			"abbreviation": "Bike",
 			"special_properties": ["Integrated Twin Linked-Bolters"],
+			"second_profiles": ["Twin Linked Bolters"],
 			"description": "A robust bike that can propel an Astartes at very high speeds. Boasts highly responsive controls that allow for fluid movement on the battlefield and and respectable Twin-Linked Bolters for offensive action.",
 			"hp_mod": {
 				"standard": 25,


### PR DESCRIPTION


#### Purpose of changes
<!-- With a few sentences, describe your reasons for making these changes. -->
Make bikes properly reflect their extra weapons

#### Describe the solution
<!-- How does the feature work, or how does this fix a bug? -->
Adds twin-linked bolters as a second profile to bikes.

#### Describe alternatives you've considered
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
None

#### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
Compile, Combat

#### Related links
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
None

#### Player notes
<!-- This will be added to the PR description in the release notes. List changes that players may be interested in, in simple words. -->
Bikes now actually have twin linked bolters.

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->
<!--- "Inspired" by the CDDA PR template -->
