### PR TITLE
fix: Power Armour tag stripping hirelings

### DIFF
--- a/scripts/scr_weapon/scr_weapon.gml
+++ b/scripts/scr_weapon/scr_weapon.gml
@@ -2241,7 +2241,6 @@ global.gear = {
 				"master_crafted": 5,
 				"artifact": 10
 			},
-			"tags": ["power_armour"],
 		},
 	// Sororitas and other imperials
 		"Light Power Armour": { // According to lore, lack of black carapace makes regular humans less capable to use PAs properly, but this is a concern for the future
@@ -2262,7 +2261,6 @@ global.gear = {
 				"artifact": 10
 			},
 			"description": "A suit of light power armour, intended to be useable by the regular humans.",
-			"tags": ["power_armour"],
 		},
 	// Eldar
 		"Ranger Armour":{


### PR DESCRIPTION
#### Purpose of changes
<!-- With a few sentences, describe your reasons for making these changes. -->
- Sisters and Tech Priests were not getting their PA because of the "power_armour" tag requiring black carapace to use.

#### Describe the solution
<!-- How does the feature work, or how does this fix a bug? -->
- Remove the tag from the hireling armor.

#### Describe alternatives you've considered
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
- Adjust the tag check, to include edge cases. Don't want to bother.
- Add a new tag, just for armor that doesn't need the carapace. I don't know about this.
- Add a separate tag "black_carapace" to signify that an armor requires it and lower stats if the unit doesn't have it.

#### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
Started new game, spawned some hirelings with cheats.

#### Related links
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
https://discord.com/channels/714022226810372107/714023282780799028/1347281774438256790

#### Player notes
<!-- This will be added to the PR description in the release notes. List changes that players may be interested in, in simple words. -->
Sisters and Tech Priests got their armor back.

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->
<!--- "Inspired" by the CDDA PR template -->
