### PR TITLE
fix: Reclusium goes beyond 11

### DIFF
--- a/objects/obj_controller/Alarm_5.gml
+++ b/objects/obj_controller/Alarm_5.gml
@@ -251,9 +251,9 @@ if (gene_xeno>0){
     }
 }
 var p=0,penitorium=0, unit;
-for(var c=0; c<11; c++){
-    for(var e=1; e<=array_length(obj_ini.god); e++){
-        if (obj_ini.god[c,e]>=10){
+for (var c = 0; c < 11; c++){
+    for (var e = 0; e < array_length(obj_ini.god[c]); e++){
+        if (obj_ini.god[c][e] == 10){
             unit=fetch_unit([c,e]);
             p+=1;
             penit_co[p]=c;

--- a/objects/obj_controller/Mouse_50.gml
+++ b/objects/obj_controller/Mouse_50.gml
@@ -43,9 +43,9 @@ if (menu==12) and (cooldown<=0) and (penitorium>0){
         }
         penitorium=0;
         var p=0;
-        for(var c=0; c<11; c++){
-            for(var e=1; e<=250; e++){
-                if (obj_ini.god[c,e]>=10){
+        for (var c = 0; c < 11; c++){
+            for (var e = 0; e < array_length(obj_ini.god[c]); e++){
+                if (obj_ini.god[c,e] == 10){
                     p+=1;
                     penit_co[p]=c;
                     penit_id[p]=e;

--- a/scripts/scr_controller_helpers/scr_controller_helpers.gml
+++ b/scripts/scr_controller_helpers/scr_controller_helpers.gml
@@ -192,9 +192,9 @@ function scr_toggle_reclu(){
 
             // Get list of jailed marines
             var p=0;
-            for(var c=0; c<11; c++){
-                for(var e=0; e<array_length(obj_ini.name[c]); e++){
-                    if (obj_ini.god[c][e]>=10){
+            for (var c = 0; c < 11; c++) {
+                for (var e = 0; e < array_length(obj_ini.god[c]); e++) {
+                    if (obj_ini.god[c][e] == 10){
                         p+=1;
                         penit_co[p]=c;
                         penit_id[p]=e;


### PR DESCRIPTION
#### Purpose of changes
Reclusium actually works beyond first 11 marines.

#### Describe the solution
Actually check against arrays in the array, should also have fixed marines disappearing in the Reclusium and marines above 250 don't disappear.

#### Describe alternatives you've considered
Renaming god.

#### Testing done
Load game, jail 500 marines in a company.

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->
<!--- "Inspired" by the CDDA PR template -->
