### PR TITLE
fix: Double jetpack on the RG CM

### DIFF
--- a/datafiles/main/chapters/9.JSON
+++ b/datafiles/main/chapters/9.JSON
@@ -118,8 +118,8 @@
                 "still_standing",
                 "seasoned"
             ],
-            "gear": "Jump Pack",
-            "mobi": "",
+            "gear": "",
+            "mobi": "Jump Pack",
             "armour": "",
             "bionics": 0
         },


### PR DESCRIPTION
#### Purpose of changes
<!-- With a few sentences, describe your reasons for making these changes. -->
Fix the Raven Guard chapter master having two jetpacks.

#### Describe the solution
<!-- How does the feature work, or how does this fix a bug? -->
Remove the jetpack from the gear slot in the chapter's json file.

#### Describe alternatives you've considered
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
None

#### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
New game as RG, no double jetpacks.

#### Related links
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
https://discord.com/channels/714022226810372107/1346752447242043413

#### Player notes
<!-- This will be added to the PR description in the release notes. List changes that players may be interested in, in simple words. -->
None

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->
<!--- "Inspired" by the CDDA PR template -->
