### PR TITLE
fix: Sternguard Veterans with two melee weapons

### DIFF
--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -1575,7 +1575,7 @@ function scr_initialize_custom() {
 				"loadout": {
 					"required": {
 						"wep1": ["", 0],
-						"wep2": ["Combat Knife", 9],
+						"wep2": ["Combat Knife", max],
 					},
 					"option": {
 						"wep1": [
@@ -1589,7 +1589,10 @@ function scr_initialize_custom() {
 								weapon_lists.special_weapons, 1
 							],
 							[
-								weapon_lists.heavy_weapons, 1
+								weapon_lists.heavy_weapons, 1, {
+									"wep2":"Combat Knife",
+									"mobi":"Heavy Weapons Pack",
+								}
 							],
 						]
 					}


### PR DESCRIPTION
#### Purpose of changes
<!-- With a few sentences, describe your reasons for making these changes. -->
Fix sternguard veterans spawning with two melee weapons, due to the overburden protection.

#### Describe the solution
<!-- How does the feature work, or how does this fix a bug? -->
Add a heavy weapon pack to the heavy weapon sternguard loadout.

#### Describe alternatives you've considered
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
None

#### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
New game as ultramarines, two melee weapons are no more.

#### Related links
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
None

#### Player notes
<!-- This will be added to the PR description in the release notes. List changes that players may be interested in, in simple words. -->
None

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->
<!--- "Inspired" by the CDDA PR template -->
