### PR TITLE
fix: Progenitor livery for helmets repairs

### DIFF
--- a/scripts/scr_ComplexSet/scr_ComplexSet.gml
+++ b/scripts/scr_ComplexSet/scr_ComplexSet.gml
@@ -752,7 +752,7 @@ function ComplexSet(unit) constructor{
     static complex_helms = function(data){
         set_complex_shader_area(["eye_lense"], data.helm_lens);
         if (data.helm_pattern == 0){
-            set_complex_shader_area(["left_head", "right_head","left_muzzle", "right_muzzle"], data.helm_secondary);
+            set_complex_shader_area(["left_head", "right_head","left_muzzle", "right_muzzle"], data.helm_primary);
 
         } else if (data.helm_pattern == 2){
             set_complex_shader_area(["left_head", "right_head"], data.helm_primary);

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -38,6 +38,7 @@ enum ePROGENITOR {
     RAVEN_GUARD,
     RANDOM,
 }
+
 function progenitor_map(){
     var founding_chapters = [
         "",
@@ -51,11 +52,13 @@ function progenitor_map(){
         "Salamanders",
         "Raven Guard",
     ]
-    for (i=1;i<10;i++){
-        if (global.chapter_name==founding_chapters[i] || obj_ini.progenitor==i){
+
+    for (var i=1; i<10; i++){
+        if (global.chapter_name == founding_chapters[i] || obj_ini.progenitor==i){
             return i;
         }
     }
+
     return 0;
 }
 
@@ -101,8 +104,12 @@ function select_livery_data(livery_data, specific) {
     }
 }
 
-function progenitor_livery(progenitor, specific = "none") {
+function helmet_livery(progenitor, specific = "none") {
     var livery_data;
+
+	if ((obj_creation.custom == 0) && (global.chapter_creation_object.origin == 1)) {
+		progenitor = progenitor_map();
+	}
 
     var name_selected = true;
     switch (global.chapter_name) {
@@ -171,7 +178,38 @@ function progenitor_livery(progenitor, specific = "none") {
                 },
             };
             break;
-
+		case "Lamenters":
+			livery_data = {
+				sgt : {
+					helm_pattern:1,
+					helm_primary : obj_creation.main_color,
+					helm_secondary : Colors.Black,
+					helm_detail : obj_creation.main_trim,
+					helm_lens : obj_creation.lens_color,
+				},
+				vet_sgt : {
+					helm_pattern:1,
+					helm_primary : obj_creation.main_color,
+					helm_secondary : Colors.Black,
+					helm_detail : obj_creation.main_trim,
+					helm_lens : obj_creation.lens_color,
+				},
+				captain : {
+					helm_pattern:0,
+					helm_primary : Colors.White,
+					helm_secondary : Colors.White,
+					helm_detail : obj_creation.main_trim,
+					helm_lens : obj_creation.lens_color,
+				},
+				veteran : {
+					helm_pattern:2,
+					helm_primary : obj_creation.main_color,
+					helm_secondary : Colors.Black,
+					helm_detail : obj_creation.main_trim,
+					helm_lens : obj_creation.lens_color,	
+				}				
+			}
+			break;
         default:
             name_selected = false;
             break;
@@ -387,21 +425,21 @@ function progenitor_livery(progenitor, specific = "none") {
                     helm_primary: Colors.Red,
                     helm_secondary: Colors.Red,
                     helm_detail: Colors.Red,
-                    helm_lens: Colors.Green,
+                    helm_lens: Colors.Lime,
                 },
                 vet_sgt: {
                     helm_pattern: 1,
                     helm_primary: Colors.Red,
-                    helm_secondary: Colors.White,
+                    helm_secondary: Colors.Red,
                     helm_detail: Colors.Red,
-                    helm_lens: Colors.Green,
+                    helm_lens: Colors.Lime,
                 },
                 captain: {
                     helm_pattern: 0,
-                    helm_primary: Colors.Dark_Ultramarine,
-                    helm_secondary: Colors.Dark_Ultramarine,
-                    helm_detail: Colors.Dark_Ultramarine,
-                    helm_lens: Colors.Red,
+                    helm_primary: obj_creation.main_color,
+                    helm_secondary: obj_creation.secondary_color,
+                    helm_detail: obj_creation.main_trim,
+                    helm_lens: obj_creation.lens_color,
                 },
                 veteran: {
                     helm_pattern: 0,
@@ -449,32 +487,32 @@ function progenitor_livery(progenitor, specific = "none") {
         case ePROGENITOR.BLOOD_ANGELS:
             livery_data = {
                 sgt: {
-                    helm_pattern: 1,
-                    helm_primary: Colors.Sanguine_Red,
-                    helm_secondary: Colors.Sanguine_Red,
-                    helm_detail: Colors.Lighter_Black,
-                    helm_lens: Colors.Lime,
+					helm_pattern: 0,
+					helm_primary: obj_creation.main_color,
+					helm_secondary: obj_creation.secondary_color,
+					helm_detail: Colors.Gold,
+					helm_lens: obj_creation.lens_color,
                 },
                 vet_sgt: {
-                    helm_pattern: 1,
-                    helm_primary: Colors.Gold,
-                    helm_secondary: Colors.Black,
-                    helm_detail: Colors.Gold,
-                    helm_lens: Colors.Lime,
+					helm_pattern: 0,
+					helm_primary: Colors.Gold,
+					helm_secondary: obj_creation.secondary_color,
+					helm_detail: obj_creation.main_trim,
+					helm_lens: obj_creation.lens_color,
                 },
                 captain: {
-                    helm_pattern: 0,
-                    helm_primary: Colors.Sanguine_Red,
-                    helm_secondary: Colors.Sanguine_Red,
-                    helm_detail: Colors.Gold,
-                    helm_lens: Colors.Lime,
+					helm_pattern: 0,
+					helm_primary: obj_creation.main_color,
+					helm_secondary: obj_creation.secondary_color,
+					helm_detail: Colors.Gold,
+					helm_lens: obj_creation.lens_color,
                 },
                 veteran: {
-                    helm_pattern: 0,
-                    helm_primary: Colors.Gold,
-                    helm_secondary: Colors.Gold,
-                    helm_detail: Colors.Gold,
-                    helm_lens: Colors.Lime,
+					helm_pattern: 0,
+					helm_primary: Colors.Gold,
+					helm_secondary: obj_creation.secondary_color,
+					helm_detail: obj_creation.main_trim,
+					helm_lens: obj_creation.lens_color,
                 },
             };
             break;
@@ -488,20 +526,20 @@ function progenitor_livery(progenitor, specific = "none") {
                     helm_primary: Colors.Red,
                     helm_secondary: Colors.Red,
                     helm_detail: Colors.Red,
-                    helm_lens: Colors.Green,
+                    helm_lens: Colors.Lime,
                 },
                 vet_sgt: {
                     helm_pattern: 1,
                     helm_primary: Colors.Red,
-                    helm_secondary: Colors.White,
+                    helm_secondary: Colors.Red,
                     helm_detail: Colors.Red,
-                    helm_lens: Colors.Green,
+                    helm_lens: Colors.Lime,
                 },
                 captain: {
                     helm_pattern: 0,
                     helm_primary: obj_creation.main_color,
-                    helm_secondary: obj_creation.main_color,
-                    helm_detail: obj_creation.main_color,
+                    helm_secondary: obj_creation.secondary_color,
+                    helm_detail: obj_creation.main_trim,
                     helm_lens: obj_creation.lens_color,
                 },
                 veteran: {
@@ -1188,7 +1226,7 @@ function scr_initialize_custom() {
     for (var i = 0; i < array_length(complex_type); i++) {
         with (complex_livery_data[$ complex_type[i]]) {
             if (helm_primary == 0 && helm_secondary == 0 && helm_lens == 0) {
-                obj_ini.complex_livery_data[$ complex_type[i]] = progenitor_livery(obj_ini.progenitor, complex_type[i]);
+                obj_ini.complex_livery_data[$ complex_type[i]] = helmet_livery(obj_ini.progenitor, complex_type[i]);
             }
         }
     }


### PR DESCRIPTION
#### Purpose of changes
<!-- With a few sentences, describe your reasons for making these changes. -->
Helmet role recoloring had some weird issues, with founding chapters skipping it completely, using secondary colors as primary, etc.

#### Describe the solution
<!-- How does the feature work, or how does this fix a bug? -->
- Add a check for founding chapters, to map them to themselves as progenitors.
- Change 0 pattern recolor from using the secondary color to use the primary one.
- Rename the function from `progenitor_livery` to `helmet_livery`.
- Add missing livery for Lamenters.
- Adjust some existing liveries.

#### Describe alternatives you've considered
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
None

#### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
New game as a custom chapter, new game as Lamenters, new game as Blood Angels.

#### Related links
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
None

#### Player notes
<!-- This will be added to the PR description in the release notes. List changes that players may be interested in, in simple words. -->
None

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->
<!--- "Inspired" by the CDDA PR template -->
