### PR TITLE
Fix: hireling XP stat growth

### DIFF
--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -239,11 +239,11 @@ global.base_stats = { //tempory stats subject to change by anyone that wishes to
 	*/
 	"sister_of_battle":{
 			title : "Sister of Battle",
-			strength : [10,1],
-			constitution : [10,1], // TODO - consider making it that hireling armour boosts constitution, and possibly other stats
-			weapon_skill : [12,1],
-			ballistic_skill : [12,1],
-			dexterity : [10,1],
+			strength : [12,1],
+			constitution : [12,1], // TODO - consider making it that hireling armour boosts constitution, and possibly other stats
+			weapon_skill : [15,1],
+			ballistic_skill : [15,1],
+			dexterity : [22,1],
 			intelligence : [10,1],
 			wisdom : [10,1],
 			charisma : [10,1],
@@ -401,6 +401,68 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data={}) 
 						stat_gains="technology";
 					}
 				}				
+				self[$ stat_gains]++;
+				stat_point_exp_marker-=15;
+				if (struct_exists(instace_stat_point_gains, stat_gains)){
+					instace_stat_point_gains[$ stat_gains]++;
+				} else {
+					instace_stat_point_gains[$ stat_gains]=1;
+				}
+				if (struct_exists(turn_stat_gains, stat_gains)){
+					turn_stat_gains[$ stat_gains]++;
+				} else {
+					turn_stat_gains[$ stat_gains]=1;
+				}
+			}
+			assign_reactionary_traits();
+		}
+		if (base_group == "human"){
+			while (stat_point_exp_marker>=15){
+				var stat_gains = choose("weapon_skill", "ballistic_skill", "piety", "wisdom"); // sisters getting more fanatical as they become more experienced
+				var special_stat = irandom(4);
+				self[$ stat_gains]++;
+				stat_point_exp_marker-=15;
+				if (struct_exists(instace_stat_point_gains, stat_gains)){
+					instace_stat_point_gains[$ stat_gains]++;
+				} else {
+					instace_stat_point_gains[$ stat_gains]=1;
+				}
+				if (struct_exists(turn_stat_gains, stat_gains)){
+					turn_stat_gains[$ stat_gains]++;
+				} else {
+					turn_stat_gains[$ stat_gains]=1;
+				}
+			}
+			assign_reactionary_traits();
+		}
+		if (base_group == "skitarii"){
+			while (stat_point_exp_marker>=15){
+				var stat_gains = choose("weapon_skill", "ballistic_skill", "technology", "wisdom");
+				var special_stat = irandom(4);
+				self[$ stat_gains]++;
+				stat_point_exp_marker-=15;
+				if (struct_exists(instace_stat_point_gains, stat_gains)){
+					instace_stat_point_gains[$ stat_gains]++;
+				} else {
+					instace_stat_point_gains[$ stat_gains]=1;
+				}
+				if (struct_exists(turn_stat_gains, stat_gains)){
+					turn_stat_gains[$ stat_gains]++;
+				} else {
+					turn_stat_gains[$ stat_gains]=1;
+				}
+			}
+			assign_reactionary_traits();
+		}
+		if (base_group == "tech_priest"){
+			while (stat_point_exp_marker>=15){
+				var stat_gains = choose("weapon_skill", "ballistic_skill", "technology", "intelligence");
+				var special_stat = irandom(4);
+					if (job!="none"){
+					if (job.type == "forge"){
+						stat_gains="technology";
+					}
+				}	
 				self[$ stat_gains]++;
 				stat_point_exp_marker-=15;
 				if (struct_exists(instace_stat_point_gains, stat_gains)){
@@ -1130,9 +1192,9 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data={}) 
 			if (base_group == "astartes"){
 				ranged_hands_limit = 2
 			} else if base_group == "tech_priest" {
-				ranged_hands_limit = 1+(technology/100);
+				ranged_hands_limit = 2+(technology/100);
 			}else if base_group == "human" {
-				ranged_hands_limit = 1;
+				ranged_hands_limit = 2;
 			}	
 			carry_string+=$"Base: {ranged_hands_limit}#";
 			if (strength>=50){
@@ -1311,7 +1373,7 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data={}) 
 			} else if base_group == "tech_priest" {
 				melee_hands_limit = 1+(technology/100);
 			}else if base_group == "human" {
-				melee_hands_limit = 1;
+				melee_hands_limit = 2;
 			}				
 			carry_string+="Base: 2#";
 			if (strength>=50){


### PR DESCRIPTION
Hirelings did not grow in terms of stats as they gained XP. This fixes this issue.

#### Purpose of changes
Let hirelings gain stats from XP.

#### Describe the solution
It fixes it completely. They gain the same amount of stat increases as marines, but they're spread out over more stats, so their combat effectiveness grows around 33% slower then marines.

#### Describe alternatives you've considered
I considered increasing the amount of XP they would require for each stat increase, but I like this better.

#### Testing done
In game I tested giving a sister 100 XP, and saw that her stats increased as a result.

#### Related links
None really.

#### Player notes
Fixed hireling stat growth.
