### PR TITLE
Rework the back row protection rules

### DIFF
--- a/objects/obj_enunit/Alarm_0.gml
+++ b/objects/obj_enunit/Alarm_0.gml
@@ -176,6 +176,10 @@ if (!engaged){// Shooting
                             continue;
                         }
                     } else if (instance_number(obj_pnunit) > 1) {
+                        if (enemy2.men > 0) {
+                            continue;
+                        }
+
                         // There were no marines in the first column, looking behind;
                         var enemy2;
                 
@@ -196,10 +200,7 @@ if (!engaged){// Shooting
                                 }
                             }
                 
-                            if (enemy2.men > 0) {
-                                scr_shoot(i, enemy2, chapter_fuck, "att", "ranged");
-                                break;
-                            }
+                            scr_shoot(i, enemy2, chapter_fuck, "att", "ranged");
                         }
                     }
                 }

--- a/objects/obj_enunit/Alarm_0.gml
+++ b/objects/obj_enunit/Alarm_0.gml
@@ -59,7 +59,6 @@ if (!engaged){// Shooting
         enemy=instance_nearest(obj_temp_inq.x,obj_temp_inq.y,obj_pnunit);
         with(obj_temp_inq){instance_destroy();}
     }*/
-    
     if (!instance_exists(obj_pnunit)) then exit;
 
     for (var i=0;i<array_length(wep);i++){
@@ -167,59 +166,43 @@ if (!engaged){// Shooting
                 
                 
                 if (string_count("Gauss",wep[i])) then _armour_piercing=false;
+
+                // Shooting normal marines;
+                if ((!_armour_piercing) && ((!instance_exists(obj_nfort)) || flank) && instance_exists(obj_pnunit) && instance_exists(enemy)) {
+                    if (enemy.men > 0) {
+                        // There are marines in the first column;
+                        if (target_block_is_valid(enemy, obj_pnunit)) {
+                            scr_shoot(i, enemy, chapter_fuck, "att", "ranged");
+                            continue;
+                        }
+                    } else if (instance_number(obj_pnunit) > 1) {
+                        // There were no marines in the first column, looking behind;
+                        var enemy2;
                 
-                if (!_armour_piercing) and ((!instance_exists(obj_nfort)) or (flank)) and (instance_exists(obj_pnunit)) and (instance_exists(enemy)){// Check for men
-                    var g=0,good=0,enemy2;
-
-                    if (target_block_is_valid(enemy,obj_pnunit)){
-                        // good=scr_target(enemy,"men");// First target has vehicles, blow it to hell
-                        scr_shoot(i,enemy,chapter_fuck,"att","ranged");
-                    }
-                    
-                    // First target does not have vehicles, cycle through objects to find one that has vehicles
-                    // Note that unless the player has 10+ vehicles in the front rank they can fire on through
-                    
-                    if (!good) and (instance_number(obj_pnunit)>1) and (enemy.veh+enemy.dreads<=10){
-                        var x2=enemy.x;
-                        repeat(instance_number(obj_pnunit)-1){
-                            if (!good){
-                                if (!flank) then x2-=10;
-                                if (flank) then x2+=10;
-                                enemy2=instance_nearest(x2,y,obj_pnunit);
-                                
-                                var j,totes;j=0;totes=0;
-                                for (j=0;j<array_length(enemy2.unit_struct);j++){
-                                    unit = enemy2.unit_struct[j];
-                                    if (!is_struct(unit))then continue;
-                                    if (unit.hp()>0){
-                                        if (enemy2.marine_type[j]=obj_ini.role[100][6]) then totes+=1;
-                                        if (enemy2.marine_type[j]="Venerable "+string(obj_ini.role[100][6])) then totes+=1;
-                                    }
-
+                        var _column_size_value = (enemy.veh * 4) + (enemy.dreads * 4) + enemy.men;
+                        var x2 = enemy.x;
+                        x2 += !flank ? 10 : -10;
+                
+                        repeat (instance_number(obj_pnunit) - 1) {
+                            enemy2 = instance_nearest(x2, y, obj_pnunit);
+                
+                            var _back_column_size_value = (enemy2.veh * 2.5) + (enemy2.dreads * 2) + (enemy2.men * 0.5);
+                            if (_back_column_size_value < _column_size_value) {
+                                continue;
+                            } else {
+                                var _pass_chance = ((_back_column_size_value / _column_size_value) - 1) * 100;
+                                if (roll_dice(1, 100, "high") > min(_pass_chance, 60)) {
+                                    continue;
                                 }
-                                for (j=0;j<array_length(enemy2.veh_hp);j++){
-                                        if (enemy2.veh_hp[j]>0){
-                                        if (enemy2.veh_type[i]="Rhino") then totes++;
-                                        if (enemy2.veh_type[i]="Predator") then totes++;
-                                        if (enemy2.veh_type[i]="Land Raider") then totes++;
-                                    }
-                                }
-                                // show_message(totes);
-                                
-                                // if (enemy2.veh+enemy2.dreads>10) then block=1;
-                                if (totes>=10) then block=1;
-                                
-                                // if (enemy2.men-enemy2.dreads>0) and (good=0) and (block=0){
-                                if (enemy2.men>0) and (good=0) and (block=0){
-                                    // good=scr_target(enemy2,"men");// This target has men, blow it to hell
-                                    scr_shoot(i,enemy2,chapter_fuck,"att","ranged");
-                                }
+                            }
+                
+                            if (enemy2.men > 0) {
+                                scr_shoot(i, enemy2, chapter_fuck, "att", "ranged");
+                                break;
                             }
                         }
                     }
                 }
-                
-
             }
         }
     }

--- a/objects/obj_enunit/Alarm_0.gml
+++ b/objects/obj_enunit/Alarm_0.gml
@@ -179,7 +179,7 @@ if (!engaged){// Shooting
                         // There were no marines in the first column, looking behind;
                         var enemy2;
                 
-                        var _column_size_value = (enemy.veh * 4) + (enemy.dreads * 4) + enemy.men;
+                        var _column_size_value = (enemy.veh * 2.5) + (enemy.dreads * 2) + (enemy.men * 0.5);
                         var x2 = enemy.x;
                         x2 += !flank ? 10 : -10;
                 
@@ -191,7 +191,7 @@ if (!engaged){// Shooting
                                 continue;
                             } else {
                                 var _pass_chance = ((_back_column_size_value / _column_size_value) - 1) * 100;
-                                if (roll_dice(1, 100, "high") > min(_pass_chance, 60)) {
+                                if (irandom_range(1, 100) > min(_pass_chance, 60)) {
                                     continue;
                                 }
                             }


### PR DESCRIPTION
#### Purpose of changes
<!-- With a few sentences, describe your reasons for making these changes. -->
The original rules are not perfect. They basically protect any number of troops behind 11 vehicles. 1k, 1kk, 1kkk, doesn't matter.
Now, not stacking a ton of units in one column may actually save their lives.
When arbitrary unit formation sizes are removed, this will matter even more to prevent single column stacking.

#### Describe the solution
<!-- How does the feature work, or how does this fix a bug? -->
Row protection now works as follows:
- Check if there are any marines in the first row, if so - shoot them.
- Check if there is more than one instance of player columns.
- Calculate the size of the front column (marines * 0.5 + vehicles * 2.5 + dreads * 2).
- Start looping through player columns.
- Check if current column is bigger (same formula) than the front column.
- If it's not, divide the current column size by the front size, subtract 1 and multiply by 100. You'll get a roll that you need to "pass" through the front column.
- The bigger the difference, the higher the chance to damage the back row, capped at 60.
- Roll 1d100 against the difference and shoot the back row if the roll has failed.

#### Describe alternatives you've considered
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
Make the chance also depend on the size of the enemy column that is attacking.

#### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
A couple of fights vs rampant orks. Debug lines show sane pass-through chances.

#### Related links
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
https://discord.com/channels/714022226810372107/1348311762629558282

#### Player notes
<!-- This will be added to the PR description in the release notes. List changes that players may be interested in, in simple words. -->
Back row protection rules are reworked. A column can only protect back columns if they are smaller than it. Vehicles and dreadnougts give more size to columns.

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->
<!--- "Inspired" by the CDDA PR template -->
