### PR TITLE
Load to ships by default

### DIFF
--- a/scripts/scr_chapter_new/scr_chapter_new.gml
+++ b/scripts/scr_chapter_new/scr_chapter_new.gml
@@ -87,7 +87,7 @@ function ChapterData() constructor {
 	battle_cry = "For the Emperor";
 	equal_specialists = 0;
 	load_to_ships = {
-		escort_load: 0,
+		escort_load: 2,
 		split_scouts: 0,
 		split_vets: 0,
 	};


### PR DESCRIPTION
### Purpose of changes
<!-- With a few sentences, describe your reasons for making these changes. -->
Load to ships is default when you enter the creation screen. Makes sense imo for it to be default for json as well.
Allows to skip the load to ships code chunk on most chapters.

### Describe the solution
<!-- How does the feature work, or how does this fix a bug? -->
Load to ships as default for json chapters.

### Describe alternatives you've considered
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
None

### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
None

### Related links
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
None

### Custom player notes entry
<!-- This will be added to the PR description in the release notes. List changes that players may be interested in, in simple words. -->
Use the PR title.

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->
<!--- "Inspired" by the CDDA PR template -->
