### PR TITLE
feat: 40k-ification of SRs/TLs

### DIFF
--- a/scripts/scr_PlanetData/scr_PlanetData.gml
+++ b/scripts/scr_PlanetData/scr_PlanetData.gml
@@ -647,14 +647,14 @@ function PlanetData(planet, system) constructor{
             }
             
             if (t!=0){
-                if (ahuh2=1) then ahuh3="Tiny";if (ahuh2=2) then ahuh3="Sparse";
-                if (ahuh2=3) then ahuh3="Moderate";if (ahuh2=4) then ahuh3="Heavy";
-                if (ahuh2=5) then ahuh3="Extreme";if (ahuh2>=6) then ahuh3="Rampant";
+                if (ahuh2=1) then ahuh3="Punicus";if (ahuh2=2) then ahuh3="Minorus";
+                if (ahuh2=3) then ahuh3="Moderatus";if (ahuh2=4) then ahuh3="Significus";
+                if (ahuh2=5) then ahuh3="Enormicus";if (ahuh2>=6) then ahuh3="Extremis";
             }
             if (t=0){
-                if (ahuh2=1) then ahuh3="Very Few";if (ahuh2=2) then ahuh3="Few";
-                if (ahuh2=3) then ahuh3="Moderate";if (ahuh2=4) then ahuh3="Numerous";
-                if (ahuh2=5) then ahuh3="Very Numerous";if (ahuh2>=6) then ahuh3="Overwhelming";
+                if (ahuh2=1) then ahuh3="Punicus";if (ahuh2=2) then ahuh3="Minorus";
+                if (ahuh2=3) then ahuh3="Moderatus";if (ahuh2=4) then ahuh3="Significus";
+                if (ahuh2=5) then ahuh3="Enormicus";if (ahuh2>=6) then ahuh3="Extremis";
             }
             
             if (ahuh!="") and (ahuh2>0) then temp8+=string(ahuh)+" "+string(ahuh3)+"#";

--- a/scripts/scr_drop_select_function/scr_drop_select_function.gml
+++ b/scripts/scr_drop_select_function/scr_drop_select_function.gml
@@ -175,7 +175,7 @@ function drop_select_draw(){
                 target_threat = "",
                 race_quantity = 0;
             var races = ["", "Ecclesiarchy", "Eldar", "Orks", "Tau", "Tyranids", "Heretics", "CSMs", "Daemons", "Necrons"];
-            var threat_levels = ["", "Negligible", "Minor", "Moderate", "High", "Very High", "Overwhelming"];
+            var threat_levels = ["", "Punicus", "Minorus", "Moderatus", "Significus", "Enormicus", "Extremis"];
             var race_quantities = [0, sisters, eldar, ork, tau, tyranids, traitors, csm, demons, necrons];
 
             if (attacking >= 5 && attacking <= 13) {


### PR DESCRIPTION
### Purpose of changes
This small feature is part of community poll, should the #482 not be ready still, or simply rejected.

### Describe the solution
Tweaking the Strength Ratings/Threat Levels to something sounding from 40k.

### Describe alternatives you've considered
Tweak the #482 itself.

### Testing done
- [ ] Compilation,
- [ ] Making to the game,
- [ ] Checking the SR/TL on worlds,
- [ ] End turn.

### Related links
https://discord.com/channels/714022226810372107/1347837163714248756
#482 

### Custom player notes entry
Names of Strength Ratings/Threat Levels have been 40k-ified.