### PR TITLE
perf: Refactor fragment shaders

### DIFF
--- a/shaders/armour_texture/armour_texture.fsh
+++ b/shaders/armour_texture/armour_texture.fsh
@@ -12,48 +12,68 @@ uniform int blend;
 uniform vec3 blend_colour;
 
 
-vec3 light_or_dark(vec3 m_colour, float shade){
-
-  return vec3((m_colour.r * shade) + 0.001, m_colour.g * shade, m_colour.b * shade);
+vec3 light_or_dark(vec3 m_colour, float shade) {
+    return vec3((m_colour.r * shade) + 0.001, m_colour.g * shade, m_colour.b * shade);
 }
-void main()
-{
+
+void main() {
+    const float _60COL = 60.0 / 255.0;
+    // Attempt to workaround Intel sampling bug
+    const float _127_25COL = 127.25 / 255.0;
+    const float _128COL = 128.0 / 255.0;
+    const float _128_75COL = 128.75 / 255.0;
+    //
+    const float _160COL = 160.0 / 255.0;
+    const float _215COL = 215.0 / 255.0;
+
     vec4 col = texture2D(gm_BaseTexture, v_vTexcoord);
-     if (col.rgb != replace_colour.rgb){
-         col.a = 0.0;
-      }
-    if (col.rgb == replace_colour.rgb){
-      col = texture2D(armour_texture, v_vMaskCoord);
-      if (col.a != 0.0){
-            vec4 col_orig = texture2D(gm_BaseTexture, v_vTexcoord);
-            if (blend == 1){
-               col.rgb = col.rgb * blend_colour.rgb;
+
+    if (col.rgba == vec4(0.0, 0.0, 0.0, 0.0)) {
+        discard;
+    }
+
+    // Intel
+    if (col.r >= _127_25COL && col.r <= _128_75COL) {
+        col.r = _128COL;
+    }
+    if (col.g >= _127_25COL && col.g <= _128_75COL) {
+        col.g = _128COL;
+    }
+    if (col.b >= _127_25COL && col.b <= _128_75COL) {
+        col.b = _128COL;
+    }
+    if (col.a >= _127_25COL && col.a <= _128_75COL) {
+        col.a = _128COL;
+    }
+    //
+
+    if (col.rgb != replace_colour.rgb) {
+        col.a = 0.0;
+    } else {
+        vec4 col_orig = col;
+        col = texture2D(armour_texture, v_vMaskCoord);
+        if (col.a != 0.0) {
+            if (blend == 1) {
+                col.rgb = col.rgb * blend_colour.rgb;
             }
-            if (col_orig.a==(128.0/255.0)){
-               col.rgb = light_or_dark(col.rgb, 1.2);
-               col.a = 1.0;
+
+            if (col_orig.a == _128COL) {
+                col.rgb = light_or_dark(col.rgb, 1.2);
+                col.a = 1.0;
+            } else if (col_orig.a == _60COL) {
+                col.rgb = light_or_dark(col.rgb, 1.4);
+                col.a = 1.0;
+            } else if (col_orig.a == _215COL) {
+                col.rgb = light_or_dark(col.rgb, 0.6);
+                col.a = 1.0;
+            } else if (col_orig.a == _160COL) {
+                col.rgb = light_or_dark(col.rgb, 0.8);
+                col.a = 1.0;
             }
-      
-            if (col_orig.a==(60.0/255.0)){
-               col.rgb = light_or_dark(col.rgb, 1.4);
-               col.a = 1.0;
-            }         
-      
-      
-            if (col_orig.a==(215.0/255.0)){
-               col.rgb = light_or_dark(col.rgb,0.6);
-               col.a = 1.0;
-            }         
-      
-            if (col_orig.a==(160.0/255.0)){
-               col.rgb = light_or_dark(col.rgb, 0.8);
-               col.a = 1.0;
-            }              
-          }
-          if (col.a == 0.0){
+        } else {
             col = texture2D(gm_BaseTexture, v_vTexcoord);
-          }
-       }
+        }
+    }
 
     gl_FragColor = v_vColour * col;
     //gl_FragColor = v_vColour * (background_col*texture2D(gm_BaseTexture, v_vTexcoord));

--- a/shaders/full_livery_shader/full_livery_shader.fsh
+++ b/shaders/full_livery_shader/full_livery_shader.fsh
@@ -34,140 +34,154 @@ varying vec2 v_vTexcoord;
 varying vec4 v_vColour;
 
 
-vec3 light_or_dark(vec3 m_colour, float shade){
-  return vec3((m_colour.r * shade) + 0.001, m_colour.g * shade, m_colour.b * shade);
+vec3 light_or_dark(vec3 m_colour, float shade) {
+    return vec3((m_colour.r * shade) + 0.001, m_colour.g * shade, m_colour.b * shade);
 }
 
-void main()
-{
-    vec4 col = texture2D(gm_BaseTexture, v_vTexcoord);
+void main() {
+    const float _20COL = 20.0 / 255.0;
+    const float _24COL = 24.0 / 255.0;
+    const float _46COL = 46.0 / 255.0;
+    const float _60COL = 60.0 / 255.0;
+    const float _64COL = 64.0 / 255.0;
+    const float _84COL = 84.0 / 255.0;
+    const float _104COL = 104.0 / 255.0;
+    const float _112COL = 112.0 / 255.0;
+    // Attempt to workaround Intel sampling bug
+    const float _127_25COL = 127.25 / 255.0;
+    const float _128COL = 128.0 / 255.0;
+    const float _128_75COL = 128.75 / 255.0;
+    //
+    const float _130COL = 130.0 / 255.0;
+    const float _135COL = 135.0 / 255.0;
+    const float _138COL = 138.0 / 255.0;
+    const float _140COL = 140.0 / 255.0;
+    const float _147COL = 147.0 / 255.0;
+    const float _151COL = 151.0 / 255.0;
+    const float _160COL = 160.0 / 255.0;
+    const float _165COL = 165.0 / 255.0;
+    const float _168COL = 168.0 / 255.0;
+    const float _169COL = 169.0 / 255.0;
+    const float _170COL = 170.0 / 255.0;
+    const float _181COL = 181.0 / 255.0;
+    const float _188COL = 188.0 / 255.0;
+    const float _194COL = 194.0 / 255.0;
+    const float _214COL = 214.0 / 255.0;
+    const float _215COL = 215.0 / 255.0;
+    const float _218COL = 218.0 / 255.0;
+    const float _230COL = 230.0 / 255.0;
+
     vec4 col_orig = texture2D(gm_BaseTexture, v_vTexcoord);
-   if (col.rgb == vec3(0.0,0.0, 128.0/255.0).rgb){
-
-      col.rgb = left_head.rgb;
-   };
-    if (col.rgb == vec3(181.0/255.0,0.0, 255.0/255.0).rgb){
-        col.rgb = right_backpack.rgb;
-    };    
-    if (col.rgb == vec3(104.0/255.0,0.0, 168.0/255.0).rgb){
-        col.rgb = left_backpack.rgb;
-    };
-   if (col.rgb == vec3(0.0,0.0, 1.0).rgb){
-         col.rgb = right_head.rgb;
-    };
-     if (col.rgb == vec3(128.0/255.0,64.0/255.0, 1.0).rgb){
-         col.rgb = left_muzzle.rgb;
-    };
-     if (col.rgb == vec3(64.0/255.0,128.0/255.0, 1.0).rgb){
-         col.rgb = right_muzzle.rgb;
-    };
-     if (col.rgb == vec3(0.0,1.0, 0.0).rgb){
-        col.rgb = eye_lense.rgb;
-    };
-     if (col.rgb == vec3(1.0,20.0/255.0, 147.0/255.0).rgb){
-        col.rgb = right_chest.rgb;
-    };
-     if (col.rgb == vec3(128.0/255.0,0.0, 128.0/255.0).rgb){
-        col.rgb = left_chest.rgb;
-    };
-     if (col.rgb == vec3(0.0,128.0/255.0, 128.0/255.0).rgb){
-        col.rgb = right_trim.rgb;
-    };
-     if (col.rgb == vec3(1.0,128.0/255.0, 0.0).rgb){
-        col.rgb = left_trim.rgb;
-    };
-     if (col.rgb == vec3(135.0/255.0,130.0/255.0, 188.0/255.0).rgb){
-        col.rgb = metallic_trim.rgb;
-    };
-     if (col.rgb == vec3(1.0,1.0, 1.0).rgb){
-        col.rgb = right_pauldron.rgb;
-    };
-     if (col.rgb == vec3(1.0,1.0, 0.0).rgb){
-        col.rgb = left_pauldron.rgb;
-    };
-     if (col.rgb == vec3(0.0/255.0,128.0/255.0, 0.0/255.0).rgb){
-        col.rgb = right_leg_upper.rgb;
-    };
-     if (col.rgb == vec3(255.0/255.0,112.0/255.0, 170.0/255.0).rgb){
-        col.rgb = left_leg_upper.rgb;
-    };
-     if (col.rgb == vec3(1.0,0.0, 0.0).rgb){
-        col.rgb = left_leg_knee.rgb;
-    };
-     if (col.rgb == vec3(128.0/255.0,0.0/255.0, 0.0/255.0).rgb){
-        col.rgb = left_leg_lower.rgb;
-    };
-     if (col.rgb == vec3(214.0/255.0,194.0/255.0, 255.0/255.0).rgb){
-        col.rgb = right_leg_knee.rgb;
-    };
-     if (col.rgb == vec3(165.0/255.0,84.0/255.0, 24.0/255.0).rgb){
-        col.rgb = right_leg_lower.rgb;
-    };
-     if (col.rgb == vec3(138.0/255.0,218.0/255.0, 140.0/255.0).rgb){
-        col.rgb = right_arm.rgb;
-    };
-     if (col.rgb == vec3(46.0/255.0,169.0/255.0, 151.0/255.0).rgb){
-        col.rgb = right_hand.rgb;
-    };
-     if (col.rgb == vec3(1.0,230.0/255.0, 140.0/255.0).rgb){
-        col.rgb = left_arm.rgb;
-    } ;
-     if (col.rgb == vec3(1.0,160.0/255.0, 112.0/255.0).rgb){
-        col.rgb = left_hand.rgb;
-    };
-    if (col.rgb == vec3(128.0/255.0,128.0/255.0,0.0)){
-      col.rgb = company_marks.rgb;
-    };
-    if (col.rgb == vec3(0.0,1.0,1.0)){
-      col.rgb = weapon_primary.rgb;
-    };
-    if (col.rgb == vec3(1.0,0.0,1.0)){
-      col.rgb = weapon_secondary.rgb;
-    };
-    if (col_orig.rgb != col.rgb){
-      if (col_orig.a==128.0/255.0){
-         col.rgb = light_or_dark(col.rgb, 1.2);
-         col.a = 1.0;
-      }
-
-      if (col_orig.a==60.0/255.0){
-         col.rgb = light_or_dark(col.rgb, 1.4);
-         col.a = 1.0;
-      }         
-
-
-      if (col_orig.a==215.0/255.0){
-         col.rgb = light_or_dark(col.rgb,0.6);
-         col.a = 1.0;
-      }         
-
-      if (col_orig.a==160.0/255.0){
-         col.rgb = light_or_dark(col.rgb, 0.8);
-         col.a = 1.0;
-      }         
-
+    if (col_orig.rgba == vec4(0.0, 0.0, 0.0, 0.0)) {
+        discard;
     }
 
-     vec3 robes_colour_base = vec3(201.0 / 255.0, 178.0 / 255.0, 147.0 / 255.0);
-     vec3 robes_highlight = vec3(230.0 / 255.0, 203.0 / 255.0, 168.0 / 255.0);
-     vec3 robes_darkness = vec3(189.0 / 255.0, 167.0 / 255.0, 138.0 / 255.0);
-     vec3 robes_colour_base_2 = vec3(169.0 / 255.0, 150.0 / 255.0, 123.0 / 255.0);
-     vec3 robes_highlight_2 = vec3(186.0 / 255.0, 165.0 / 255.0, 135.0 / 255.0);
-     vec3 robes_darkness_2 = vec3(148.0 / 255.0, 132.0 / 255.0, 108.0 / 255.0);
-      if (col.rgb == robes_colour_base.rgb || col.rgb == robes_colour_base_2.rgb) {
-         col.rgb = light_or_dark(robes_colour_replace , 1.0).rgb;
-      };
-      if (col.rgb == robes_highlight.rgb || col.rgb == robes_highlight_2.rgb) {
-         col.rgb = light_or_dark(robes_colour_replace , 1.25).rgb;
-      //col.rgb = mix(robes_highlight.rgb, robes_colour_replace.rgb, 0.25);
-      };
-      if (col.rgb == robes_darkness.rgb || col.rgb == robes_darkness_2.rgb) {
-      //col.rgb = vec3(col.r*0.8, col.g*0.8, col.b*0.8).rgb;
-      //col.rgb = robes_colour_replace.rgb;
-      //col.rgb = mix(robes_darkness.rbg, robes_colour_replace.rgb, 0.25);
-         col.rgb = light_or_dark(robes_colour_replace , 0.75).rgb;
-      };
+    // Intel
+    if (col_orig.r >= _127_25COL && col_orig.r <= _128_75COL) {
+        col_orig.r = _128COL;
+    }
+    if (col_orig.g >= _127_25COL && col_orig.g <= _128_75COL) {
+        col_orig.g = _128COL;
+    }
+    if (col_orig.b >= _127_25COL && col_orig.b <= _128_75COL) {
+        col_orig.b = _128COL;
+    }
+    if (col_orig.a >= _127_25COL && col_orig.a <= _128_75COL) {
+        col_orig.a = _128COL;
+    }
+    //
+    vec4 col = col_orig;
+
+
+    if (col.rgb == vec3(0.0, 0.0, _128COL).rgb) {
+        col.rgb = left_head.rgb;
+    } else if (col.rgb == vec3(_181COL, 0.0, 1.0).rgb) {
+        col.rgb = right_backpack.rgb;
+    } else if (col.rgb == vec3(_104COL, 0.0, _168COL).rgb) {
+        col.rgb = left_backpack.rgb;
+    } else if (col.rgb == vec3(0.0, 0.0, 1.0).rgb){
+        col.rgb = right_head.rgb;
+    } else if (col.rgb == vec3(_128COL, _64COL, 1.0).rgb) {
+        col.rgb = left_muzzle.rgb;
+    } else if (col.rgb == vec3(_64COL, _128COL, 1.0).rgb) {
+        col.rgb = right_muzzle.rgb;
+    } else if (col.rgb == vec3(0.0, 1.0, 0.0).rgb) {
+        col.rgb = eye_lense.rgb;
+    } else if (col.rgb == vec3(1.0, _20COL, _147COL).rgb) {
+        col.rgb = right_chest.rgb;
+    } else if (col.rgb == vec3(_128COL, 0.0, _128COL).rgb) {
+        col.rgb = left_chest.rgb;
+    } else if (col.rgb == vec3(0.0, _128COL, _128COL).rgb) {
+        col.rgb = right_trim.rgb;
+    } else if (col.rgb == vec3(1.0, _128COL, 0.0).rgb) {
+        col.rgb = left_trim.rgb;
+    } else if (col.rgb == vec3(_135COL, _130COL, _188COL).rgb) {
+        col.rgb = metallic_trim.rgb;
+    } else if (col.rgb == vec3(1.0, 1.0, 1.0).rgb) {
+        col.rgb = right_pauldron.rgb;
+    } else if (col.rgb == vec3(1.0, 1.0, 0.0).rgb) {
+        col.rgb = left_pauldron.rgb;
+    } else if (col.rgb == vec3(0.0, _128COL, 0.0).rgb) {
+        col.rgb = right_leg_upper.rgb;
+    } else if (col.rgb == vec3(1.0, _112COL, _170COL).rgb) {
+        col.rgb = left_leg_upper.rgb;
+    } else if (col.rgb == vec3(1.0, 0.0, 0.0).rgb) {
+        col.rgb = left_leg_knee.rgb;
+    } else if (col.rgb == vec3(_128COL, 0.0, 0.0).rgb) {
+        col.rgb = left_leg_lower.rgb;
+    } else if (col.rgb == vec3(_214COL, _194COL, 1.0).rgb) {
+        col.rgb = right_leg_knee.rgb;
+    } else if (col.rgb == vec3(_165COL, _84COL, _24COL).rgb) {
+        col.rgb = right_leg_lower.rgb;
+    } else if (col.rgb == vec3(_138COL, _218COL, _140COL).rgb) {
+        col.rgb = right_arm.rgb;
+    } else if (col.rgb == vec3(_46COL, _169COL, _151COL).rgb) {
+        col.rgb = right_hand.rgb;
+    } else if (col.rgb == vec3(1.0, _230COL, _140COL).rgb) {
+        col.rgb = left_arm.rgb;
+    } else if (col.rgb == vec3(1.0, _160COL, _112COL).rgb) {
+        col.rgb = left_hand.rgb;
+    } else if (col.rgb == vec3(_128COL, _128COL, 0.0)) {
+        col.rgb = company_marks.rgb;
+    } else if (col.rgb == vec3(0.0, 1.0, 1.0)) {
+        col.rgb = weapon_primary.rgb;
+    } else if (col.rgb == vec3(1.0, 0.0, 1.0)) {
+        col.rgb = weapon_secondary.rgb;
+    }
+
+    if (col_orig.rgb != col.rgb) {
+        if (col_orig.a == _128COL){
+            col.rgb = light_or_dark(col.rgb, 1.2);
+            col.a = 1.0;
+        } else if (col_orig.a == _60COL) {
+            col.rgb = light_or_dark(col.rgb, 1.4);
+            col.a = 1.0;
+        } else if (col_orig.a == _215COL) {
+            col.rgb = light_or_dark(col.rgb,0.6);
+            col.a = 1.0;
+        } else if (col_orig.a == _160COL) {
+            col.rgb = light_or_dark(col.rgb, 0.8);
+            col.a = 1.0;
+        }
+    }
+
+    const vec3 robes_colour_base = vec3(201.0 / 255.0, 178.0 / 255.0, 147.0 / 255.0);
+    const vec3 robes_highlight = vec3(230.0 / 255.0, 203.0 / 255.0, 168.0 / 255.0);
+    const vec3 robes_darkness = vec3(189.0 / 255.0, 167.0 / 255.0, 138.0 / 255.0);
+    const vec3 robes_colour_base_2 = vec3(169.0 / 255.0, 150.0 / 255.0, 123.0 / 255.0);
+    const vec3 robes_highlight_2 = vec3(186.0 / 255.0, 165.0 / 255.0, 135.0 / 255.0);
+    const vec3 robes_darkness_2 = vec3(148.0 / 255.0, 132.0 / 255.0, 108.0 / 255.0);
+    if (col.rgb == robes_colour_base.rgb || col.rgb == robes_colour_base_2.rgb) {
+        col.rgb = light_or_dark(robes_colour_replace , 1.0).rgb;
+    } else if (col.rgb == robes_highlight.rgb || col.rgb == robes_highlight_2.rgb) {
+        col.rgb = light_or_dark(robes_colour_replace , 1.25).rgb;
+    //col.rgb = mix(robes_highlight.rgb, robes_colour_replace.rgb, 0.25);
+    } else if (col.rgb == robes_darkness.rgb || col.rgb == robes_darkness_2.rgb) {
+    //col.rgb = vec3(col.r*0.8, col.g*0.8, col.b*0.8).rgb;
+    //col.rgb = robes_colour_replace.rgb;
+    //col.rgb = mix(robes_darkness.rbg, robes_colour_replace.rgb, 0.25);
+        col.rgb = light_or_dark(robes_colour_replace , 0.75).rgb;
+    }
 
     gl_FragColor = v_vColour * col;
-
 }

--- a/shaders/helm_shader/helm_shader.fsh
+++ b/shaders/helm_shader/helm_shader.fsh
@@ -7,12 +7,13 @@ varying vec4 v_vColour;
 uniform vec3 replace_colour;
 uniform sampler2D background_texture;
 
-void main()
-{
+void main() {
 // Remap v_vTexcoord to the UV bounds
-	vec4 col = texture2D(gm_BaseTexture, v_vTexcoord);
+    const float _200COL = 200.0 / 255.0;
 
-    if (col.rgb == vec3(200.0/255.0,0.0,0.0)){
+    vec4 col = texture2D(gm_BaseTexture, v_vTexcoord);
+
+    if (col.rgb == vec3(_200COL, 0.0, 0.0)) {
         col.rgb = replace_colour.rgb;        
     }
 

--- a/shaders/light_dark_shader/light_dark_shader.fsh
+++ b/shaders/light_dark_shader/light_dark_shader.fsh
@@ -6,10 +6,10 @@ varying vec4 v_vColour;
 
 uniform float highlight;
 vec3 light_or_dark(vec3 m_colour, float shade){
-  return vec3((m_colour.r * shade) + 0.01, m_colour.g * shade, m_colour.b * shade);
+    return vec3((m_colour.r * shade) + 0.01, m_colour.g * shade, m_colour.b * shade);
 }
-void main()
-{
+
+void main() {
     vec4 col = texture2D(gm_BaseTexture, v_vTexcoord);
     col.rgb = light_or_dark(col.rgb, highlight);
     gl_FragColor = v_vColour * col;

--- a/shaders/sReplaceColor/sReplaceColor.fsh
+++ b/shaders/sReplaceColor/sReplaceColor.fsh
@@ -26,106 +26,78 @@ uniform int u_blend_modes;
 uniform sampler2D background_texture;
 uniform sampler2D armour_texture;
 
-vec3 light_or_dark(vec3 m_colour, float shade){
+vec3 light_or_dark(vec3 m_colour, float shade) {
   return vec3((m_colour.r * shade) + 0.01, m_colour.g * shade, m_colour.b * shade);
 }
 
-void main()
-{
-  vec3 robes_colour_base = vec3(201.0 / 255.0, 178.0 / 255.0, 147.0 / 255.0);
-  vec3 robes_highlight = vec3(230.0 / 255.0, 203.0 / 255.0, 168.0 / 255.0);
-  vec3 robes_darkness = vec3(189.0 / 255.0, 167.0 / 255.0, 138.0 / 255.0);
-  vec3 robes_colour_base_2 = vec3(169.0 / 255.0, 150.0 / 255.0, 123.0 / 255.0);
-  vec3 robes_highlight_2 = vec3(186.0 / 255.0, 165.0 / 255.0, 135.0 / 255.0);
-  vec3 robes_darkness_2 = vec3(148.0 / 255.0, 132.0 / 255.0, 108.0 / 255.0);
-  vec4 col = texture2D(gm_BaseTexture, v_vTexcoord);
-  if (u_blend_modes==3 && (col.rgb == f_Colour1.rgb|| col.rgb == f_Colour2.rgb)){
-    vec4 background = texture2D(background_texture, v_vTexcoord);
-    if (background.rgb==helm_replace.rgb || background.rgb==helm_second_replace.rgb || helm_lense_replace.rgb==helm_replace.rgb){
-      col.rgb = background.rgb;
+void main() {
+    const vec3 robes_colour_base = vec3(201.0 / 255.0, 178.0 / 255.0, 147.0 / 255.0);
+    const vec3 robes_highlight = vec3(230.0 / 255.0, 203.0 / 255.0, 168.0 / 255.0);
+    const vec3 robes_darkness = vec3(189.0 / 255.0, 167.0 / 255.0, 138.0 / 255.0);
+    const vec3 robes_colour_base_2 = vec3(169.0 / 255.0, 150.0 / 255.0, 123.0 / 255.0);
+    const vec3 robes_highlight_2 = vec3(186.0 / 255.0, 165.0 / 255.0, 135.0 / 255.0);
+    const vec3 robes_darkness_2 = vec3(148.0 / 255.0, 132.0 / 255.0, 108.0 / 255.0);
+
+    vec4 col = texture2D(gm_BaseTexture, v_vTexcoord);
+    if (u_blend_modes == 3 && (col.rgb == f_Colour1.rgb || col.rgb == f_Colour2.rgb)){
+        vec4 background = texture2D(background_texture, v_vTexcoord);
+        if (background.rgb == helm_replace.rgb || background.rgb == helm_second_replace.rgb || helm_lense_replace.rgb == helm_replace.rgb) {
+            col.rgb = background.rgb;
+        }
+    } else if (col.rgb == f_Colour1.rgb && u_blend_modes != 2 && u_blend_modes != 3) {
+        col.rgb = f_Replace1.rgb;
+    } else if (col.rgb == f_Replace1.rgb && u_blend_modes == 2) {//draw textured armour
+        vec2 i = vec2(5.0 * v_vTexcoord.x, 5.0 * v_vTexcoord.y);
+        while (i.x > 1.0){
+            i.x -= 1.0;
+        }
+        while (i.y > 1.0) {
+            i.y -= 1.0;
+        }
+        vec4 armour_texture_col = texture2D(armour_texture, i);
+        col.rgb = armour_texture_col.rgb;
     }
-  }   
-  if (col.rgb == f_Colour1.rgb && u_blend_modes!=2)
-  {
-    if (u_blend_modes!=3){
-      col.rgb = f_Replace1.rgb;
+
+    if (col.rgb == f_Colour2.rgb) {
+        col.rgb = f_Replace2.rgb;
+    } else if (col.rgb == f_Colour3.rgb) {
+        col.rgb = f_Replace3.rgb;
+    } else if (col.rgb == f_Colour4.rgb) {
+        col.rgb = f_Replace4.rgb;
+    } else if (col.rgb == f_Colour5.rgb) {
+        col.rgb = f_Replace5.rgb;
+    } else if (col.rgb == f_Colour6.rgb) {
+        col.rgb = f_Replace6.rgb;
+    } else if (col.rgb == f_Colour7.rgb) {
+        col.rgb = f_Replace7.rgb;
+    } else if (col.rgb == robes_colour_base.rgb || col.rgb == robes_colour_base_2.rgb) {
+        col.rgb = light_or_dark(robes_colour_replace, 1.0).rgb;
+    } else if (col.rgb == robes_highlight.rgb || col.rgb == robes_highlight_2.rgb) {
+        col.rgb = light_or_dark(robes_colour_replace, 1.25).rgb;
+        //col.rgb = mix(robes_highlight.rgb, robes_colour_replace.rgb, 0.25);
+    } else if (col.rgb == robes_darkness.rgb || col.rgb == robes_darkness_2.rgb) {
+        //col.rgb = vec3(col.r*0.8, col.g*0.8, col.b*0.8).rgb;
+        //col.rgb = robes_colour_replace.rgb;
+        //col.rgb = mix(robes_darkness.rbg, robes_colour_replace.rgb, 0.25);
+        col.rgb = light_or_dark(robes_colour_replace, 0.75).rgb;
     }
-  }
-  if (col.rgb == f_Replace1.rgb && u_blend_modes==2){//draw textured armour
-    vec2 i=vec2(5.0*v_vTexcoord.x, 5.0*v_vTexcoord.y);
-    while (i.x>1.0){
-        i.x-=1.0;
+
+    if (u_blend_modes == 1) {
+        vec3 robe = light_or_dark(robes_colour_replace, 1.0).rgb;
+        vec3 robe_light = light_or_dark(robes_colour_replace, 1.25).rgb;
+        vec3 robe_dark = light_or_dark(robes_colour_replace, 0.75).rgb;
+
+        vec4 background_col = texture2D(background_texture, v_vTexcoord);
+
+        if (background_col.rgb == robe.rgb) {
+            col.a = 0.0;
+        } else if (background_col.rgb == robe_light.rgb) {
+            col.a = 0.0;
+        } else if (background_col.rgb == robe_dark.rgb) {
+            col.a = 0.0;
+        } else if ((background_col.rgb != f_Replace1.rgb) && (background_col.rgb != f_Replace2.rgb) && (background_col.rgb != f_Replace3.rgb) && background_col.a > 0.0 ) {
+            col.a = 0.0;
+        }
     }
-    while (i.y>1.0){
-        i.y-=1.0;
-    }
-    vec4 armour_texture_col = texture2D(armour_texture, i);
-    col.rgb = armour_texture_col.rgb;
-  }
-
-  if (col.rgb == f_Colour2.rgb)
-  {
-    col.rgb = f_Replace2.rgb;
-  }
-
-  if (col.rgb == f_Colour3.rgb)
-  {
-    col.rgb = f_Replace3.rgb;
-  }
-
-  if (col.rgb == f_Colour4.rgb)
-  {
-    col.rgb = f_Replace4.rgb;
-  }
-
-  if (col.rgb == f_Colour5.rgb)
-  {
-    col.rgb = f_Replace5.rgb;
-  }
-
-  if (col.rgb == f_Colour6.rgb)
-  {
-    col.rgb = f_Replace6.rgb;
-  }
-
-  if (col.rgb == f_Colour7.rgb)
-  {
-    col.rgb = f_Replace7.rgb;
-  }
-
-  if (col.rgb == robes_colour_base.rgb || col.rgb == robes_colour_base_2.rgb)
-  {
-    col.rgb = light_or_dark(robes_colour_replace , 1.0).rgb;
-  }
-  if (col.rgb == robes_highlight.rgb || col.rgb == robes_highlight_2.rgb) {
-    col.rgb = light_or_dark(robes_colour_replace , 1.25).rgb;
-    //col.rgb = mix(robes_highlight.rgb, robes_colour_replace.rgb, 0.25);
-  }
-  if (col.rgb == robes_darkness.rgb || col.rgb == robes_darkness_2.rgb) {
-    //col.rgb = vec3(col.r*0.8, col.g*0.8, col.b*0.8).rgb;
-    //col.rgb = robes_colour_replace.rgb;
-    //col.rgb = mix(robes_darkness.rbg, robes_colour_replace.rgb, 0.25);
-    col.rgb = light_or_dark(robes_colour_replace , 0.75).rgb;
-  }
-  if (u_blend_modes == 1) {
-    vec3 robe = light_or_dark(robes_colour_replace, 1.0).rgb;
-    vec3 robe_light = light_or_dark(robes_colour_replace, 1.25).rgb;
-    vec3 robe_dark = light_or_dark(robes_colour_replace, 0.75).rgb;
-
-    vec4 background_col = texture2D(background_texture, v_vTexcoord);
-
-    if (background_col.rgb == robe.rgb) {
-      col.a = 0.0;
-    }
-    if (background_col.rgb == robe_light.rgb) {
-      col.a = 0.0;
-    }
-    if (background_col.rgb ==robe_dark.rgb){
-      col.a = 0.0;
-    }
-    if ((background_col.rgb != f_Replace1.rgb) && (background_col.rgb != f_Replace2.rgb) && (background_col.rgb != f_Replace3.rgb) && background_col.a >0.0 ) {
-      col.a = 0.0;
-    }
-  }
-  gl_FragColor = v_vColour * col;
+    gl_FragColor = v_vColour * col;
 }


### PR DESCRIPTION
### Purpose of changes
Reformat, slight perf gains and attempt to workaround intel bug.

### Describe the solution
Using constant vars to precalc, use elses, and discards to drop out early.

Check range 127.25 to 128.75 and convert to 128.0.

### Testing done
Check chapter marine creator thing, new game.

### Related links
https://discord.com/channels/714022226810372107/1345991168021893192

### Custom player notes entry
<!-- This will be added to the PR description in the release notes. List changes that players may be interested in, in simple words. -->
Use the PR title.

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->
<!--- "Inspired" by the CDDA PR template -->
