### PR TITLE
fix: Forge imperium ships merging

### DIFF
--- a/objects/obj_en_fleet/Collision_obj_en_fleet.gml
+++ b/objects/obj_en_fleet/Collision_obj_en_fleet.gml
@@ -2,15 +2,15 @@ if (last_turn_check == obj_controller.turn){
     exit;
 }
 
-var _same_navy = navy == other.navy;
-if (other.owner == self.owner && _same_navy) {
-    if !(action_x == other.action_x && action_y == other.action_y) { exit; }
-
-    if (trade_goods != "" && other.trade_goods != "") && (!fleet_has_cargo("colonize") && !fleet_has_cargo("colonize", other)) {
-        if (action_x == other.action_x && action_y == other.action_y) && (!fleet_has_cargo("ork_warboss") && !fleet_has_cargo("ork_warboss", other)) { // ork_warboss would never match as it seems only imperium ships get the 'merge' directive
-            if (string_count("merge", trade_goods) > 0 && string_count("merge", other.trade_goods) > 0) {
-                if (id > other.id) {
-                   merge_fleets(other.id, self.id);
+if (id > other.id) {
+    if (string_count("merge", trade_goods) > 0 && string_count("merge", other.trade_goods) > 0) {
+        var _same_navy = navy == other.navy;
+        if (other.owner == self.owner && _same_navy) {
+            if (action_x == other.action_x && action_y == other.action_y) {
+                if (trade_goods != "" && other.trade_goods != "") && (!fleet_has_cargo("colonize") && !fleet_has_cargo("colonize", other)) {
+                    if (!fleet_has_cargo("ork_warboss") && !fleet_has_cargo("ork_warboss", other)) { // ork_warboss would never match as it seems only imperium ships get the 'merge' directive
+                        merge_fleets(other.id, self.id);
+                    }
                 }
             }
         }

--- a/objects/obj_en_fleet/Collision_obj_en_fleet.gml
+++ b/objects/obj_en_fleet/Collision_obj_en_fleet.gml
@@ -1,20 +1,15 @@
-
 if (last_turn_check == obj_controller.turn){
     exit;
 }
+
 var _same_navy = navy == other.navy;
-if (other.owner==self.owner && _same_navy){
-    if !((action_x=other.action_x) and (action_y=other.action_y)) then exit;
+if (other.owner == self.owner && _same_navy) {
+    if !(action_x == other.action_x && action_y == other.action_y) { exit; }
 
-
-    if ((trade_goods!="") && (other.trade_goods!="") && !fleet_has_cargo("colonize") && !fleet_has_cargo("colonize", other)){
-
-
-        if (action_x=other.action_x) and (action_y=other.action_y) and (!(fleet_has_cargo("ork_warboss"))) and ( !(fleet_has_cargo("ork_warboss", other))){
-
-
-            if (string_count("!",trade_goods)>0) and (string_count("!",other.trade_goods)>0){
-                if (id>other.id){
+    if (trade_goods != "" && other.trade_goods != "") && (!fleet_has_cargo("colonize") && !fleet_has_cargo("colonize", other)) {
+        if (action_x == other.action_x && action_y == other.action_y) && (!fleet_has_cargo("ork_warboss") && !fleet_has_cargo("ork_warboss", other)) { // ork_warboss would never match as it seems only imperium ships get the 'merge' directive
+            if (string_count("merge", trade_goods) > 0 && string_count("merge", other.trade_goods) > 0) {
+                if (id > other.id) {
                    merge_fleets(other.id, self.id);
                 }
             }
@@ -22,5 +17,3 @@ if (other.owner==self.owner && _same_navy){
     }
 }
 last_turn_check = obj_controller.turn;
-
-

--- a/objects/obj_en_fleet/Collision_obj_en_fleet.gml
+++ b/objects/obj_en_fleet/Collision_obj_en_fleet.gml
@@ -3,11 +3,11 @@ if (last_turn_check == obj_controller.turn){
 }
 
 if (id > other.id) {
-    if (string_count("merge", trade_goods) > 0 && string_count("merge", other.trade_goods) > 0) {
+    if (trade_goods != "" && other.trade_goods != "" && string_count("merge", trade_goods) > 0 && string_count("merge", other.trade_goods) > 0) {
         var _same_navy = navy == other.navy;
         if (other.owner == self.owner && _same_navy) {
             if (action_x == other.action_x && action_y == other.action_y) {
-                if (trade_goods != "" && other.trade_goods != "") && (!fleet_has_cargo("colonize") && !fleet_has_cargo("colonize", other)) {
+                if (!fleet_has_cargo("colonize") && !fleet_has_cargo("colonize", other)) {
                     if (!fleet_has_cargo("ork_warboss") && !fleet_has_cargo("ork_warboss", other)) { // ork_warboss would never match as it seems only imperium ships get the 'merge' directive
                         merge_fleets(other.id, self.id);
                     }


### PR DESCRIPTION
### Purpose of changes
Allow Imperium forge ships to merge.

### Describe the solution
`string_count("!",trade_goods)>0` to `string_count("merge", trade_goods) > 0`

### Testing done
Load game, next turn.

https://discord.com/channels/714022226810372107/1121959429546455050/1350271258855477269
<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->
<!--- "Inspired" by the CDDA PR template -->
