### PR TITLE
perf: Run GC more often and change its logging

### DIFF
--- a/objects/obj_garbage_collector/Step_0.gml
+++ b/objects/obj_garbage_collector/Step_0.gml
@@ -2,21 +2,21 @@ if (gc_timer > 0) {
     gc_timer -= 1;
     // show_debug_message($"obj_garbage_collector: gc_timer = {gc_timer}");
 } else {
-    gc_timer = 100; // Default is every frame, so de-facto 1;
+    gc_timer = 50; // Default is every frame, so de-facto 1;
     gc_collect();
 
     wait_and_execute(0, function(){
         var _gc_stats = gc_get_stats();
-        var _gc_touched = $"Objects Touched: {_gc_stats.objects_touched}";
-        var _gc_collected = $"Objects Collected: {_gc_stats.objects_collected}";
-        var _gc_traversal_t = $"Traversal Time: {_gc_stats.traversal_time} μs";
-        var _gc_collection_t = $"Collection Time: {_gc_stats.collection_time} μs";
+        var _gc_touched = $"Touched: {_gc_stats.objects_touched}";
+        var _gc_collected = $"Collected: {_gc_stats.objects_collected}";
+        var _gc_traversal_t = $"T1: {round(_gc_stats.traversal_time / 1000)} ms";
+        var _gc_collection_t = $"T2: {round(_gc_stats.collection_time / 1000)} ms";
         var _gc_lines = [_gc_touched, _gc_collected, _gc_traversal_t, _gc_collection_t];
         // show_debug_message_time($"(GC{_gc_stats.gc_frame}) Garbage Collected!");
 
-        var _gc_message = $"Garbage Collected {_gc_stats.gc_frame}!";
+        var _gc_message = $"";
         for (var i = 0; i < array_length(_gc_lines); i++) {
-            _gc_message += $" {_gc_lines[i]}.";
+            _gc_message += $"{_gc_lines[i]}. ";
         }
         log_message(_gc_message);
     });


### PR DESCRIPTION
### Purpose of changes
<!-- With a few sentences, describe your reasons for making these changes. -->
- GC was running with delays that are too big in comparison to the defaults.
- us are kinda unreadable.
- Debug lines are too long and not super informative.

### Describe the solution
<!-- How does the feature work, or how does this fix a bug? -->
- Reduce the GC delay by two times, to 50 steps from 100.
- Convert the displayed us to ms.
- Reduce the debug line length by removing some not strictly necessary text.

### Describe alternatives you've considered
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
- Rare GC can actually make the gameplay worse, because too much garbage accumulated between the passes, causing stutters on big collections.
- Too frequent GC can actually make the gameplay worse as well, because frequent passes stutter the game due to traversal times.
- The goal is to find a middle ground, and I think 50 doesn't worsen the flow in comparison to 100, considering that the GM default is 1 iirc.

### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
Let the game run for a bit.

### Related links
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
None

### Custom player notes entry
<!-- This will be added to the PR description in the release notes. List changes that players may be interested in, in simple words. -->
Use the PR title.

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->
<!--- "Inspired" by the CDDA PR template -->
