### PR TITLE
fix: Marine unloading/loading typo

### DIFF
--- a/scripts/scr_ui_manage/scr_ui_manage.gml
+++ b/scripts/scr_ui_manage/scr_ui_manage.gml
@@ -16,8 +16,8 @@ function load_marines_into_ship(system, ship, units, reload=false) {
             ma_lid[loop] = sh_ide[ship];
             ma_wid[loop] = 0;
             _set(obj_ini.veh_loc, vehicle,sh_name[ship])
-            _set(obj_ini.veh_lid, vehicle, sh_name[ship])
-            _set(obj_ini.veh_wid, vehicle, sh_ide[ship])
+            _set(obj_ini.veh_lid, vehicle, sh_ide[ship])
+            _set(obj_ini.veh_wid, vehicle, 0)
             _set(obj_ini.veh_uid, vehicle, sh_uid[ship])
             obj_ini.ship_carrying[sh_ide[ship]] += size;
 


### PR DESCRIPTION
### Purpose of changes
<!-- With a few sentences, describe your reasons for making these changes. -->
Fix a crash on unloading.

### Describe the solution
<!-- How does the feature work, or how does this fix a bug? -->
Vehicle location id = ship id.
Vehicle world id = 0 on load.

### Describe alternatives you've considered
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
None

### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
Loaded the whole 10th company into a ship and unloaded. No crashes or other visual errors.

### Related links
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
https://discord.com/channels/714022226810372107/1351230298360123412/1351330597510971434

### Custom player notes entry
<!-- This will be added to the PR description in the release notes. List changes that players may be interested in, in simple words. -->
Use the PR title.

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->
<!--- "Inspired" by the CDDA PR template -->
