### PR TITLE
chore: Default save image index -1

### DIFF
--- a/objects/obj_saveload/Create_0.gml
+++ b/objects/obj_saveload/Create_0.gml
@@ -56,10 +56,10 @@ first_open=saves+1;
 
 
 
-img1=0;
-img2=0;
-img3=0;
-img4=0;
+img1=-1;
+img2=-1;
+img3=-1;
+img4=-1;
 
 
 


### PR DESCRIPTION
### Purpose of changes
<!-- With a few sentences, describe your reasons for making these changes. -->
When the code to delete the sprite runs on instance destruction, the room sprite was getting deleted, apparently.

### Describe the solution
<!-- How does the feature work, or how does this fix a bug? -->
Change default save image index from 0 to -1 (if not overwritten).

### Describe alternatives you've considered
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
None

### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
On VM compile, save/loading works fine now, no sprites are broken.
Need to test it with YYC.

### Related links
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
https://discord.com/channels/714022226810372107/1351230298360123412/1351261248444039188

### Custom player notes entry
<!-- This will be added to the PR description in the release notes. List changes that players may be interested in, in simple words. -->
Use the PR title.

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->
<!--- "Inspired" by the CDDA PR template -->
