### PR TITLE
feat: Adjust how the starting disposition is affected by the sliders

### DIFF
--- a/scripts/scr_creation/scr_creation.gml
+++ b/scripts/scr_creation/scr_creation.gml
@@ -113,14 +113,19 @@ function scr_creation(slide_num) {
 				disposition[eSTART_FACTION.Inquisition] = 30 + ((cooperation - 5) * 2) - (2 * (10 - purity)) - (2 * (10 - stability)); // Inq
 				disposition[eSTART_FACTION.Ecclesiarchy] = 40 + ((cooperation - 5) * 4)  - (10 - purity) - ((10 - stability)); // Ecclesiarchy
 			
-				if (founding == eCHAPTERS.SPACE_WOLVES) {
-					disposition[eSTART_FACTION.Progenitor] = 70;
-				} else if (founding == eCHAPTERS.IMPERIAL_FISTS) {
-					disposition[eSTART_FACTION.Progenitor] = 50;
-				} else if (founding == eCHAPTERS.SALAMANDERS) {
-					disposition[eSTART_FACTION.Progenitor] = 70;
-				} else if (founding == 10) { // random/unknown
-					disposition[eSTART_FACTION.Inquisition] -= 5;
+				switch (founding) {
+					case eCHAPTERS.SPACE_WOLVES:
+					case eCHAPTERS.SALAMANDERS:
+						disposition[eSTART_FACTION.Progenitor] = 70;
+						break;
+					case eCHAPTERS.IMPERIAL_FISTS:
+						disposition[eSTART_FACTION.Progenitor] = 50;
+						break;
+					case eCHAPTERS.UNKNOWN:
+						disposition[eSTART_FACTION.Inquisition] -= 5;
+						break;
+					default:
+						break;
 				}
 
 				if (strength > 5) {

--- a/scripts/scr_creation/scr_creation.gml
+++ b/scripts/scr_creation/scr_creation.gml
@@ -158,6 +158,7 @@ function scr_creation(slide_num) {
 				}
 				if (scr_has_adv("Warp Touched")) {
 					disposition[eSTART_FACTION.Inquisition] -= 4;
+					disposition[eSTART_FACTION.Ecclesiarchy] -= 4;
 				}
 				if (scr_has_disadv("Tolerant")) {
 					disposition[eSTART_FACTION.Progenitor] -= 5;

--- a/scripts/scr_creation/scr_creation.gml
+++ b/scripts/scr_creation/scr_creation.gml
@@ -1,3 +1,13 @@
+enum eSTART_FACTION {
+	Progenitor = 1,
+	Imperium,
+	Mechanicus,
+	Inquisition,
+	Ecclesiarchy,
+	Astartes,
+	Reserved,
+}
+
 /// @mixin obj_creation
 function scr_creation(slide_num) {
 
@@ -95,75 +105,69 @@ function scr_creation(slide_num) {
 	            if (purity=10) then mutations=0;
 	        }
         
-	        if (custom>0){
-	            disposition[0]=0;
-	            disposition[1]=60;// Prog
-	            disposition[2]=0;// Imp
-	            disposition[3]=0;// Mech
-	            disposition[4]=0;// Inq
-	            disposition[5]=0;// Ecclesiarchy
-	            disposition[6]=50;// Astartes
-	            disposition[7]=0;// Reserved
-            
-	            if (founding==eCHAPTERS.SPACE_WOLVES) then disposition[1]=70;
-	            if (founding==eCHAPTERS.IMPERIAL_FISTS) then disposition[1]=50;
-	            if (founding==eCHAPTERS.SALAMANDERS) then disposition[1]=70;
-            
-	            disposition[2]=50;
-	            disposition[3]=40;
-	            disposition[4]=30;
-	            disposition[5]=40;
-            
-	            if (strength>5) then disposition[4]-=(strength-5)*2;
-	            if (purity<6) then disposition[4]-=5;
-	            if (founding==10) then disposition[4]-=5; // random/unknown
-            
-	            if (cooperation<5){
-	                disposition[6]-=(6-cooperation)*2;
-	                disposition[5]-=(6-cooperation)*2;
-	                disposition[4]-=(6-cooperation);
-	                disposition[3]-=(6-cooperation);
-	                disposition[2]-=(6-cooperation)*2;
-	            }
-            
-	            if(scr_has_adv("Crafters")){
-					disposition[3]+=2;
+			if (custom > 0) {
+				disposition[0] = 0;
+				disposition[eSTART_FACTION.Progenitor] = 60 + ((cooperation - 5) * 4); // Prog
+				disposition[eSTART_FACTION.Imperium] = 50 + ((cooperation - 5) * 4); // Imp
+				disposition[eSTART_FACTION.Mechanicus] = 40 + ((cooperation - 5) * 2); // Mech
+				disposition[eSTART_FACTION.Inquisition] = 30 + ((cooperation - 5) * 2) - (2 * (10 - purity)) - (2 * (10 - stability)); // Inq
+				disposition[eSTART_FACTION.Ecclesiarchy] = 40 + ((cooperation - 5) * 4)  - (10 - purity) - ((10 - stability)); // Ecclesiarchy
+			
+				if (founding == eCHAPTERS.SPACE_WOLVES) {
+					disposition[eSTART_FACTION.Progenitor] = 70;
+				} else if (founding == eCHAPTERS.IMPERIAL_FISTS) {
+					disposition[eSTART_FACTION.Progenitor] = 50;
+				} else if (founding == eCHAPTERS.SALAMANDERS) {
+					disposition[eSTART_FACTION.Progenitor] = 70;
+				} else if (founding == 10) { // random/unknown
+					disposition[eSTART_FACTION.Inquisition] -= 5;
 				}
-				if(scr_has_adv("Tech-Brothers")){
-					disposition[3]+=10;
+
+				if (strength > 5) {
+					disposition[eSTART_FACTION.Inquisition] -= (strength - 5) * 2;
+				} else if (strength < 5) {
+					disposition[eSTART_FACTION.Imperium] += (5 - strength) * 2;
 				}
-				if(scr_has_disadv("Psyker Intolerant")){
-					disposition[4]+=5;
+			
+				if (scr_has_adv("Crafters")) {
+					disposition[eSTART_FACTION.Mechanicus] += 2;
 				}
-				if(scr_has_disadv("Warp Tainted")){
-					disposition[1]-=10;
-					disposition[2]-=10;
-					disposition[3]-=10;
-					disposition[4]-=10;
-					disposition[5]-=10;
-					disposition[6]-=10;
+				if (scr_has_adv("Tech-Brothers")) {
+					disposition[eSTART_FACTION.Mechanicus] += 10;
 				}
-				if(scr_has_disadv("Sieged")){
-					disposition[6]+=5;
+				if (scr_has_disadv("Psyker Intolerant")) {
+					disposition[eSTART_FACTION.Inquisition] += 5;
+					disposition[eSTART_FACTION.Ecclesiarchy] += 5;
 				}
-				if(scr_has_disadv("Suspicious")){
-					disposition[4]-=15;
+				if (scr_has_disadv("Warp Tainted")) {
+					disposition[eSTART_FACTION.Progenitor] -= 10;
+					disposition[eSTART_FACTION.Imperium] -= 10;
+					disposition[eSTART_FACTION.Mechanicus] -= 10;
+					disposition[eSTART_FACTION.Inquisition] -= 10;
+					disposition[eSTART_FACTION.Ecclesiarchy] -= 10;
+					disposition[eSTART_FACTION.Astartes] -= 10;
 				}
-				if(scr_has_disadv("Tech-Heresy")){
-					disposition[3]-=8;
+				if (scr_has_disadv("Sieged")) {
+					disposition[eSTART_FACTION.Imperium] += 5;
 				}
-				if(scr_has_adv("Warp Touched")){
-					disposition[4]-=4;
+				if (scr_has_disadv("Suspicious")) {
+					disposition[eSTART_FACTION.Inquisition] -= 15;
 				}
-				if(scr_has_disadv("Tolerant")){
-	                disposition[1]-=5;
-					disposition[2]-=5;
-	                disposition[3]-=5;
-					disposition[4]-=5;
-					disposition[5]-=5;
-					disposition[6]-=5;
+				if (scr_has_disadv("Tech-Heresy")) {
+					disposition[eSTART_FACTION.Mechanicus] -= 8;
 				}
-	        }
+				if (scr_has_adv("Warp Touched")) {
+					disposition[eSTART_FACTION.Inquisition] -= 4;
+				}
+				if (scr_has_disadv("Tolerant")) {
+					disposition[eSTART_FACTION.Progenitor] -= 5;
+					disposition[eSTART_FACTION.Imperium] -= 5;
+					disposition[eSTART_FACTION.Mechanicus] -= 5;
+					disposition[eSTART_FACTION.Inquisition] -= 5;
+					disposition[eSTART_FACTION.Ecclesiarchy] -= 5;
+					disposition[eSTART_FACTION.Astartes] -= 5;
+				}
+			}
 	    }
 	}
 


### PR DESCRIPTION
### Purpose of changes
<!-- With a few sentences, describe your reasons for making these changes. -->
- In the original formulas, cooperation slider was not very good imo, both if you scroll it down or up. Free 10 points.
- Disposition was only affected by the purity, when stability also means mutated marines, even worse, actually.
- Strength was only reducing disposition when above 5, not increasing when below. A bit weird.

### Describe the solution
<!-- How does the feature work, or how does this fix a bug? -->
- Each point of cooperation now gives/takes 4 disposition with all factions, except inquisition and mechanicus. They get 2 per point.
- Each point of purity below 10 reduces disposition with inquisition by 2, with ecclesiarchy by 1.
- Each point of stability below 10 reduces disposition with inquisition by 2, with ecclesiarchy by 1.
- Each point of strength below 5 now increases imperium disposition by 2.
- Daemon Binders now also reduces the church dispo by 8.
- Psyker related traits also reduce/add the church disposition, in addition to inquisition.
- There is now an enum to ease readability.

### Describe alternatives you've considered
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
None

### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
None

### Related links
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
None

### Custom player notes entry
<!-- This will be added to the PR description in the release notes. List changes that players may be interested in, in simple words. -->
Use the PR title.

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->
<!--- "Inspired" by the CDDA PR template -->
