### PR TITLE
fix: Marine location consistency

### DIFF
--- a/objects/obj_ini/Create_0.gml
+++ b/objects/obj_ini/Create_0.gml
@@ -30,6 +30,7 @@ penitent_max=0;
 penitent_current=0;
 penitent_end=0;
 man_size=0;
+home_planet = 2;
 
 // Equipment- maybe the bikes should go here or something?          yes they should
 i=-1;

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -308,7 +308,7 @@ global.base_stats = { //tempory stats subject to change by anyone that wishes to
 function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data={}) constructor{
 	constitution=0; strength=0;luck=0;dexterity=0;wisdom=0;piety=0;charisma=0;technology=0;intelligence=0;weapon_skill=0;ballistic_skill=0;size = 0;planet_location=0;
 	if (!instance_exists(obj_controller) && class!="blank"){//game start unit planet location
-		planet_location=2;
+		planet_location = obj_ini.home_planet;
 	}
 	ship_location=-1;
     last_ship = {uid : "", name : ""};

--- a/scripts/scr_player_fleet_functions/scr_player_fleet_functions.gml
+++ b/scripts/scr_player_fleet_functions/scr_player_fleet_functions.gml
@@ -490,12 +490,21 @@ function fleet_full_ship_array(fleet="none", exclude_capitals=false, exclude_fri
 	return all_ships;
 }
 function set_fleet_location(location){
-	fleet_ships = fleet_full_ship_array();
+	var fleet_ships = fleet_full_ship_array();
 	var temp;
 	for (var i=0;i<array_length(fleet_ships);i++){
 		temp = fleet_ships[i];
 		if (temp>=0 && temp < array_length(obj_ini.ship_location)){
 			obj_ini.ship_location[temp] = location;
+		}
+	}
+	var unit;
+	for (var co=0;co<=obj_ini.companies;co++){
+		for (i=0;i<array_length(obj_ini.name[co]);i++){
+			unit = fetch_unit([co,i]);
+			if (array_contains(fleet_ships, unit.ship_location)){
+				obj_ini.loc[co][i]=location;
+			}
 		}
 	}
 }

--- a/scripts/scr_system_spawn_functions/scr_system_spawn_functions.gml
+++ b/scripts/scr_system_spawn_functions/scr_system_spawn_functions.gml
@@ -57,6 +57,7 @@ function player_home_star(home_planet){
 
         p_type[home_planet]=obj_ini.home_type;
         planet[home_planet]=1;
+        obj_ini.home_planet = home_planet;
 
         if (obj_ini.home_name!="random"){
             array_push(global.name_generator.star_used_names, obj_ini.home_name);
@@ -88,6 +89,16 @@ function player_home_star(home_planet){
         if (global.chapter_name!="Lamenters") then obj_controller.recruiting_worlds+=string(name)+" I|";
         
         p_player[home_planet]=obj_ini.man_size;
+
+		var unit;
+		for (var co=0;co<=obj_ini.companies;co++){
+			for (i=0;i<array_length(obj_ini.name[co]);i++){
+				unit = fetch_unit([co,i]);
+				if (obj_ini.loc[co][i] == name){
+					unit.planet_location = home_planet;
+				}
+			}
+		}
 }
 
 


### PR DESCRIPTION
### Purpose of changes
make sure marines spawn on the planet with the players fortress monastery if applicable
make sure marine location updates with fleet location so marines do not end up showing in the wrong location
### Describe the solution
<!-- How does the feature work, or how does this fix a bug? -->
- fixes two reported bug

### Describe alternatives you've considered
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
None

### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
started several new games and tested location move, fleet and test if marines are logged in the correct locations

### Related links
[<!-- Other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
https://discord.com/channels/714022226810372107/1120687959365128243/threads/1352117591560421416
https://discord.com/channels/714022226810372107/1348610026272718918
### Custom player notes entry
<!-- This will be added to the PR description in the release notes. List changes that players may be interested in, in simple words. -->
Use the PR title.

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->
<!--- "Inspired" by the CDDA PR template -->
