### PR TITLE
fix: Disable enemy array compressing, as it's broken

### DIFF
--- a/scripts/scr_clean/scr_clean.gml
+++ b/scripts/scr_clean/scr_clean.gml
@@ -7,59 +7,22 @@ function compress_enemy_array(_target_column) {
 		return;
 	}
 
-	with (_target_column) {
-		// Define all data arrays to be processed with their default values
-        var _data_arrays = [{
-            arr: dudes,
-            def: ""
-        }, {
-            arr: dudes_special,
-            def: ""
-        }, {
-            arr: dudes_num,
-            def: 0
-        }, {
-            arr: dudes_ac,
-            def: 0
-        }, {
-            arr: dudes_hp,
-            def: 0
-        }, {
-            arr: dudes_vehicle,
-            def: 0
-        }, {
-            arr: dudes_damage,
-            def: 0
-        }];
+    show_debug_message($"dudes_num: {dudes_num}");
 
-		// Track which slots are empty
-		var _empty_slots = array_create(20, false);
-		for (var i = 0; i < array_length(_empty_slots); i++) {
+	with (_target_column) {
+		for (var i = 1; i < array_length(dudes_num); i++) {
+            if (i == 30) {
+                break;
+            }
 			if (dudes_num[i] <= 0) {
-				_empty_slots[i] = true;
+				array_delete(dudes, i, 1);
+                array_delete(dudes_special, i, 1);
+                array_delete(dudes_ac, i, 1);
+                array_delete(dudes_hp, i, 1);
+                array_delete(dudes_vehicle, i, 1);
+                array_delete(dudes_damage, i, 1);
 			}
 		}
-
-        // Compress arrays using a pointer that doesn't restart from beginning
-        var pos = 0;
-        while (pos < array_length(_empty_slots) - 1) {
-            if (_empty_slots[pos] && !_empty_slots[pos + 1]) {
-                // Move data from position pos+1 to pos
-                for (var j = 0; j < array_length(_data_arrays); j++) {
-                    _data_arrays[j].arr[pos] = _data_arrays[j].arr[pos + 1];
-                    _data_arrays[j].arr[pos + 1] = _data_arrays[j].def;
-                }
-                _empty_slots[pos] = false;
-                _empty_slots[pos + 1] = true;
-
-                // Only backtrack if we're not at the beginning
-                if (pos > 0) {
-                    pos--;  // Check this position again in case we need to shift more
-                }
-            } else {
-                pos++;  // Move to next position
-            }
-        }
 	}
 }
 

--- a/scripts/scr_powers/scr_powers.gml
+++ b/scripts/scr_powers/scr_powers.gml
@@ -260,7 +260,7 @@ function scr_powers(caster_id) {
                 }
 
                 // Process the enemy column after applying casualties
-                compress_enemy_array(_target_data.column);
+                // compress_enemy_array(_target_data.column);
                 destroy_empty_column(_target_data.column);
 
                 // Log battle message to combat feed

--- a/scripts/scr_shoot/scr_shoot.gml
+++ b/scripts/scr_shoot/scr_shoot.gml
@@ -449,7 +449,7 @@ function scr_shoot(weapon_index_position, target_object, target_type, damage_dat
 			}
 
 			if (stop = 0) {
-                compress_enemy_array(target_object);
+                // compress_enemy_array(target_object);
                 destroy_empty_column(target_object);
 			}
 


### PR DESCRIPTION
### Purpose of changes
<!-- With a few sentences, describe your reasons for making these changes. -->
- It doesn't work properly. Enemy arrays get emptied out and deleted in the subsequent empty column destruction, causing enemy columns to shrink after one of the enemy types got killed.
- I tried debugging `dudes_num` and it's for some reason broken as well, showing wrong unit counts. This is the reason for why the array gets cleaned - because it should.

### Describe the solution
<!-- How does the feature work, or how does this fix a bug? -->
- Disable the array compressing for now.
- Refactor the compressing function to just delete empty members, instead of setting them to default. 

### Describe alternatives you've considered
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
None

### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
A battle against orks where I previously observed the bug. No problems anymore.
The array compressing was supposedly only helping with performance, by reducing various "find me something" loop times.

### Related links
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
None

### Custom player notes entry
<!-- This will be added to the PR description in the release notes. List changes that players may be interested in, in simple words. -->
Use the PR title.

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->
<!--- "Inspired" by the CDDA PR template -->
