### PR TITLE
fix: Management view not showing up

### DIFF
--- a/scripts/scr_controller_helpers/scr_controller_helpers.gml
+++ b/scripts/scr_controller_helpers/scr_controller_helpers.gml
@@ -119,6 +119,7 @@ function basic_manage_settings(){
 	diplomacy=0; 
 	zoomed=0;  
 	view_squad=false; 	
+	scr_management(1);
     management_buttons = {
     	squad_toggle : new UnitButtonObject({
     		style : "pixel",


### PR DESCRIPTION
### Purpose of changes
<!-- With a few sentences, describe your reasons for making these changes. -->
The chapter management screen is empty after pressing the "chapter management" button.

### Describe the solution
<!-- How does the feature work, or how does this fix a bug? -->
Add a `scr_management(1)` call that was removed in https://github.com/Adeptus-Dominus/ChapterMaster/pull/617 .

### Describe alternatives you've considered
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
None

### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
Launched the game and the management screen works again.

### Related links
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
https://discord.com/channels/714022226810372107/1121959429546455050/1353048934733451457

### Custom player notes entry
<!-- This will be added to the PR description in the release notes. List changes that players may be interested in, in simple words. -->
Exclude

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->
<!--- "Inspired" by the CDDA PR template -->
