### PR TITLE
fix: Unit management view breaking and win some step time

### DIFF
--- a/objects/obj_controller/Step_0.gml
+++ b/objects/obj_controller/Step_0.gml
@@ -545,11 +545,148 @@ try {
                 temp[117] = unit.ranged_attack();
                 // Damage Resistance
                 temp[118] = string(damage_res) + "%";
+                temp[130] = "Health damage taken by the marine is reduced by this percentage. This happens after the flat reduction from armor.\n\nContributing factors:\n";
+                var equipment_types = ["armour", "weapon_one", "weapon_two", "mobility", "gear"];
+                for (var i = 0; i < array_length(equipment_types); i++) {
+                    var equipment_type = equipment_types[i];
+                    var dr = 0;
+                    var name = "";
+                    switch (equipment_type) {
+                        case "armour":
+                            dr = unit.get_armour_data("damage_resistance_mod");
+                            name = unit.get_armour_data("name");
+                            break;
+                        case "weapon_one":
+                            dr = unit.get_weapon_one_data("damage_resistance_mod");
+                            name = unit.get_weapon_one_data("name");
+                            break;
+                        case "weapon_two":
+                            dr = unit.get_weapon_two_data("damage_resistance_mod");
+                            name = unit.get_weapon_two_data("name");
+                            break;
+                        case "mobility":
+                            dr = unit.get_mobility_data("damage_resistance_mod");
+                            name = unit.get_mobility_data("name");
+                            break;
+                        case "gear":
+                            dr = unit.get_gear_data("damage_resistance_mod");
+                            name = unit.get_gear_data("name");
+                            break;
+                    }
+                    if (dr != 0) {
+                        temp[130] += $"{name}: {dr}%\n";
+                    }
+                }
+                temp[130] += string("CON: {0}%\nEXP: {1}%", round(unit.constitution / 2), round(unit.experience / 10));
                 if (is_struct(temp[121])) {
                     try {
                         temp[121].destroy_image();
                     }
                     delete temp[121];
+                }
+                temp[124] = $"{round(unit.hp())}/{round(unit.max_health())}"; // Health Tracker
+                temp[125] = $"A measure how much punishment the creature can take. Marines can go into the negatives and still survive, but they'll require a bionic to become fighting fit once more.\n\nContributing factors:\nCON: {round(100 * (1 + ((unit.constitution - 40) * 0.025)))}\n";
+                for (var i = 0; i < array_length(equipment_types); i++) {
+                    var equipment_type = equipment_types[i];
+                    var hp_mod = 0;
+                    var name = "";
+                    switch (equipment_type) {
+                        case "armour":
+                            hp_mod = unit.get_armour_data("hp_mod");
+                            name = unit.get_armour_data("name");
+                            break;
+                        case "weapon_one":
+                            hp_mod = unit.get_weapon_one_data("hp_mod");
+                            name = unit.get_weapon_one_data("name");
+                            break;
+                        case "weapon_two":
+                            hp_mod = unit.get_weapon_two_data("hp_mod");
+                            name = unit.get_weapon_two_data("name");
+                            break;
+                        case "mobility":
+                            hp_mod = unit.get_mobility_data("hp_mod");
+                            name = unit.get_mobility_data("name");
+                            break;
+                        case "gear":
+                            hp_mod = unit.get_gear_data("hp_mod");
+                            name = unit.get_gear_data("name");
+                            break;
+                    }
+                    if (hp_mod != 0) {
+                        temp[125] += $"{name}: {format_number_with_sign(hp_mod)}%\n";
+                    }
+                }
+                temp[126] = $"{unit.armour_calc()}"; // Armour Rating
+                temp[127] = "Reduces incoming damage at a flat rate. Certain enemies may attack in ways that may bypass your armor entirely, for example power weapons and some warp sorceries.\n\nContributing factors:\n";
+                for (var i = 0; i < array_length(equipment_types); i++) {
+                    var equipment_type = equipment_types[i];
+                    var ac = 0;
+                    var name = "";
+                    switch (equipment_type) {
+                        case "armour":
+                            ac = unit.get_armour_data("armour_value");
+                            name = unit.get_armour_data("name");
+                            break;
+                        case "weapon_one":
+                            ac = unit.get_weapon_one_data("armour_value");
+                            name = unit.get_weapon_one_data("name");
+                            break;
+                        case "weapon_two":
+                            ac = unit.get_weapon_two_data("armour_value");
+                            name = unit.get_weapon_two_data("name");
+                            break;
+                        case "mobility":
+                            ac = unit.get_mobility_data("armour_value");
+                            name = unit.get_mobility_data("name");
+                            break;
+                        case "gear":
+                            ac = unit.get_gear_data("armour_value");
+                            name = unit.get_gear_data("name");
+                            break;
+                    }
+                    if (ac != 0) {
+                        temp[127] += $"{name}: {ac}\n";
+                    }
+                }
+                if (obj_controller.stc_bonus[1] == 5 || obj_controller.stc_bonus[2] == 3) {
+                    temp[127] += $"STC Bonus: x1.05\n";
+                }
+                temp[128] = $"{unit.bionics}";
+                var _body_parts = ARR_body_parts;
+                var _body_parts_display = ARR_body_parts_display;
+                temp[129] = "Bionic Augmentation is something a unit can do to both enhance their capabilities, but also replace a missing limb to get back into the fight.";
+                temp[129] += "\nThere is a limit of 10 Bionic augmentations. After that the damage is so extensive that a marine requires a dreadnought to keep going.";
+                temp[129] += "\nFor everyone else? It's time for the emperor's mercy.";
+                temp[129] += "\n\nCurrent Bionic Augmentations:\n";
+                for (var part = 0; part < array_length(_body_parts); part++) {
+                    if (struct_exists(unit.body[$ _body_parts[part]], "bionic")) {
+                        var part_display = _body_parts_display[part];
+                        temp[129] += $"Bionic {part_display}";
+                        switch (part_display) {
+                            case "Left Leg":
+                            case "Right Leg":
+                                temp[129] += $" (CON: +2 STR: +1 DEX: -2)\n";
+                                break;
+                            case "Left Eye":
+                            case "Right Eye":
+                                temp[129] += $" (CON: +1 WIS: +1 DEX: +1)\n";
+                                break;
+                            case "Left Arm":
+                            case "Right Arm":
+                                temp[129] += $" (CON: +2 STR: +2 WS: -1)\n";
+                                break;
+                            case "Torso":
+                                temp[129] += $" (CON: +4 STR: +1 DEX: -1)\n";
+                                break;
+                            case "Throat":
+                                temp[129] += $" (CHA: -1)\n";
+                                break;
+                            case "Jaw":
+                            case "Head":
+                                temp[129] += $" (CON: +1)\n";
+                                break;
+                        }
+                    }
                 }
                 temp[121] = unit.draw_unit_image();
 

--- a/scripts/exp_and_exp_growth/exp_and_exp_growth.gml
+++ b/scripts/exp_and_exp_growth/exp_and_exp_growth.gml
@@ -243,7 +243,7 @@ function unit_stat_growth(grow_stat=false){
             return undefined;
         }
 	} else {
-		show_debug_message($"{total_traited}")
+		// show_debug_message($"{total_traited}")
 		return stat_gain_chances;
 
 	}

--- a/scripts/scr_ComplexSet/scr_ComplexSet.gml
+++ b/scripts/scr_ComplexSet/scr_ComplexSet.gml
@@ -413,7 +413,7 @@ function ComplexSet(unit) constructor{
                             
                             var armour_sampler = shader_get_sampler_index(armour_texture, "armour_texture");
                             texture_set_stage(armour_sampler, tex_texture);
-                            show_debug_message($"{_tex_data.areas[t]}");
+                            // show_debug_message($"{_tex_data.areas[t]}");
                             var _replace_col = shader_get_uniform(armour_texture, "replace_colour");
                             shader_set_uniform_f_array(_replace_col, _tex_data.areas[t]);
                             draw_sprite(_sprite,choice ?? 0,x_surface_offset,y_surface_offset);    

--- a/scripts/scr_complex_colour_kit/scr_complex_colour_kit.gml
+++ b/scripts/scr_complex_colour_kit/scr_complex_colour_kit.gml
@@ -456,7 +456,7 @@ function setup_complex_livery_shader(setup_role, game_setup=false, unit = "none"
     } else {
         shader_set_uniform_f_array(shader_get_uniform(full_livery_shader, "robes_colour_replace"), cloth_col);
     }
-    show_debug_message(data_set);
+    // show_debug_message(data_set);
     var _textures = {
 
     }

--- a/scripts/scr_controller_helpers/scr_controller_helpers.gml
+++ b/scripts/scr_controller_helpers/scr_controller_helpers.gml
@@ -141,7 +141,6 @@ function basic_manage_settings() {
     diplomacy = 0;
     zoomed = 0;
     view_squad = false;
-    scr_management(1);
     management_buttons = {
         squad_toggle: new UnitButtonObject({
             style: "pixel",
@@ -166,6 +165,7 @@ function scr_toggle_manage() {
         with(obj_controller) {
             if (menu != 1) {
                 basic_manage_settings();
+                scr_management(1);
             } else if (menu == 1) {
                 menu = 0;
                 hide_banner = 0;

--- a/scripts/scr_draw_management_unit/scr_draw_management_unit.gml
+++ b/scripts/scr_draw_management_unit/scr_draw_management_unit.gml
@@ -4,7 +4,7 @@ function scr_draw_management_unit(selected, yy = 0, xx = 0, draw = true) {
     var string_role = "";
     var health_string = "";
     var eventing = false;
-    jailed = false;
+    var jailed = false;
     var impossible = !is_struct(display_unit[selected]) && !is_array(display_unit[selected]);
     var is_man = false;
     if (man[selected] == "man" && is_struct(display_unit[selected])) {

--- a/scripts/scr_ui_manage/scr_ui_manage.gml
+++ b/scripts/scr_ui_manage/scr_ui_manage.gml
@@ -95,7 +95,7 @@ function alternative_manage_views(x1, y1) {
             y1: _squad_button.y1,
             keystroke: keyboard_check_pressed(ord("P"))
         });
-		if (_profile_toggle.draw(!text_bar)) {
+        if (_profile_toggle.draw(!text_bar)) {
             unit_profile = !unit_profile;
         }
 
@@ -441,193 +441,70 @@ function scr_ui_manage() {
             }
 
             // Stats
-            text = $"{selected_unit.bionics}"; // Bionics tracker
-            x1 = x_left + 110;
-            y1 = yy + 208;
-            x2 = x1 + string_width(text);
-            y2 = y1 + string_height(text);
-            x3 = x1 - 26;
-            y3 = y1 - 4;
+            // Bionics tracker
+            if (cn.temp[128] != "") {
+                text = cn.temp[128];
+                tooltip_text = cn.temp[129];
+                x1 = x_left + 110;
+                y1 = yy + 208;
+                x2 = x1 + string_width(text);
+                y2 = y1 + string_height(text);
+                x3 = x1 - 26;
+                y3 = y1 - 4;
 
-            draw_sprite_stretched(spr_icon_bionics, 0, x3, y3, 24, 24);
-            draw_text_outline(x1, y1, text);
-            var _body_parts = ARR_body_parts;
-            var _body_parts_display = ARR_body_parts_display;
-            bionic_tooltip = "Bionic Augmentation is something a unit can do to both enhance their capabilities, but also replace a missing limb to get back into the fight.";
-            bionic_tooltip += "\nThere is a limit of 10 Bionic augmentations. After that the damage is so extensive that a marine requires a dreadnought to keep going.";
-            bionic_tooltip += "\nFor everyone else? It's time for the emperor's mercy.";
-            bionic_tooltip += "\n\nCurrent Bionic Augmentations:\n";
-            for (var part = 0; part < array_length(_body_parts); part++) {
-                if (struct_exists(selected_unit.body[$ _body_parts[part]], "bionic")) {
-                    var part_display = _body_parts_display[part];
-                    bionic_tooltip += $"Bionic {part_display}";
-                    switch (part_display) {
-                        case "Left Leg":
-                        case "Right Leg":
-                            bionic_tooltip += $" (CON: +2 STR: +1 DEX: -2)\n";
-                            break;
-                        case "Left Eye":
-                        case "Right Eye":
-                            bionic_tooltip += $" (CON: +1 WIS: +1 DEX: +1)\n";
-                            break;
-                        case "Left Arm":
-                        case "Right Arm":
-                            bionic_tooltip += $" (CON: +2 STR: +2 WS: -1)\n";
-                            break;
-                        case "Torso":
-                            bionic_tooltip += $" (CON: +4 STR: +1 DEX: -1)\n";
-                            break;
-                        case "Throat":
-                            bionic_tooltip += $" (CHA: -1)\n";
-                            break;
-                        case "Jaw":
-                        case "Head":
-                            bionic_tooltip += $" (CON: +1)\n";
-                            break;
-                    }
-                }
-            }
-            if (bionic_tooltip != "") {
-                array_push(tooltip_drawing, [bionic_tooltip, [x3, y1, x2, y2], "Bionics Installed"]);
+                draw_sprite_stretched(spr_icon_bionics, 0, x3, y3, 24, 24);
+                draw_text_outline(x1, y1, text);
+                array_push(tooltip_drawing, [tooltip_text, [x3, y1, x2, y2], "Bionics Installed"]);
             }
 
-            text = $"{selected_unit.armour_calc()}"; // Armour Rating
-            var tooltip_text = "Reduces incoming damage at a flat rate. Certain enemies may attack in ways that may bypass your armor entirely, for example power weapons and some warp sorceries.\n\nContributing factors:\n";
-            var equipment_types = ["armour", "weapon_one", "weapon_two", "mobility", "gear"];
-            for (var i = 0; i < array_length(equipment_types); i++) {
-                var equipment_type = equipment_types[i];
-                var ac = 0;
-                var name = "";
-                switch (equipment_type) {
-                    case "armour":
-                        ac = selected_unit.get_armour_data("armour_value");
-                        name = selected_unit.get_armour_data("name");
-                        break;
-                    case "weapon_one":
-                        ac = selected_unit.get_weapon_one_data("armour_value");
-                        name = selected_unit.get_weapon_one_data("name");
-                        break;
-                    case "weapon_two":
-                        ac = selected_unit.get_weapon_two_data("armour_value");
-                        name = selected_unit.get_weapon_two_data("name");
-                        break;
-                    case "mobility":
-                        ac = selected_unit.get_mobility_data("armour_value");
-                        name = selected_unit.get_mobility_data("name");
-                        break;
-                    case "gear":
-                        ac = selected_unit.get_gear_data("armour_value");
-                        name = selected_unit.get_gear_data("name");
-                        break;
-                }
-                if (ac != 0) {
-                    tooltip_text += $"{name}: {ac}\n";
-                }
+            // Armour Rating
+            if (cn.temp[126] != "") {
+                text = cn.temp[126];
+                tooltip_text = cn.temp[127];
+                x1 = x_left + 20;
+                y1 = yy + 232;
+                x2 = x1 + string_width(text);
+                y2 = y1 + string_height(text);
+                x3 = x1 - 26;
+                y3 = y1 - 4;
+                draw_sprite_stretched(spr_icon_shield2, 0, x3, y3, 24, 24);
+                draw_text_outline(x1, y1, text);
+                array_push(tooltip_drawing, [tooltip_text, [x3, y1, x2, y2], "Armour Rating"]);
             }
-            if (obj_controller.stc_bonus[1] == 5 || obj_controller.stc_bonus[2] == 3) {
-                tooltip_text += $"STC Bonus: x1.05\n";
-            }
-            x1 = x_left + 20;
-            y1 = yy + 232;
-            x2 = x1 + string_width(text);
-            y2 = y1 + string_height(text);
-            x3 = x1 - 26;
-            y3 = y1 - 4;
-            draw_sprite_stretched(spr_icon_shield2, 0, x3, y3, 24, 24);
-            draw_text_outline(x1, y1, text);
-            array_push(tooltip_drawing, [tooltip_text, [x3, y1, x2, y2], "Armour Rating"]);
 
-            text = $"{round(selected_unit.hp())}/{round(selected_unit.max_health())}"; // Health Tracker
-            tooltip_text = $"A measure how much punishment the creature can take. Marines can go into the negatives and still survive, but they'll require a bionic to become fighting fit once more.\n\nContributing factors:\nCON: {round(100 * (1 + ((selected_unit.constitution - 40) * 0.025)))}\n";
-            for (var i = 0; i < array_length(equipment_types); i++) {
-                var equipment_type = equipment_types[i];
-                var hp_mod = 0;
-                var name = "";
-                switch (equipment_type) {
-                    case "armour":
-                        hp_mod = selected_unit.get_armour_data("hp_mod");
-                        name = selected_unit.get_armour_data("name");
-                        break;
-                    case "weapon_one":
-                        hp_mod = selected_unit.get_weapon_one_data("hp_mod");
-                        name = selected_unit.get_weapon_one_data("name");
-                        break;
-                    case "weapon_two":
-                        hp_mod = selected_unit.get_weapon_two_data("hp_mod");
-                        name = selected_unit.get_weapon_two_data("name");
-                        break;
-                    case "mobility":
-                        hp_mod = selected_unit.get_mobility_data("hp_mod");
-                        name = selected_unit.get_mobility_data("name");
-                        break;
-                    case "gear":
-                        hp_mod = selected_unit.get_gear_data("hp_mod");
-                        name = selected_unit.get_gear_data("name");
-                        break;
-                }
-                if (hp_mod != 0) {
-                    tooltip_text += $"{name}: {format_number_with_sign(hp_mod)}%\n";
-                }
+            // Health
+            if (cn.temp[124] != "") {
+                text = cn.temp[124];
+                tooltip_text = cn.temp[125];
+                x1 = x_left + 20;
+                y1 = yy + 208;
+                x2 = x1 + string_width(text);
+                y2 = y1 + string_height(text);
+                x3 = x1 - 26;
+                y3 = y1 - 4;
+                draw_sprite_stretched(spr_icon_health, 0, x3, y3, 24, 24);
+                draw_text_outline(x1, y1, text);
+                array_push(tooltip_drawing, [tooltip_text, [x3, y1, x2, y2], "Health"]);
             }
-            x1 = x_left + 20;
-            y1 = yy + 208;
-            x2 = x1 + string_width(text);
-            y2 = y1 + string_height(text);
-            x3 = x1 - 26;
-            y3 = y1 - 4;
-            draw_sprite_stretched(spr_icon_health, 0, x3, y3, 24, 24);
-            draw_text_outline(x1, y1, text);
-            array_push(tooltip_drawing, [tooltip_text, [x3, y1, x2, y2], "Health"]);
 
             // Experience
             if (cn.temp[113] != "") {
-                text = $"{cn.temp[113]}";
+                text = cn.temp[113];
+                tooltip_text = "A measureme of how battle-hardened the unit is. Provides a lot of various bonuses across the board.";
                 x1 = x_left + 20;
                 y1 = yy + 184;
                 x2 = x1 + string_width(text);
                 y2 = y1 + string_height(text);
                 x3 = x1 - 26;
                 y3 = y1 - 4;
-                tooltip_text = "A measureme of how battle-hardened the unit is. Provides a lot of various bonuses across the board.";
                 array_push(tooltip_drawing, [tooltip_text, [x3, y1, x2, y2], "Experience"]);
                 draw_sprite_stretched(spr_icon_veteran, 0, x_left - 6, yy + 180, 24, 24);
                 draw_text_outline(x1, y1, text);
             }
 
             if (cn.temp[118] != "") {
-                tooltip_text = "Health damage taken by the marine is reduced by this percentage. This happens after the flat reduction from armor.\n\nContributing factors:\n";
-                for (var i = 0; i < array_length(equipment_types); i++) {
-                    var equipment_type = equipment_types[i];
-                    var dr = 0;
-                    var name = "";
-                    switch (equipment_type) {
-                        case "armour":
-                            dr = selected_unit.get_armour_data("damage_resistance_mod");
-                            name = selected_unit.get_armour_data("name");
-                            break;
-                        case "weapon_one":
-                            dr = selected_unit.get_weapon_one_data("damage_resistance_mod");
-                            name = selected_unit.get_weapon_one_data("name");
-                            break;
-                        case "weapon_two":
-                            dr = selected_unit.get_weapon_two_data("damage_resistance_mod");
-                            name = selected_unit.get_weapon_two_data("name");
-                            break;
-                        case "mobility":
-                            dr = selected_unit.get_mobility_data("damage_resistance_mod");
-                            name = selected_unit.get_mobility_data("name");
-                            break;
-                        case "gear":
-                            dr = selected_unit.get_gear_data("damage_resistance_mod");
-                            name = selected_unit.get_gear_data("name");
-                            break;
-                    }
-                    if (dr != 0) {
-                        tooltip_text += $"{name}: {dr}%\n";
-                    }
-                }
-                text = $"{cn.temp[118]}"; // Damage Resistance
-                tooltip_text += string("CON: {0}%\nEXP: {1}%", round(selected_unit.constitution / 2), round(selected_unit.experience / 10));
+                text = cn.temp[118]; // Damage Resistance
+                tooltip_text = cn.temp[130];
                 x1 = x_left + 110;
                 y1 = yy + 232;
                 x2 = x1 + string_width(text);

--- a/scripts/scr_unit_quick_find_pane/scr_unit_quick_find_pane.gml
+++ b/scripts/scr_unit_quick_find_pane/scr_unit_quick_find_pane.gml
@@ -23,7 +23,7 @@ function UnitQuickFindPanel() constructor{
 	    garrison_log = {};
 	    obj_controller.specialist_point_handler.calculate_research_points(false);
 	    var _ship_count = array_length(obj_ini.ship_carrying);
-	    show_debug_message(obj_controller.specialist_point_handler.point_breakdown);
+	    // show_debug_message(obj_controller.specialist_point_handler.point_breakdown);
 	    for (var co=0;co<=obj_ini.companies;co++){
 	    	for (var u=0;u<array_length(obj_ini.TTRPG[co]);u++){
 				/// @type {Struct.TTRPG_stats}


### PR DESCRIPTION
### Purpose of changes
<!-- With a few sentences, describe your reasons for making these changes. -->
- Fix a bug that was causing the management view to open with the chapter view on top.
- Reduce step time on the management screen.

### Describe the solution
<!-- How does the feature work, or how does this fix a bug? -->
- Move the scr_management call, so that "apparently" it's not called when not needed.
- Improve step performance by precalculating most of the performance intensive unit view stats once, instead of every step.
- Kill some show_debug stuff, because it was flooding the output.

### Describe alternatives you've considered
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
Kill the `max_health` calls on the management view, as it eats 3ms by just existing for 33 units on the screen every step.

### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
Both fleet and system unit management now opens properly.
Step time on the management screen is improved by ~3-4 ms.

### Related links
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
https://discord.com/channels/714022226810372107/1353143470923059290

### Custom player notes entry
<!-- This will be added to the PR description in the release notes. List changes that players may be interested in, in simple words. -->
Use the PR title.

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->
<!--- "Inspired" by the CDDA PR template -->
