### PR TITLE
feat: Extend Shortcut support in for squad management

### DIFF
--- a/scripts/scr_company_struct/scr_company_struct.gml
+++ b/scripts/scr_company_struct/scr_company_struct.gml
@@ -271,9 +271,9 @@ function CompanyStruct(comp) constructor{
 						mission_type="garrison";
 					}
 
-		garrison_button.keystroke = press_exclusive(ord("G"));		//Shortcut for hotkeys feel free to move them anywhere
+		garrison_button.keystroke = press_exclusive(ord("G"));
 		previous_squad_button.keystroke = press_exclusive(vk_left);
-	        next_squad_button.keystroke = press_exclusive(vk_tab);
+		next_squad_button.keystroke = press_exclusive(vk_tab);
 					if (array_contains(current_squad.class, "scout")) || (array_contains(current_squad.class, "bike")){
 						if (sabotage_button.draw()){
 							send_on_mission=true;


### PR DESCRIPTION
### Purpose of changes
Makes mastering your chapter far easier

### Describe the solution
Just assign buttons

### Describe alternatives you've considered
maybe more keys?

### Testing done
Yeah works well from what i saw i hope planets don't get nuked from this change

### Related links
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
None

### Custom player notes entry
C cancel assignment 
G start guard duty selection 
Right arrow well moves to the next squad 
Likewise Left arrow previous squad
Tab also moving to the next Squad.

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->
<!--- "Inspired" by the CDDA PR template -->
