### PR TITLE
fix: Crusade event spawns again

### DIFF
--- a/objects/obj_en_fleet/Alarm_1.gml
+++ b/objects/obj_en_fleet/Alarm_1.gml
@@ -935,7 +935,7 @@ if (action=="" && _is_orbiting){
 }
 
 
-if (action="move") and (action_eta>5000){
+if (action=="move") and (action_eta>5000){
     var woop = instance_nearest(x,y,obj_star);
     if (woop.storm=0){
     	action_eta-=10000;

--- a/objects/obj_p_fleet/Alarm_1.gml
+++ b/objects/obj_p_fleet/Alarm_1.gml
@@ -46,8 +46,7 @@ try_and_report_loop("player alarm 1",function(){
             action_x=x+lengthdir_x(600,dr);
             action_y=y+lengthdir_y(600,dr);
             action="crusade2";
-            action_eta=choose(3,4,5);
-            alarm[4]=1;
+            set_fleet_movement(false, "crusade2");
         }
         if (action_eta=0) and (action="crusade2"){
             with(obj_star){
@@ -64,8 +63,9 @@ try_and_report_loop("player alarm 1",function(){
             var ret=instance_nearest(x,y,obj_star);
             action_x=ret.x;
             action_y=ret.y;
-            action="crusade3";action_eta=floor(point_distance(x,y,ret.x,ret.y)/128)+1;
-            alarm[4]=1;instance_activate_object(obj_star);
+            action="crusade3";
+            set_fleet_movement(false, "crusade3");
+            instance_activate_object(obj_star);
         }
         if (action_eta=0) and (action="crusade3"){
             // Popup here
@@ -85,7 +85,13 @@ try_and_report_loop("player alarm 1",function(){
             orbiting=steh;
             // show_message("Present Fleets at alarm[1]: "+string(steh.present_fleets));
             
-            var b;b=0;repeat(4){b+=1;if (steh.p_first[b]<=5) and (steh.dispo[b]>-30) and (steh.dispo[b]<0) then steh.dispo[b]=min(obj_ini.imperium_disposition,obj_controller.disposition[2])+choose(-1,-2,-3,-4,0,1,2,3,4);}
+            var b=0;
+            for (var i=1;i<=steh.planets;i++){
+                if (steh.p_first[b]<=5) and (steh.dispo[b]>-30) and (steh.dispo[b]<0){
+                    steh.dispo[b]=min(obj_ini.imperium_disposition,obj_controller.disposition[2])+irandom(8)-4;
+                } 
+
+            }
             if (steh.p_owner[1]=5) or (steh.p_owner[2]=5) or (steh.p_owner[3]=5) or (steh.p_owner[4]=5){
                 if (obj_controller.faction_defeated[5]=0) and (obj_controller.known[eFACTION.Ecclesiarchy]=0) then obj_controller.known[eFACTION.Ecclesiarchy]=1;
             }

--- a/scripts/scr_crusade/scr_crusade.gml
+++ b/scripts/scr_crusade/scr_crusade.gml
@@ -167,23 +167,23 @@ function launch_crusade(){
 		return false;
 	}
 	else{
-		var assigned_crusade = false;
-		for(var i = 1; i <= star_id.planets;i++){
-			assigned_crusade = add_new_problem(i, "great_crusade", 36,star_id);
-			if (assigned_crusade>0) then break;
-		}
-		if(!assigned_crusade){
-			log_error("RE: Crusade, couldn't assign a crusade at the system");
+
+		//TODO decide the target/purpose of the crusade to create more variety and to help with post crusade rewards
+		var _nearest_player_fleet = get_nearest_player_fleet(star_id.x, star_id.y);
+		if (_nearest_player_fleet == "none"){
 			return false;
 		}
-		else{
-			//TODO decide the target/purpose of the crusade to create more variety and to help with post crusade rewards
-			scr_popup("Crusade","Fellow Astartes legions are preparing to embark on a Crusade to a nearby sector.  Your forces are expected at "+string(star_id.name)+"; 36 turns from now your ships there shall begin their journey.","crusade","");
-			var star_alert = instance_create(star_id.x+16,star_id.y-24,obj_star_event);
-			star_alert.image_alpha=1;
-			star_alert.image_speed=1;
-			scr_event_log("","A Crusade is called; our forces are expected at "+string(star_id.name)+" in 36 months.", star_id.name);
-			return true;	
+		var travel_leeway = 10;
+		if (_nearest_player_fleet.action == "move"){
+			travel_leeway += _nearest_player_fleet.eta;
 		}
+		var _eta = get_viable_travel_time(travel_leeway, _nearest_player_fleet.x, _nearest_player_fleet.y, star_id.x,star_id.y, _nearest_player_fleet,false)
+		scr_popup("Crusade",$"Fellow Astartes legions are preparing to embark on a Crusade to a nearby sector.  Your forces are expected at {star_id.name}; {_eta} months from now your ships there shall begin their journey.","crusade","");
+		var star_alert = instance_create(star_id.x+16,star_id.y-24,obj_star_event);
+		star_alert.image_alpha=1;
+		star_alert.image_speed=1;
+		scr_event_log("",$"A Crusade is called; our forces are expected at {star_id.name} in {_eta} months.", star_id.name);
+		assigned_crusade = add_new_problem(irandom_range(1 ,star_id.planets), "great_crusade", _eta,star_id);
+		return true;	
 	}
 }

--- a/scripts/scr_enemy_ai_d/scr_enemy_ai_d.gml
+++ b/scripts/scr_enemy_ai_d/scr_enemy_ai_d.gml
@@ -111,24 +111,27 @@ function scr_enemy_ai_d() {
         }
 
         if (has_problem_planet_and_time(i, "great_crusade", 0)>-1){
-            var flet,cont,dir;cont=0;
-            flet=instance_nearest(x,y,obj_p_fleet);
+            var dir;
+            var join_crusade=false;
+            var _player_fleet = instance_nearest(x,y,obj_p_fleet);
         
-            if (flet.action="") then cont=1;
-            if (cont=1) and (point_distance(x,y,flet.x,flet.y)<40) then cont=2;
+            if (_player_fleet.action=""){
+                if (point_distance(x, y, _player_fleet.x, _player_fleet.y)<10 ){
+                    join_crusade=true;
+                }
+            }
         
-            if (cont=2){
-                flet.action="crusade1";
+            if (join_crusade){
                 dir=point_direction(room_width/2,room_height/2,x,y);
-                flet.action_x=x+lengthdir_x(2000,dir);
-                flet.action_y=y+lengthdir_y(2000,dir);
-                // flet.action_eta=floor(random(8))+12;
-                flet.action_eta=floor(random(8))+2;
-                flet.alarm[4]=1;
+                with (_player_fleet){
+                    action_x=x+lengthdir_x(1200,dir);
+                    action_y=y+lengthdir_y(1200,dir);
+                    set_fleet_movement(false, "crusade1");
+                }
+
                 scr_alert("green","crusade","Fleet embarks upon Crusade.",x,y);
                 scr_event_log("","Fleet embarks upon Crusade.");
-            }
-            if (cont=1) or (cont=0){
+            }else {
                 // hit loyalty here
                 obj_controller.disposition[2]-=5;
                 obj_controller.disposition[4]-=10;

--- a/scripts/scr_fleet_functions/scr_fleet_functions.gml
+++ b/scripts/scr_fleet_functions/scr_fleet_functions.gml
@@ -139,13 +139,13 @@ function is_orbiting(){
 	return false;
 }
 
-function set_fleet_movement(fastest_route = true){
+function set_fleet_movement(fastest_route = true, new_action="move"){
 
 	action = "";
 
 	if (action==""){
 		turns_static = 0;
-	    var sys, mine, fleet;
+	    var mine, fleet;
 	    var connected=0,cont=0,target_dist=0;
 	    if (fastest_route){
 	    	mine=instance_nearest(x,y,obj_star);
@@ -158,20 +158,25 @@ function set_fleet_movement(fastest_route = true){
 		    		complex_route = path;
 		    		action_x = targ.x;
 					action_y = targ.y;
-		    		set_fleet_movement(false);
+		    		set_fleet_movement(false, new_action);
 		    	} else {
-		    		set_fleet_movement(false);
+		    		set_fleet_movement(false, new_action);
 		    	}
 		    } else {
-		    	set_fleet_movement(false);
+		    	set_fleet_movement(false, new_action);
 		    }
 	    } else {
 
-		    sys=instance_nearest(action_x,action_y,obj_star);
+		    var _target_sys = instance_nearest(action_x,action_y,obj_star);
+		    var _target_is_sys = false;
+
+		    if (instance_exists(_target_sys)){
+		    	_target_is_sys = point_distance(_target_sys.x, _target_sys.y, action_x, action_y)<10;
+		    }
 
 		    mine=instance_nearest(x,y,obj_star);
 	        
-	        var eta = calculate_fleet_eta(x,y,action_x,action_y,action_spd,instance_exists(sys),is_orbiting(),warp_able);
+	        var eta = calculate_fleet_eta(x,y,action_x,action_y,action_spd,_target_is_sys,is_orbiting(),warp_able);
 	        action_eta = eta;
 	        if (action_eta<=0) or (owner  != eFACTION.Inquisition){
 	            action_eta=eta;
@@ -183,10 +188,9 @@ function set_fleet_movement(fastest_route = true){
 	        // action_x=sys.x;
 	        // action_y=sys.y;
 	        orbiting = false;
-	        action="move";
-	        
+	        action=new_action;
+	      	minimum_eta=1;
 	        if (minimum_eta>action_eta) and (minimum_eta>0) then action_eta=minimum_eta;
-	        minimum_eta=0;
 		}
 	}
 }

--- a/scripts/scr_player_fleet_functions/scr_player_fleet_functions.gml
+++ b/scripts/scr_player_fleet_functions/scr_player_fleet_functions.gml
@@ -586,13 +586,18 @@ function player_fleet_selected_count(fleet="none"){
 
 
 
-function get_nearest_player_fleet(nearest_x, nearest_y, is_static=false, is_moving=false){
+function get_nearest_player_fleet(nearest_x, nearest_y, is_static=false, is_moving=false, stop_complex_actions = true){
 	var chosen_fleet = "none";
 	if instance_exists(obj_p_fleet){
 		with(obj_p_fleet){
 			var viable = !(is_static && action!="");
 			if (viable && is_moving){
 				if (action!="move") then viable = false;
+			}
+			if (stop_complex_actions){
+				if (string_count("crusade", action) || action == "Lost"){
+					viable = false;
+				}
 			}
 			if (!viable) then continue;
 			if (point_in_rectangle(x, y, 0, 0, room_width, room_height)){

--- a/scripts/scr_random_event/scr_random_event.gml
+++ b/scripts/scr_random_event/scr_random_event.gml
@@ -90,7 +90,7 @@ function scr_random_event(execute_now) {
 					[
 						EVENT.warp_storms,
 						EVENT.enemy_forces,
-						//EVENT.crusade, // Reportly breaks often because of lack of imperial fleets and eats player ships // TODO LOW CRUSADE_EVENT // fix
+						EVENT.crusade, // Reportly breaks often because of lack of imperial fleets and eats player ships // TODO LOW CRUSADE_EVENT // fix
 						EVENT.enemy, // Save-scumming event, Should probably base this on something else than tech-scavs
 						EVENT.mutation,
 						EVENT.ship_lost, // Another save-scumming event, mainly due to rarity of player ships

--- a/scripts/scr_star_travel_algorithm/scr_star_travel_algorithm.gml
+++ b/scripts/scr_star_travel_algorithm/scr_star_travel_algorithm.gml
@@ -115,3 +115,9 @@ function determine_warp_join(star_a, star_b){
 	}
 	return lane_strength;
 }
+
+
+function get_viable_travel_time(time_abundance, start_x,start_y, xx,yy,fleet, start_from_star=false){
+	var alg_calc = new FastestRouteAlgorithm(start_x,start_y, xx,yy,fleet, start_from_star);
+	return alg_calc.final_route_info[1] + time_abundance;
+}

--- a/scripts/scr_unit_quick_find_pane/scr_unit_quick_find_pane.gml
+++ b/scripts/scr_unit_quick_find_pane/scr_unit_quick_find_pane.gml
@@ -167,26 +167,38 @@ function UnitQuickFindPanel() constructor{
 			    draw_text(xx+160, yy+90+(20*i), cur_fleet.frigate_number);
 			    draw_text(xx+240, yy+90+(20*i), cur_fleet.escort_number);
 			    var _fleet_point_data = cur_fleet.point_breakdown;
+			    var _loc_display_string = "";
+			    var _zoomable_loc = true;
 			    if (cur_fleet.action == "Lost"){
-			    	draw_text(xx+310, yy+90+(20*i), "Lost");
+			    	_loc_display_string = "Lost";
+			    	_zoomable_loc = false;
 			    }
+			    else if (string_count("crusade", cur_fleet.action)){
+			    	_loc_display_string = "Crusading";
+			    	_zoomable_loc = false;
+			    }			    
 			    else if (cur_fleet.action=="move"){
-			    	draw_text(xx+310, yy+90+(20*i), "Warp Travel");
+			    	_loc_display_string = "Warp Travel";
 			    } else {
 			    	var _near_star = instance_nearest(cur_fleet.x, cur_fleet.y, obj_star);
-			    	draw_text(xx+310, yy+90+(20*i), _near_star.name);
+			    	_loc_display_string = _near_star.name;
+			    	
 			    	var _special_points = obj_controller.specialist_point_handler.point_breakdown.systems;
 			    	if (struct_exists(_special_points,_near_star)){
 						var _fleet_point_data = _special_points[$ _near_star.name][0];
 					}
 			    }
+			    draw_text(xx+310, yy+90+(20*i), _loc_display_string);
+
 			    var _fleet_coords = [xx+10, yy+90+(20*i)-2,xx+main_panel.width,yy+90+(20*i)+18];
 			    
-			    if (point_and_click([xx+10, yy+90+(20*i)-2,xx+main_panel.width,yy+90+(20*i)+18])){
-			    	travel_target = [cur_fleet.x, cur_fleet.y];
-			    	travel_increments = [(travel_target[0]-obj_controller.x)/15,(travel_target[1]-obj_controller.y)/15];
-			    	travel_time = 0;
-			    }
+			    if (_zoomable_loc){
+    			    if (point_and_click([xx+10, yy+90+(20*i)-2,xx+main_panel.width,yy+90+(20*i)+18])){
+    			    	travel_target = [cur_fleet.x, cur_fleet.y];
+    			    	travel_increments = [(travel_target[0]-obj_controller.x)/15,(travel_target[1]-obj_controller.y)/15];
+    			    	travel_time = 0;
+    			    }
+    			}
 
 			    if (scr_hit(_fleet_coords)){
 					detail_slate.draw(xx+main_panel.width-10,_fleet_coords[1]-20, 1.5, 1.5);


### PR DESCRIPTION
### Purpose of changes
make the crusading event naturally spawn in game again
also make some improvements to code base
ensure crusades are always reachable by player by creating get_viable_travel_time function which uses the fastest route algorithm to ensure a location can always be reached by at least 1 fleet with a margin of 10 turns (reachable margin can be augmented as required)

### Describe the solution
- allow the crusade1 2 and 3 actions to be sent into the set fleet movement function

### Testing done
use "event crusade" cheat to spawn crusade and send player fleet on crusade

### Related links
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
None

### Custom player notes entry
<!-- This will be added to the PR description in the release notes. List changes that players may be interested in, in simple words. -->
Use the PR title.

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->
<!--- "Inspired" by the CDDA PR template -->