### PR TITLE
fix: Tome Keepers psyker advantage and starting disposition

### DIFF
--- a/datafiles/main/chapters/32.JSON
+++ b/datafiles/main/chapters/32.JSON
@@ -30,7 +30,7 @@
             "Enemy: Necrons",
             "Enemy: Orks",
             "Venerable Ancients",
-            "Psyker Abundance",
+            "Warp Touched",
             "Siege Masters",
             "",
             ""
@@ -78,6 +78,16 @@
                 "name": "Page"
             }
         },
+        "disposition": [
+            0, // nothing
+            44, // Progenitor faction
+            42, // Imperium
+            32, // Admech
+            20, //Inquisition
+            20, // Ecclesiarchy
+            0, // Astartes
+            0 // nothing
+        ],
         "full_liveries":[
             {
             "right_trim":8.0,


### PR DESCRIPTION
### Purpose of changes
<!-- With a few sentences, describe your reasons for making these changes. -->
- Fix obsolete advantage name.
- Fix 0 starting disposition with all factions (why do you have to do it manually???).

### Describe the solution
<!-- How does the feature work, or how does this fix a bug? -->
- Proper advantage name.
- Copy disposition values from a custom chapter with the same stats.

### Describe alternatives you've considered
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
None

### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- New game as Tome Keepers.

### Related links
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
https://discord.com/channels/714022226810372107/1121959429546455050/1354871109668966472

### Custom player notes entry
<!-- This will be added to the PR description in the release notes. List changes that players may be interested in, in simple words. -->
Use the PR title.

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->
<!--- "Inspired" by the CDDA PR template -->
