### PR TITLE
feat: Adjust after battle EXP and Req rewards

### DIFF
--- a/objects/obj_ncombat/Alarm_5.gml
+++ b/objects/obj_ncombat/Alarm_5.gml
@@ -442,7 +442,7 @@ if (defeat=0) and (reduce_power=true){
         new_power = max(new_power, 0);
 
         // Give some money for killing enemies?
-        var _quad_factor = 8;
+        var _quad_factor = 6;
         requisition_reward = _quad_factor * sqr(threat);
         obj_controller.requisition += requisition_reward;
 

--- a/objects/obj_ncombat/Alarm_5.gml
+++ b/objects/obj_ncombat/Alarm_5.gml
@@ -384,8 +384,8 @@ if (battle_special="fallen2") then reduce_power=false;
 if (battle_special="study2a") then reduce_power=false;
 if (battle_special="study2b") then reduce_power=false;
 if (defeat=0) and (reduce_power=true){
-    var enemy_power,new_power, power_reduction, final_pow, requisition_reward, power_fought;
-    enemy_power=0;new_power=0; power_reduction=0; requisition_reward=0; power_fought=0;
+    var enemy_power,new_power, power_reduction, final_pow, requisition_reward;
+    enemy_power=0;new_power=0; power_reduction=0; requisition_reward=0;
 
     if (enemy=2){
         enemy_power=battle_object.p_guardsmen[battle_id];
@@ -435,17 +435,15 @@ if (defeat=0) and (reduce_power=true){
     if (enemy!=2){
         if (dropping == true || defending == true) {
             power_reduction = 1;
-            power_fought = max(enemy_power - 1, 1); // Raiding generates enemies at -1 power, so less points
         } else {
             power_reduction = 2;
-            power_fought = enemy_power;
         }
         new_power = enemy_power - power_reduction;
         new_power = max(new_power, 0);
 
         // Give some money for killing enemies?
-        var reward_table = [0, 5, 10, 20, 40, 80, 160, 320];
-        requisition_reward = reward_table[power_fought];
+        var _quad_factor = 8;
+        requisition_reward = _quad_factor * sqr(threat);
         obj_controller.requisition += requisition_reward;
 
 		//(¿?) Ramps up threat/enemy presence in case enemy Type == "Daemon" (¿?)

--- a/objects/obj_ncombat/KeyPress_13.gml
+++ b/objects/obj_ncombat/KeyPress_13.gml
@@ -49,7 +49,8 @@ if ((started=2) or (started=4)){
     // started=3;alarm[5]=3;obj_pnunit.alarm[4]=1;obj_pnunit.alarm[5]=2;obj_enunit.alarm[1]=3;
     started=3;
     // obj_pnunit.alarm[4]=2;obj_pnunit.alarm[5]=3;obj_enunit.alarm[1]=1;
-    total_battle_exp_gain = threat * 50;
+    var _quad_factor = 10;
+    total_battle_exp_gain = _quad_factor * sqr(threat);
     if (instance_exists(obj_enunit)){obj_enunit.alarm[1]=1;}
     instance_activate_object(obj_star);
     instance_activate_object(obj_event_log);


### PR DESCRIPTION
### Purpose of changes
<!-- With a few sentences, describe your reasons for making these changes. -->
- To make the reward table a bit more predictable and simple.

### Describe the solution
<!-- How does the feature work, or how does this fix a bug? -->
- Exp and Req reward formulas are now `_quad_factor * sqr(threat);`. Exp has the factor of 10, and Req of 6.
- In practice, this means that the rewards are a bit smaller at lower levels, but higher at high levels.
![image](https://github.com/user-attachments/assets/cdb9862f-4949-442e-aed7-ec0851560eef)

### Describe alternatives you've considered
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
None

### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
None

### Related links
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
None

### Custom player notes entry
<!-- This will be added to the PR description in the release notes. List changes that players may be interested in, in simple words. -->
Use the PR title.

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->
<!--- "Inspired" by the CDDA PR template -->
