### PR TITLE
fix: Stop cloaks being drawn on scouts

### DIFF
--- a/scripts/scr_ComplexSet/scr_ComplexSet.gml
+++ b/scripts/scr_ComplexSet/scr_ComplexSet.gml
@@ -758,7 +758,7 @@ function ComplexSet(unit) constructor{
 
         }
         var type = unit.get_body_data("type","cloak");
-        if (type != "none" && (armour_type == ArmourType.Normal || armour_type == ArmourType.Terminator)) {
+        if (type != "none" && armour_type != ArmourType.Scout ) {
             static _cloaks = {
                 "scale":spr_cloak_scale,
                 "pelt":spr_cloak_fur,

--- a/scripts/scr_ComplexSet/scr_ComplexSet.gml
+++ b/scripts/scr_ComplexSet/scr_ComplexSet.gml
@@ -758,7 +758,7 @@ function ComplexSet(unit) constructor{
 
         }
         var type = unit.get_body_data("type","cloak");
-        if (type != "none" && armour_type == ArmourType.Normal || armour_type == ArmourType.Terminator) {
+        if (type != "none" && (armour_type == ArmourType.Normal || armour_type == ArmourType.Terminator)) {
             static _cloaks = {
                 "scale":spr_cloak_scale,
                 "pelt":spr_cloak_fur,

--- a/scripts/scr_ComplexSet/scr_ComplexSet.gml
+++ b/scripts/scr_ComplexSet/scr_ComplexSet.gml
@@ -758,7 +758,7 @@ function ComplexSet(unit) constructor{
 
         }
         var type = unit.get_body_data("type","cloak");
-        if (type != "none") {
+        if (type != "none" && armour_type == ArmourType.Normal || armour_type == ArmourType.Terminator) {
             static _cloaks = {
                 "scale":spr_cloak_scale,
                 "pelt":spr_cloak_fur,


### PR DESCRIPTION
### Purpose of changes
stop ill fitting cloaks on dreads and scouts

### Describe the solution
add check for the correct body_type to add base cloak


### Testing done
test game compile and check no scouts spawning with ill fitting cloaks

### Related links
https://discord.com/channels/714022226810372107/1354643086860619908


<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->
<!--- "Inspired" by the CDDA PR template -->
