### PR TITLE
feat: Slime increases armor maintenance, without destruction

### DIFF
--- a/objects/obj_ncombat/Alarm_5.gml
+++ b/objects/obj_ncombat/Alarm_5.gml
@@ -257,32 +257,28 @@ if (ground_mission){
 }
 
 if (slime>0){
-    var compan_slime;
-    compan_slime=0;
-    
-    var s1,s2,s3,s4;
-    s1="";s2="";s3="";s4="";
-    
-    i=-1;
-    
-    s1="Slime has short-circuited and destroyed "+string(slime);
+    var compan_slime = 0;
+
+    var slime_string=$"Fualty mucranoids and other afflictions have caused additional damage {slime} Forge Points will need to be allocated to repair damage";
     
     for (var i=0;i<=10;i++){
         if (mucra[i]){
             compan_slime+=1;
-			if (i>0){
-				s3+=$"{i}, ";
-			} else {
-				s3+=$"HQ, ";
-			}
+            if (i>0){
+                s3+=$"{i}, ";
+            } else {
+                s3+=$"HQ, ";
+            }
         }
     }
     
-    s2=$" {slime==1?"suit":"suits"} of Power Armour.  {compan_slime>1?$"{s3} Companies":$"{s3} company"} {s4} has been effected.";
+    slime_string += $" {slime==1?"suit":"suits"} of Power Armour.  {compan_slime>1?$"{s3} Companies":$"{s3} company"} {s4} has been effected.";
     
-    s3=string_delete(s3,string_length(s3)-1,2);
+    string_delete(s3,string_length(s3)-1,2);
+
+    slime_string += s3;
     
-    newline=s1+s2+s3+s4;
+    newline=slime_string;
     newline_color="red";
     scr_newtext();
     newline=" ";

--- a/objects/obj_ncombat/Alarm_5.gml
+++ b/objects/obj_ncombat/Alarm_5.gml
@@ -257,28 +257,11 @@ if (ground_mission){
 }
 
 if (slime>0){
-    var compan_slime = 0;
-
-    var slime_string=$"Fualty mucranoids and other afflictions have caused additional damage {slime} Forge Points will need to be allocated to repair damage";
-    
-    /*var s3 = "";
-    for (var i=0;i<=10;i++){
-        if (mucra[i]){
-            compan_slime+=1;
-            if (i>0){
-                s3+=$"{i}, ";
-            } else {
-                s3+=$"HQ, ";
-            }
-        }
-    }*/
-    
-    //slime_string += $" {slime==1?"suit":"suits"} of Power Armour.  {compan_slime>1?$"{s3} Companies":$"{s3} company"} has been effected.";
-    
-    
+    var slime_string=$"Faulty Mucranoid and other afflictions have caused damage to the equipment. {slime} Forge Points will be allocated for repairs.";    
     newline=slime_string;
     newline_color="red";
     scr_newtext();
+
     newline=" ";
     scr_newtext();
 }

--- a/objects/obj_ncombat/Alarm_5.gml
+++ b/objects/obj_ncombat/Alarm_5.gml
@@ -261,6 +261,7 @@ if (slime>0){
 
     var slime_string=$"Fualty mucranoids and other afflictions have caused additional damage {slime} Forge Points will need to be allocated to repair damage";
     
+    /*var s3 = "";
     for (var i=0;i<=10;i++){
         if (mucra[i]){
             compan_slime+=1;
@@ -270,13 +271,10 @@ if (slime>0){
                 s3+=$"HQ, ";
             }
         }
-    }
+    }*/
     
-    slime_string += $" {slime==1?"suit":"suits"} of Power Armour.  {compan_slime>1?$"{s3} Companies":$"{s3} company"} {s4} has been effected.";
+    //slime_string += $" {slime==1?"suit":"suits"} of Power Armour.  {compan_slime>1?$"{s3} Companies":$"{s3} company"} has been effected.";
     
-    string_delete(s3,string_length(s3)-1,2);
-
-    slime_string += s3;
     
     newline=slime_string;
     newline_color="red";

--- a/scripts/scr_after_combat/scr_after_combat.gml
+++ b/scripts/scr_after_combat/scr_after_combat.gml
@@ -141,13 +141,12 @@ function after_battle_part2() {
         }
         if (_unit.base_group=="astartes"){
             if (marine_dead[i]=0) and (_unit.gene_seed_mutations.mucranoid==1) and (ally[i]=false){
-                var muck=floor(random(200))+1;
-                if (muck=50){    //slime is armour destroyed due to mucranoid
-                    var _power_armour = ARR_power_armour;
-                    if (array_contains(_power_armour,_unit.armour())){
-                        _unit.update_armour("", false, false);
+                var muck=roll_personal_dice(1,100,"high",_unit);
+                if (muck==1){    //slime  armour damaged due to mucranoid
+                    if (_unit.armour != ""){
+                        obj_controller.specialist_point_handler.add_to_armoury_repair(_unit.armour());
                         obj_ncombat.mucra[marine_co[i]]=1;
-                        obj_ncombat.slime+=1;
+                        obj_ncombat.slime+=_unit.get_armour_data("maintenance");
                     }
                 }
             }

--- a/sprites/spr_left_pauldron_fur_hanging/spr_left_pauldron_fur_hanging.yy
+++ b/sprites/spr_left_pauldron_fur_hanging/spr_left_pauldron_fur_hanging.yy
@@ -87,6 +87,8 @@
     "playbackSpeedType":0,
     "resourceType":"GMSequence",
     "resourceVersion":"2.0",
+    "seqHeight":232.0,
+    "seqWidth":164.0,
     "showBackdrop":true,
     "showBackdropImage":false,
     "timeUnits":1,

--- a/sprites/spr_right_pauldron_fur_hanging/spr_right_pauldron_fur_hanging.yy
+++ b/sprites/spr_right_pauldron_fur_hanging/spr_right_pauldron_fur_hanging.yy
@@ -87,6 +87,8 @@
     "playbackSpeedType":0,
     "resourceType":"GMSequence",
     "resourceVersion":"2.0",
+    "seqHeight":232.0,
+    "seqWidth":164.0,
     "showBackdrop":true,
     "showBackdropImage":false,
     "timeUnits":1,

--- a/sprites/spr_scout_colors/spr_scout_colors.yy
+++ b/sprites/spr_scout_colors/spr_scout_colors.yy
@@ -74,6 +74,8 @@
     "playbackSpeedType":1,
     "resourceType":"GMSequence",
     "resourceVersion":"2.0",
+    "seqHeight":232.0,
+    "seqWidth":167.0,
     "showBackdrop":true,
     "showBackdropImage":false,
     "timeUnits":1,

--- a/sprites/spr_scout_complex/spr_scout_complex.yy
+++ b/sprites/spr_scout_complex/spr_scout_complex.yy
@@ -63,6 +63,8 @@
     "playbackSpeedType":0,
     "resourceType":"GMSequence",
     "resourceVersion":"2.0",
+    "seqHeight":232.0,
+    "seqWidth":167.0,
     "showBackdrop":true,
     "showBackdropImage":false,
     "timeUnits":1,

--- a/sprites/spr_scout_heads/spr_scout_heads.yy
+++ b/sprites/spr_scout_heads/spr_scout_heads.yy
@@ -64,6 +64,8 @@
     "playbackSpeedType":0,
     "resourceType":"GMSequence",
     "resourceVersion":"2.0",
+    "seqHeight":232.0,
+    "seqWidth":167.0,
     "showBackdrop":true,
     "showBackdropImage":false,
     "timeUnits":1,

--- a/sprites/spr_scout_new/spr_scout_new.yy
+++ b/sprites/spr_scout_new/spr_scout_new.yy
@@ -71,6 +71,8 @@
     "playbackSpeedType":0,
     "resourceType":"GMSequence",
     "resourceVersion":"2.0",
+    "seqHeight":232.0,
+    "seqWidth":167.0,
     "showBackdrop":true,
     "showBackdropImage":false,
     "timeUnits":1,

--- a/sprites/spr_term_left_fur_hanging/spr_term_left_fur_hanging.yy
+++ b/sprites/spr_term_left_fur_hanging/spr_term_left_fur_hanging.yy
@@ -66,6 +66,8 @@
     "playbackSpeedType":0,
     "resourceType":"GMSequence",
     "resourceVersion":"2.0",
+    "seqHeight":271.0,
+    "seqWidth":181.0,
     "showBackdrop":true,
     "showBackdropImage":false,
     "timeUnits":1,

--- a/sprites/spr_term_right_fur_hanging/spr_term_right_fur_hanging.yy
+++ b/sprites/spr_term_right_fur_hanging/spr_term_right_fur_hanging.yy
@@ -66,6 +66,8 @@
     "playbackSpeedType":0,
     "resourceType":"GMSequence",
     "resourceVersion":"2.0",
+    "seqHeight":271.0,
+    "seqWidth":181.0,
     "showBackdrop":true,
     "showBackdropImage":false,
     "timeUnits":1,


### PR DESCRIPTION
### Purpose of changes
Slime now does not destroy armours it just adds a forge point hit for that turn using the existing infrastructure for adding maintenance points for de-equipped armour. 
Essentially doubles the maintenance of the armour for that turn. So the slime barekly effects mk7 armour but for a mk3 adds a chunk of forge point hit
### Describe the solution
potential fix tot nuking it

### Describe alternatives you've considered
plenty of alternatives this is just one quick option

### Testing done
very little but if thjis route is alright or can be made to work thenm i'll do more

### Related links
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
None

### Custom player notes entry
<!-- This will be added to the PR description in the release notes. List changes that players may be interested in, in simple words. -->
Use the PR title.

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->
<!--- "Inspired" by the CDDA PR template -->
