### PR TITLE
feat: Specialist assignment buttons for companies and a refactor

### DIFF
--- a/objects/obj_popup/Draw_0.gml
+++ b/objects/obj_popup/Draw_0.gml
@@ -1572,7 +1572,7 @@ try {
 		}
 		draw_text(xx + 1470, yy + 210, string_hash_to_newline("HQ [" + string(check) + "]"));
 		check = " ";
-		// if (obj_controller.command_set[1]!=0 && !is_specialist(unit_role, "libs")){
+		// if (obj_controller.command_set[1]!=0 && !is_specialist(unit_role, "lib")){
 		for (i = 1; i <= 10; i++) {
 			var comp_data = company_promote_data[i - 1];
 			if (obj_controller.command_set[2] == 1) {

--- a/scripts/exp_and_exp_growth/exp_and_exp_growth.gml
+++ b/scripts/exp_and_exp_growth/exp_and_exp_growth.gml
@@ -90,7 +90,7 @@ function unit_stat_growth(grow_stat=false){
 
 	var group_growths = [
 		["forge" , "technology"],
-		["libs" , "intelligence"],
+		["lib" , "intelligence"],
 		["chap" , "charisma"],
 		["apoth" , "intelligence"],
 	];
@@ -258,7 +258,7 @@ function add_unit_exp(add_val){
 		instace_stat_point_gains = handle_stat_growth(true);
 	}
 
-	if (IsSpecialist("libs")) {
+	if (IsSpecialist("lib")) {
 		_powers_learned = update_powers()
 	}
 	role_refresh();

--- a/scripts/is_specialist/is_specialist.gml
+++ b/scripts/is_specialist/is_specialist.gml
@@ -254,7 +254,7 @@ function collect_role_group(group="standard", location="", opposite=false, searc
 			if (unit.name()=="") then continue;
 			if (group!="all"){
 				if (is_array(group)){
-					_is_special_group = unit.IsSpecialist(group[0], group[1]);
+					_is_special_group = unit.IsSpecialist(group[0], group[1],group[3]);
 				} else {
 					_is_special_group = unit.IsSpecialist(group);
 				}

--- a/scripts/is_specialist/is_specialist.gml
+++ b/scripts/is_specialist/is_specialist.gml
@@ -4,117 +4,13 @@ function active_roles(){
 }
 
 function role_groups(group, include_trainee = true, include_heads = true) {
-    var role_list = [];
-    var roles = active_roles();
+    var _role_list = [];
+    var _roles = active_roles();
+	var _chap_name = instance_exists(obj_creation) ? obj_creation.chapter_name : global.chapter_name;
 
     switch (group) {
-        case "lib":
-            role_list = [
-                roles[eROLE.Librarian],
-                "Codiciery",
-                "Lexicanum"
-            ];
-			if (include_trainee) {
-				array_push(role_list, $"{roles[eROLE.Librarian]} Aspirant");
-            }
-			if (include_heads) {
-				array_push(role_list, $"Chief {roles[eROLE.Librarian]}");
-            }
-            break;
-        case "trainee":
-            role_list = [
-                $"{roles[eROLE.Librarian]} Aspirant",
-                $"{roles[eROLE.Apothecary]} Aspirant",
-                $"{roles[eROLE.Chaplain]} Aspirant",
-                $"{roles[eROLE.Techmarine]} Aspirant"
-            ];
-            break;
-        case "heads":
-            role_list = [
-                "Master of Sanctity",
-                $"Chief {roles[eROLE.Librarian]}",
-                "Forge Master",
-                "Chapter Master",
-                "Master of the Apothecarion"
-            ];
-            break;
-        case "veterans":
-            role_list = [
-                roles[eROLE.Veteran],
-                roles[eROLE.Terminator],
-                roles[eROLE.VeteranSergeant],
-                roles[eROLE.HonourGuard]
-            ];
-            break;
-        case "rank_and_file":
-            role_list = [
-                roles[eROLE.Tactical],
-                roles[eROLE.Devastator],
-                roles[eROLE.Assault],
-                roles[eROLE.Scout]
-            ];
-            break;
-        case "squad_leaders":
-            role_list = [
-                roles[eROLE.Sergeant],
-                roles[eROLE.VeteranSergeant]
-            ];
-            break;
-        case "command":
-            role_list = [
-                roles[eROLE.Captain],
-                roles[eROLE.Apothecary],
-                roles[eROLE.Chaplain],
-                roles[eROLE.Techmarine],
-                roles[eROLE.Librarian],
-                "Codiciery",
-                "Lexicanum",
-                roles[eROLE.Ancient],
-                roles[eROLE.Champion]
-            ];
-            break;
-        case "dreadnoughts":
-            role_list = [
-                roles[eROLE.Dreadnought],
-                $"Venerable {roles[eROLE.Dreadnought]}"
-            ];
-            break;
-        case "forge":
-            role_list = [
-                roles[eROLE.Techmarine],
-                "Techpriest"
-            ];
-			if (include_trainee) {
-				array_push(role_list, $"{roles[eROLE.Techmarine]} Aspirant");
-            }
-			if (include_heads) {
-				array_push(role_list, "Forge Master");
-            }
-            break;
-        case "captain_candidates":
-            role_list = [
-                roles[eROLE.Sergeant],
-                roles[eROLE.VeteranSergeant],
-                roles[eROLE.Champion],
-                roles[eROLE.Captain],
-                roles[eROLE.Terminator],
-                roles[eROLE.Veteran],
-                roles[eROLE.Ancient]
-            ];
-            break;
-    }
-
-    return role_list;
-}
-
-function is_specialist(unit_role, type = "standard", include_trainee = true, include_heads = true) {
-    var _roles = active_roles();
-    var _chap_name = instance_exists(obj_creation) ? obj_creation.chapter_name : global.chapter_name;
-    var _specialists = [];
-
-    switch (type) {
         case "standard":
-            _specialists = [
+            _role_list = [
                 _roles[eROLE.Captain],
                 _roles[eROLE.Dreadnought],
                 $"Venerable {_roles[eROLE.Dreadnought]}",
@@ -128,81 +24,152 @@ function is_specialist(unit_role, type = "standard", include_trainee = true, inc
                 _roles[eROLE.HonourGuard]
             ];
             if (include_trainee) {
-				_specialists = array_concat(_specialists, role_groups("trainee"));
+				_role_list = array_concat(_roles, role_groups("trainee"));
             }
 			if (include_heads) {
-				_specialists = array_concat(_specialists, role_groups("heads"));
+				_role_list = array_concat(_roles, role_groups("heads"));
             }
             break;
 
-        case "libs":
-            _specialists = role_groups("lib", include_trainee, include_heads);
-            break;
-        case "forge":
-            _specialists = role_groups("forge", include_trainee, include_heads);
-            break;
-        case "chap":
-            _specialists = [_roles[eROLE.Chaplain]];
-            if (_chap_name == "Iron Hands") {
-                array_push(_specialists, _roles[eROLE.Techmarine]);
-				if (include_trainee) {
-					array_push(_specialists, $"{_roles[eROLE.Techmarine]} Aspirant");
-				}
-				if (include_heads) {
-					array_push(_specialists, "Forge Master");
-				}
-            }
+        case "lib":
+            _role_list = [
+                _roles[eROLE.Librarian],
+                "Codiciery",
+                "Lexicanum"
+            ];
 			if (include_trainee) {
-				array_push(_specialists, $"{_roles[eROLE.Chaplain]} Aspirant");
-			}
-			if (include_heads) {
-				array_push(_specialists, "Master of Sanctity");
-			}
-            break;
-        case "apoth":
-            _specialists = [_roles[eROLE.Apothecary]];
-            if (_chap_name == "Space Wolves") {
-                array_push(_specialists, _roles[eROLE.Chaplain]);
-				if (include_trainee) {
-					array_push(_specialists, $"{_roles[eROLE.Chaplain]} Aspirant");
-				}
-				if (include_heads) {
-					array_push(_specialists, "Master of Sanctity");
-				}
-            }
-			if (include_trainee) {
-				array_push(_specialists, $"{_roles[eROLE.Apothecary]} Aspirant");
+				array_push(_role_list, $"{_roles[eROLE.Librarian]} Aspirant");
             }
 			if (include_heads) {
-				array_push(_specialists, "Master of the Apothecarion");
+				array_push(_role_list, $"Chief {_roles[eROLE.Librarian]}");
             }
             break;
+		case "forge":
+			_role_list = [
+				_roles[eROLE.Techmarine],
+				"Techpriest"
+			];
+			if (include_trainee) {
+				array_push(_role_list, $"{_roles[eROLE.Techmarine]} Aspirant");
+			}
+			if (include_heads) {
+				array_push(_role_list, "Forge Master");
+			}
+			break;
+		case "chap":
+			_role_list = [_roles[eROLE.Chaplain]];
+			if (_chap_name == "Iron Hands") {
+				array_push(_role_list, _roles[eROLE.Techmarine]);
+				if (include_trainee) {
+					array_push(_role_list, $"{_roles[eROLE.Techmarine]} Aspirant");
+				}
+				if (include_heads) {
+					array_push(_role_list, "Forge Master");
+				}
+			}
+			if (include_trainee) {
+				array_push(_role_list, $"{_roles[eROLE.Chaplain]} Aspirant");
+			}
+			if (include_heads) {
+				array_push(_role_list, "Master of Sanctity");
+			}
+			break;
+		case "apoth":
+			_role_list = [_roles[eROLE.Apothecary]];
+			if (_chap_name == "Space Wolves") {
+				array_push(_role_list, _roles[eROLE.Chaplain]);
+				if (include_trainee) {
+					array_push(_role_list, $"{_roles[eROLE.Chaplain]} Aspirant");
+				}
+				if (include_heads) {
+					array_push(_role_list, "Master of Sanctity");
+				}
+			}
+			if (include_trainee) {
+				array_push(_role_list, $"{_roles[eROLE.Apothecary]} Aspirant");
+			}
+			if (include_heads) {
+				array_push(_role_list, "Master of the Apothecarion");
+			}
+			break;
 
-        case "heads":
-            _specialists = role_groups("heads");
-            break;
-        case "command":
-            _specialists = role_groups("command");
-            break;
         case "trainee":
-            _specialists = role_groups("trainee");
+            _role_list = [
+                $"{_roles[eROLE.Librarian]} Aspirant",
+                $"{_roles[eROLE.Apothecary]} Aspirant",
+                $"{_roles[eROLE.Chaplain]} Aspirant",
+                $"{_roles[eROLE.Techmarine]} Aspirant"
+            ];
             break;
-        case "rank_and_file":
-            _specialists = role_groups("rank_and_file");
-            break;
-        case "squad_leaders":
-            _specialists = role_groups("squad_leaders");
-            break;
-        case "dreadnoughts":
-            _specialists = role_groups("dreadnoughts");
+        case "heads":
+            _role_list = [
+                "Master of Sanctity",
+                $"Chief {_roles[eROLE.Librarian]}",
+                "Forge Master",
+                "Chapter Master",
+                "Master of the Apothecarion"
+            ];
             break;
         case "veterans":
-            _specialists = role_groups("veterans");
+            _role_list = [
+                _roles[eROLE.Veteran],
+                _roles[eROLE.Terminator],
+                _roles[eROLE.VeteranSergeant],
+                _roles[eROLE.HonourGuard]
+            ];
+            break;
+        case "rank_and_file":
+            _role_list = [
+                _roles[eROLE.Tactical],
+                _roles[eROLE.Devastator],
+                _roles[eROLE.Assault],
+                _roles[eROLE.Scout]
+            ];
+            break;
+        case "squad_leaders":
+            _role_list = [
+                _roles[eROLE.Sergeant],
+                _roles[eROLE.VeteranSergeant]
+            ];
+            break;
+        case "command":
+            _role_list = [
+                _roles[eROLE.Captain],
+                _roles[eROLE.Apothecary],
+                _roles[eROLE.Chaplain],
+                _roles[eROLE.Techmarine],
+                _roles[eROLE.Librarian],
+                "Codiciery",
+                "Lexicanum",
+                _roles[eROLE.Ancient],
+                _roles[eROLE.Champion]
+            ];
+            break;
+        case "dreadnoughts":
+            _role_list = [
+                _roles[eROLE.Dreadnought],
+                $"Venerable {_roles[eROLE.Dreadnought]}"
+            ];
             break;
         case "captain_candidates":
-            _specialists = role_groups("captain_candidates");
+            _role_list = [
+                _roles[eROLE.Sergeant],
+                _roles[eROLE.VeteranSergeant],
+                _roles[eROLE.Champion],
+                _roles[eROLE.Captain],
+                _roles[eROLE.Terminator],
+                _roles[eROLE.Veteran],
+                _roles[eROLE.Ancient]
+            ];
             break;
     }
+
+    return _role_list;
+}
+
+function is_specialist(unit_role, type = "standard", include_trainee = true, include_heads = true) {
+    var _roles = active_roles();
+    var _specialists = role_groups(type, include_trainee, include_heads);
 
     return array_contains(_specialists, unit_role);
 }

--- a/scripts/is_specialist/is_specialist.gml
+++ b/scripts/is_specialist/is_specialist.gml
@@ -3,7 +3,7 @@ function active_roles(){
 	return _roles;
 }
 
-function role_groups(group, include_trainee = true, include_heads = true) {
+function role_groups(group, include_trainee = false, include_heads = true) {
     var _role_list = [];
     var _roles = active_roles();
 	var _chap_name = instance_exists(obj_creation) ? obj_creation.chapter_name : global.chapter_name;

--- a/scripts/is_specialist/is_specialist.gml
+++ b/scripts/is_specialist/is_specialist.gml
@@ -254,7 +254,7 @@ function collect_role_group(group="standard", location="", opposite=false, searc
 			if (unit.name()=="") then continue;
 			if (group!="all"){
 				if (is_array(group)){
-					_is_special_group = unit.IsSpecialist(group[0], group[1],group[3]);
+					_is_special_group = unit.IsSpecialist(group[0], group[1],group[2]);
 				} else {
 					_is_special_group = unit.IsSpecialist(group);
 				}

--- a/scripts/is_specialist/is_specialist.gml
+++ b/scripts/is_specialist/is_specialist.gml
@@ -191,29 +191,6 @@ function is_specialist(unit_role, type="standard", include_trainee=false) {
 		case "captain_candidates":
 			specialists = role_groups("captain_candidates");
 			break;
-		case "chap_candidates":
-			specialists = [
-						roles[14],//chaplain
-			];
-			if (_chap_name == "Iron Hands"){
-				array_push(specialists, roles[16]);
-			}	
-			break;
-		case "tech_marine_candidates":
-			specialists = [
-						roles[16],//tech marine
-			];
-			break;
-		case "apothecary_candidates":
-			specialists = [
-						roles[15],//Apothecary marine
-			];
-			break;
-		case "librarian_candidates":
-			specialists = [
-						roles[17], //librarian
-			];
-			break;
 	}
 
 	return array_contains(specialists,unit_role);

--- a/scripts/is_specialist/is_specialist.gml
+++ b/scripts/is_specialist/is_specialist.gml
@@ -92,35 +92,12 @@ function role_groups(group){
 				 roles[11],			
 			];
 			break;
-		case "chap_candidates":
-			specialists = [
-						roles[14],//chaplain
-			];
-			if (_chap_name == "Iron Hands"){
-				array_push(specialists, roles[16]);
-			}	
-			break;
-		case "tech_marine_candidates":
-			specialists = [
-						roles[16],//tech marine
-			];
-			break;
-		case "apothecary_candidates":
-			specialists = [
-						roles[15],//Apothecary marine
-			];
-			break;
-		case "librarian_candidates":
-			specialists = [
-						roles[17], //librarian
-			];
-			break;
-			
+
 	}
 	return role_list;
 }
 
-function is_specialist(unit_role, type="standard", include_trainee=false) {
+function is_specialist(unit_role, type="standard", include_trainee=false, include_heads=true) {
 
 	// unit_role
 	//TODO need to make all string roles not strings but array references
@@ -160,36 +137,46 @@ function is_specialist(unit_role, type="standard", include_trainee=false) {
 			if (include_trainee){
 				array_push(specialists,  string("{0} Aspirant",roles[17]));
 			}
+			if (include_heads){
+				array_push(specialists,  string("Chief {0}",roles[17]));
+			}
 			break;
 		case "forge":
 			specialists = role_groups("forge");
 			if (include_trainee){
 				array_push(specialists,  string("{0} Aspirant",roles[16]));
+			}
+			if (include_heads){
+				array_push(specialists,  "Forge Master");
 			}			
 			break;
 		case "chap":
 			specialists = [
 						roles[14],//chaplain
-						"Master of Sanctity",
 			];
 			if (include_trainee){
 				array_push(specialists,  string("{0} Aspirant",roles[14]));
 			}
 			if (_chap_name == "Iron Hands"){
 				array_push(specialists, roles[16]);
-			}	
+			}
+			if (include_heads){
+				array_push(specialists,  "Master of Sanctity");
+			}		
 			break;
 		case "apoth":
 			specialists = [
 						roles[15],
-						"Master of the Apothecarion",
 			];
 			if (include_trainee){
 				array_push(specialists,  string("{0} Aspirant",roles[15]));
 			}	
 			if (_chap_name == "Space Wolves"){
 				array_push(specialists, roles[14]);
-			}		
+			}
+			if (include_heads){
+				array_push(specialists,  "Master of the Apothecarion");
+			}					
 			break;
 		case "heads":
 			specialists = role_groups("heads");

--- a/scripts/is_specialist/is_specialist.gml
+++ b/scripts/is_specialist/is_specialist.gml
@@ -3,208 +3,174 @@ function active_roles(){
 	return _roles;
 }
 
-function role_groups(group){
-	var role_list = [];
-	var roles = active_roles();
-	switch (group){
-		case "lib":
-			role_list = [
-						string("Chief {0}",roles[17]),
-						roles[17], //librarian
-						"Codiciery",
-						"Lexicanum",
-			];
-			break;
-		case "trainee":
-			role_list = [
-				string("{0} Aspirant",roles[17]),
-				string("{0} Aspirant",roles[15]),  
-				string("{0} Aspirant",roles[14]),
-				string("{0} Aspirant",roles[16]),
-			];
-			break;
-		case "heads":
-			role_list = [
-				"Master of Sanctity",
-				string("Chief {0}", roles[17]),
-				"Forge Master", 
-				"Chapter Master", 
-				"Master of the Apothecarion"
-			];
-			break;
-		case "veterans":
-			role_list = [
-				roles[3],  //veterans
-				roles[4],  //terminatore
-				roles[19], //vet sergeant
-				roles[2],  //honour guard
-			];
-			break;
-		case "rank_and_file":
-			role_list = [
-				roles[8], //tactical marine
-				roles[9], //devastator
-				roles[10], //assualt
-				roles[12], //scout
-			];
-			break;
+function role_groups(group) {
+    var role_list = [];
+    var roles = active_roles();
 
-		case "squad_leaders":
-			role_list = [
-				roles[18], //sergeant
-				roles[19],  //vet sergeant
-			]
-			break;
-		case "command":
-			role_list = [
-	            roles[5],
-	            roles[14],
-	            roles[15],
-	            roles[16],
-	            roles[17],
-	            "Codiciery",
-	            "Lexicanum",
-	            roles[11],
-	            roles[7],
-	        ]; 
-	        break;
-	    case "dreadnoughts":
-	        role_list = [
-				roles[6],//dreadnought
-				string("Venerable {0}",roles[6]),
-			];
-			break;
-		case "forge":
-	        role_list = [
-				roles[16],//techmarine
-				"Forge Master",
-				"Techpriest"
-			];
-			break;
-		case "captain_candidates":
-			role_list = [
-				roles[eROLE.Sergeant], //sergeant
-				roles[eROLE.VeteranSergeant],
-				roles[eROLE.Champion],				
-				roles[eROLE.Captain],								
-				roles[eROLE.Terminator],				
-				roles[eROLE.Veteran],
-				 roles[11],			
-			];
-			break;
+    switch (group) {
+        case "lib":
+            role_list = [
+                $"Chief {roles[eROLE.Librarian]}",
+                roles[eROLE.Librarian],
+                "Codiciery",
+                "Lexicanum"
+            ];
+            break;
+        case "trainee":
+            role_list = [
+                $"{roles[eROLE.Librarian]} Aspirant",
+                $"{roles[eROLE.Apothecary]} Aspirant",
+                $"{roles[eROLE.Chaplain]} Aspirant",
+                $"{roles[eROLE.Techmarine]} Aspirant"
+            ];
+            break;
+        case "heads":
+            role_list = [
+                "Master of Sanctity",
+                $"Chief {roles[eROLE.Librarian]}",
+                "Forge Master",
+                "Chapter Master",
+                "Master of the Apothecarion"
+            ];
+            break;
+        case "veterans":
+            role_list = [
+                roles[eROLE.Veteran],
+                roles[eROLE.Terminator],
+                roles[eROLE.VeteranSergeant],
+                roles[eROLE.HonourGuard]
+            ];
+            break;
+        case "rank_and_file":
+            role_list = [
+                roles[eROLE.Tactical],
+                roles[eROLE.Devastator],
+                roles[eROLE.Assault],
+                roles[eROLE.Scout]
+            ];
+            break;
+        case "squad_leaders":
+            role_list = [
+                roles[eROLE.Sergeant],
+                roles[eROLE.VeteranSergeant]
+            ];
+            break;
+        case "command":
+            role_list = [
+                roles[eROLE.Captain],
+                roles[eROLE.Apothecary],
+                roles[eROLE.Chaplain],
+                roles[eROLE.Techmarine],
+                roles[eROLE.Librarian],
+                "Codiciery",
+                "Lexicanum",
+                roles[eROLE.Ancient],
+                roles[eROLE.Champion]
+            ];
+            break;
+        case "dreadnoughts":
+            role_list = [
+                roles[eROLE.Dreadnought],
+                $"Venerable {roles[eROLE.Dreadnought]}"
+            ];
+            break;
+        case "forge":
+            role_list = [
+                roles[eROLE.Techmarine],
+                "Forge Master",
+                "Techpriest"
+            ];
+            break;
+        case "captain_candidates":
+            role_list = [
+                roles[eROLE.Sergeant],
+                roles[eROLE.VeteranSergeant],
+                roles[eROLE.Champion],
+                roles[eROLE.Captain],
+                roles[eROLE.Terminator],
+                roles[eROLE.Veteran],
+                roles[eROLE.Ancient]
+            ];
+            break;
+    }
 
-	}
-	return role_list;
+    return role_list;
 }
 
-function is_specialist(unit_role, type="standard", include_trainee=false, include_heads=true) {
+function is_specialist(unit_role, type = "standard", include_trainee = true, include_heads = true) {
+    var _roles = active_roles();
+    var _chap_name = instance_exists(obj_creation) ? obj_creation.chapter_name : global.chapter_name;
+    var _specialists = [];
 
-	// unit_role
-	//TODO need to make all string roles not strings but array references
-	var roles = instance_exists(obj_creation) ?  obj_creation.role[100] : obj_ini.role[100];
-	var _chap_name = instance_exists(obj_creation) ? obj_creation.chapter_name : global.chapter_name;
-	switch(type){
-		case "standard":
-			specialists = ["Chapter Master",
-							"Forge Master",
-							"Master of Sanctity",
-							"Master of the Apothecarion",
-							string("Chief {0}",roles[17]),//chief librarian
-							roles[5],//captain
-							roles[6],//dreadnought
-							string("Venerable {0}",roles[6]),
-							roles[7],//company_champion
-							roles[14],//chaplain
-							roles[15],//apothecary
-							roles[16],//techmarine
-							roles[17], //librarian
-							"Codiciery",
-							"Lexicanum",
-							roles[2],//honour guard
-			];
-			if (include_trainee){
-				array_push(specialists, 
-							 string("{0} Aspirant",roles[17]),
-							 string("{0} Aspirant",roles[15]),  
-							 string("{0} Aspirant",roles[14]),
-							 string("{0} Aspirant",roles[16]),
-							 );
-			}
-			break;
-      
-		case "libs":
-			specialists = role_groups("lib");
-			if (include_trainee){
-				array_push(specialists,  string("{0} Aspirant",roles[17]));
-			}
-			if (include_heads){
-				array_push(specialists,  string("Chief {0}",roles[17]));
-			}
-			break;
-		case "forge":
-			specialists = role_groups("forge");
-			if (include_trainee){
-				array_push(specialists,  string("{0} Aspirant",roles[16]));
-			}
-			if (include_heads){
-				array_push(specialists,  "Forge Master");
-			}			
-			break;
-		case "chap":
-			specialists = [
-						roles[14],//chaplain
-			];
-			if (include_trainee){
-				array_push(specialists,  string("{0} Aspirant",roles[14]));
-			}
-			if (_chap_name == "Iron Hands"){
-				array_push(specialists, roles[16]);
-			}
-			if (include_heads){
-				array_push(specialists,  "Master of Sanctity");
-			}		
-			break;
-		case "apoth":
-			specialists = [
-						roles[15],
-			];
-			if (include_trainee){
-				array_push(specialists,  string("{0} Aspirant",roles[15]));
-			}	
-			if (_chap_name == "Space Wolves"){
-				array_push(specialists, roles[14]);
-			}
-			if (include_heads){
-				array_push(specialists,  "Master of the Apothecarion");
-			}					
-			break;
-		case "heads":
-			specialists = role_groups("heads");
-			break;
-		case "command":	
-			specialists = role_groups("command");
-			break;	
-		case "trainee":	
-			specialists = role_groups("trainee");
-			break;
-		case "rank_and_file":
-			specialists = role_groups("rank_and_file");
-			break;
-		case "squad_leaders":
-			specialists = role_groups("squad_leaders");
-			break;
-		case "dreadnoughts":
-			specialists = role_groups("dreadnoughts");	
-			break;
-		case "veterans":
-			specialists = role_groups("veterans");
-			break;
-		case "captain_candidates":
-			specialists = role_groups("captain_candidates");
-			break;
-	}
+    switch (type) {
+        case "standard":
+            _specialists = [
+                _roles[eROLE.Captain],
+                _roles[eROLE.Dreadnought],
+                $"Venerable {_roles[eROLE.Dreadnought]}",
+                _roles[eROLE.Champion],
+                _roles[eROLE.Chaplain],
+                _roles[eROLE.Apothecary],
+                _roles[eROLE.Techmarine],
+                _roles[eROLE.Librarian],
+                "Codiciery",
+                "Lexicanum",
+                _roles[eROLE.HonourGuard]
+            ];
+            if (include_trainee) {
+				_specialists = array_concat(_specialists, role_groups("trainee"));
+            }
+			if (include_heads) {
+				_specialists = array_concat(_specialists, role_groups("heads"));
+            }
+            break;
 
-	return array_contains(specialists,unit_role);
+        case "libs":
+            _specialists = role_groups("lib");
+            break;
+        case "forge":
+            _specialists = role_groups("forge");
+            break;
+        case "chap":
+            _specialists = [_roles[eROLE.Chaplain]];
+            if (_chap_name == "Iron Hands") {
+                array_push(_specialists, _roles[eROLE.Techmarine]);
+            }
+            break;
+        case "apoth":
+            _specialists = [_roles[eROLE.Apothecary]];
+            if (_chap_name == "Space Wolves") {
+                array_push(_specialists, _roles[eROLE.Chaplain]);
+            }
+            break;
+
+        case "heads":
+            _specialists = role_groups("heads");
+            break;
+        case "command":
+            _specialists = role_groups("command");
+            break;
+        case "trainee":
+            _specialists = role_groups("trainee");
+            break;
+        case "rank_and_file":
+            _specialists = role_groups("rank_and_file");
+            break;
+        case "squad_leaders":
+            _specialists = role_groups("squad_leaders");
+            break;
+        case "dreadnoughts":
+            _specialists = role_groups("dreadnoughts");
+            break;
+        case "veterans":
+            _specialists = role_groups("veterans");
+            break;
+        case "captain_candidates":
+            _specialists = role_groups("captain_candidates");
+            break;
+    }
+
+    return array_contains(_specialists, unit_role);
 }
 
 //TODO write this out with proper formatting when i can be assed

--- a/scripts/is_specialist/is_specialist.gml
+++ b/scripts/is_specialist/is_specialist.gml
@@ -167,7 +167,7 @@ function role_groups(group, include_trainee = false, include_heads = true) {
     return _role_list;
 }
 
-function is_specialist(unit_role, type = "standard", include_trainee = true, include_heads = true) {
+function is_specialist(unit_role, type = "standard", include_trainee = false, include_heads = true) {
     var _specialists = role_groups(type, include_trainee, include_heads);
 
     return array_contains(_specialists, unit_role);

--- a/scripts/is_specialist/is_specialist.gml
+++ b/scripts/is_specialist/is_specialist.gml
@@ -168,7 +168,6 @@ function role_groups(group, include_trainee = true, include_heads = true) {
 }
 
 function is_specialist(unit_role, type = "standard", include_trainee = true, include_heads = true) {
-    var _roles = active_roles();
     var _specialists = role_groups(type, include_trainee, include_heads);
 
     return array_contains(_specialists, unit_role);

--- a/scripts/is_specialist/is_specialist.gml
+++ b/scripts/is_specialist/is_specialist.gml
@@ -190,7 +190,30 @@ function is_specialist(unit_role, type="standard", include_trainee=false) {
 			break;
 		case "captain_candidates":
 			specialists = role_groups("captain_candidates");
-			break;			
+			break;
+		case "chap_candidates":
+			specialists = [
+						roles[14],//chaplain
+			];
+			if (_chap_name == "Iron Hands"){
+				array_push(specialists, roles[16]);
+			}	
+			break;
+		case "tech_marine_candidates":
+			specialists = [
+						roles[16],//tech marine
+			];
+			break;
+		case "apothecary_candidates":
+			specialists = [
+						roles[15],//Apothecary marine
+			];
+			break;
+		case "librarian_candidates":
+			specialists = [
+						roles[17], //librarian
+			];
+			break;
 	}
 
 	return array_contains(specialists,unit_role);

--- a/scripts/is_specialist/is_specialist.gml
+++ b/scripts/is_specialist/is_specialist.gml
@@ -92,6 +92,30 @@ function role_groups(group){
 				 roles[11],			
 			];
 			break;
+		case "chap_candidates":
+			specialists = [
+						roles[14],//chaplain
+			];
+			if (_chap_name == "Iron Hands"){
+				array_push(specialists, roles[16]);
+			}	
+			break;
+		case "tech_marine_candidates":
+			specialists = [
+						roles[16],//tech marine
+			];
+			break;
+		case "apothecary_candidates":
+			specialists = [
+						roles[15],//Apothecary marine
+			];
+			break;
+		case "librarian_candidates":
+			specialists = [
+						roles[17], //librarian
+			];
+			break;
+			
 	}
 	return role_list;
 }

--- a/scripts/is_specialist/is_specialist.gml
+++ b/scripts/is_specialist/is_specialist.gml
@@ -3,18 +3,23 @@ function active_roles(){
 	return _roles;
 }
 
-function role_groups(group) {
+function role_groups(group, include_trainee = true, include_heads = true) {
     var role_list = [];
     var roles = active_roles();
 
     switch (group) {
         case "lib":
             role_list = [
-                $"Chief {roles[eROLE.Librarian]}",
                 roles[eROLE.Librarian],
                 "Codiciery",
                 "Lexicanum"
             ];
+			if (include_trainee) {
+				array_push(role_list, $"{roles[eROLE.Librarian]} Aspirant");
+            }
+			if (include_heads) {
+				array_push(role_list, $"Chief {roles[eROLE.Librarian]}");
+            }
             break;
         case "trainee":
             role_list = [
@@ -77,9 +82,14 @@ function role_groups(group) {
         case "forge":
             role_list = [
                 roles[eROLE.Techmarine],
-                "Forge Master",
                 "Techpriest"
             ];
+			if (include_trainee) {
+				array_push(role_list, $"{roles[eROLE.Techmarine]} Aspirant");
+            }
+			if (include_heads) {
+				array_push(role_list, "Forge Master");
+            }
             break;
         case "captain_candidates":
             role_list = [
@@ -126,10 +136,10 @@ function is_specialist(unit_role, type = "standard", include_trainee = true, inc
             break;
 
         case "libs":
-            _specialists = role_groups("lib");
+            _specialists = role_groups("lib", include_trainee, include_heads);
             break;
         case "forge":
-            _specialists = role_groups("forge");
+            _specialists = role_groups("forge", include_trainee, include_heads);
             break;
         case "chap":
             _specialists = [_roles[eROLE.Chaplain]];

--- a/scripts/is_specialist/is_specialist.gml
+++ b/scripts/is_specialist/is_specialist.gml
@@ -145,12 +145,36 @@ function is_specialist(unit_role, type = "standard", include_trainee = true, inc
             _specialists = [_roles[eROLE.Chaplain]];
             if (_chap_name == "Iron Hands") {
                 array_push(_specialists, _roles[eROLE.Techmarine]);
+				if (include_trainee) {
+					array_push(_specialists, $"{_roles[eROLE.Techmarine]} Aspirant");
+				}
+				if (include_heads) {
+					array_push(_specialists, "Forge Master");
+				}
             }
+			if (include_trainee) {
+				array_push(_specialists, $"{_roles[eROLE.Chaplain]} Aspirant");
+			}
+			if (include_heads) {
+				array_push(_specialists, "Master of Sanctity");
+			}
             break;
         case "apoth":
             _specialists = [_roles[eROLE.Apothecary]];
             if (_chap_name == "Space Wolves") {
                 array_push(_specialists, _roles[eROLE.Chaplain]);
+				if (include_trainee) {
+					array_push(_specialists, $"{_roles[eROLE.Chaplain]} Aspirant");
+				}
+				if (include_heads) {
+					array_push(_specialists, "Master of Sanctity");
+				}
+            }
+			if (include_trainee) {
+				array_push(_specialists, $"{_roles[eROLE.Apothecary]} Aspirant");
+            }
+			if (include_heads) {
+				array_push(_specialists, "Master of the Apothecarion");
             }
             break;
 

--- a/scripts/is_specialist/is_specialist.gml
+++ b/scripts/is_specialist/is_specialist.gml
@@ -220,7 +220,7 @@ function collect_role_group(group="standard", location="", opposite=false, searc
 			if (unit.name()=="") then continue;
 			if (group!="all"){
 				if (is_array(group)){
-					if (array_length == 3) {
+					if (array_length(group) == 3) {
 						_is_special_group = unit.IsSpecialist(group[0], group[1], group[2]);
 					} else {
 						_is_special_group = unit.IsSpecialist(group[0], group[1]);

--- a/scripts/is_specialist/is_specialist.gml
+++ b/scripts/is_specialist/is_specialist.gml
@@ -24,10 +24,10 @@ function role_groups(group, include_trainee = true, include_heads = true) {
                 _roles[eROLE.HonourGuard]
             ];
             if (include_trainee) {
-				_role_list = array_concat(_roles, role_groups("trainee"));
+				_role_list = array_concat(_role_list, role_groups("trainee"));
             }
 			if (include_heads) {
-				_role_list = array_concat(_roles, role_groups("heads"));
+				_role_list = array_concat(_role_list, role_groups("heads"));
             }
             break;
 
@@ -220,7 +220,11 @@ function collect_role_group(group="standard", location="", opposite=false, searc
 			if (unit.name()=="") then continue;
 			if (group!="all"){
 				if (is_array(group)){
-					_is_special_group = unit.IsSpecialist(group[0], group[1],group[2]);
+					if (array_length == 3) {
+						_is_special_group = unit.IsSpecialist(group[0], group[1], group[2]);
+					} else {
+						_is_special_group = unit.IsSpecialist(group[0], group[1]);
+					}
 				} else {
 					_is_special_group = unit.IsSpecialist(group);
 				}

--- a/scripts/scr_company_struct/scr_company_struct.gml
+++ b/scripts/scr_company_struct/scr_company_struct.gml
@@ -181,16 +181,13 @@ function CompanyStruct(comp) constructor{
 					ancient = unit;
 				} else if (unit.role() == role_set[eROLE.Champion]){
 					champion = unit;
-				}
-				  else if (unit.role() == role_set[eROLE.Chaplain]){
+				} else if (unit.role() == role_set[eROLE.Chaplain]){
 					chaplain = unit;
-				}else if (unit.role() == role_set[eROLE.Apothecary]){
+				} else if (unit.role() == role_set[eROLE.Apothecary]){
 					apothecary = unit;
-				}
-				  else if (unit.role() == role_set[eROLE.Techmarine]){
+				} else if (unit.role() == role_set[eROLE.Techmarine]){
 					tech_marine = unit;
-				}
-				  else if (unit.role() == role_set[eROLE.Librarian]){
+				} else if (unit.role() == role_set[eROLE.Librarian]){
 					lib = unit;
 				}
 			}

--- a/scripts/scr_company_struct/scr_company_struct.gml
+++ b/scripts/scr_company_struct/scr_company_struct.gml
@@ -181,14 +181,19 @@ function CompanyStruct(comp) constructor{
 					ancient = unit;
 				} else if (unit.role() == role_set[eROLE.Champion]){
 					champion = unit;
-				} else if (unit.role() == role_set[eROLE.Chaplain]){
-					chaplain = unit;
-				} else if (unit.role() == role_set[eROLE.Apothecary]){
-					apothecary = unit;
-				} else if (unit.role() == role_set[eROLE.Techmarine]){
-					tech_marine = unit;
-				} else if (unit.role() == role_set[eROLE.Librarian]){
-					lib = unit;
+				} else {
+					if (unit.IsSpecialist("chap")) {
+						chaplain = unit;
+					}
+					if (unit.IsSpecialist("apoth")) {
+						apothecary = unit;
+					}
+					if (unit.IsSpecialist("forge")) {
+						tech_marine = unit;
+					}
+					if (unit.IsSpecialist("lib")) {
+						lib = unit;
+					}
 				}
 			}
 		}

--- a/scripts/scr_company_struct/scr_company_struct.gml
+++ b/scripts/scr_company_struct/scr_company_struct.gml
@@ -145,6 +145,10 @@ function CompanyStruct(comp) constructor{
 	captain = "none";
 	champion = "none";
 	ancient = "none";
+        chaplain = "none";
+        apothecary = "none";
+	tech_marine = "none";
+	lib = "none";
 
 	static reset_squad_surface = function(){
 		if (is_array(squad_draw_surfaces)){
@@ -177,6 +181,18 @@ function CompanyStruct(comp) constructor{
 					ancient = unit;
 				} else if (unit.role() == role_set[eROLE.Champion]){
 					champion = unit;
+				}
+				  else if (unit.role() == role_set[eROLE.Chaplain]){
+					chaplain = unit;
+				}
+			          else if (unit.role() == role_set[eROLE.Apothecary]){
+					apothecary = unit;
+				}
+				  else if (unit.role() == role_set[eROLE.Techmarine]){
+					tech_marine = unit;
+				}
+				  else if (unit.role() == role_set[eROLE.Librarian]){
+					lib = unit;
 				}
 			}
 		}

--- a/scripts/scr_company_struct/scr_company_struct.gml
+++ b/scripts/scr_company_struct/scr_company_struct.gml
@@ -145,8 +145,8 @@ function CompanyStruct(comp) constructor{
 	captain = "none";
 	champion = "none";
 	ancient = "none";
-        chaplain = "none";
-        apothecary = "none";
+    chaplain = "none";
+    apothecary = "none";
 	tech_marine = "none";
 	lib = "none";
 

--- a/scripts/scr_company_struct/scr_company_struct.gml
+++ b/scripts/scr_company_struct/scr_company_struct.gml
@@ -184,8 +184,7 @@ function CompanyStruct(comp) constructor{
 				}
 				  else if (unit.role() == role_set[eROLE.Chaplain]){
 					chaplain = unit;
-				}
-			          else if (unit.role() == role_set[eROLE.Apothecary]){
+				}else if (unit.role() == role_set[eROLE.Apothecary]){
 					apothecary = unit;
 				}
 				  else if (unit.role() == role_set[eROLE.Techmarine]){

--- a/scripts/scr_complex_colour_kit/scr_complex_colour_kit.gml
+++ b/scripts/scr_complex_colour_kit/scr_complex_colour_kit.gml
@@ -411,7 +411,7 @@ function setup_complex_livery_shader(setup_role, game_setup=false, unit = "none"
         var _full_liveries = obj_ini.full_liveries;
         var _roles = obj_ini.role[100];
         var data_set = obj_ini.full_liveries[0];
-        if (is_specialist(setup_role, "libs")){
+        if (is_specialist(setup_role, "lib")){
             data_set = _full_liveries[eROLE.Librarian];
         } else if (is_specialist(setup_role, "heads")){
             if (is_specialist(setup_role, "apoth")){

--- a/scripts/scr_culture_visuals/scr_culture_visuals.gml
+++ b/scripts/scr_culture_visuals/scr_culture_visuals.gml
@@ -315,13 +315,13 @@ global.modular_drawing_items = [
         sprite : spr_gear_librarian,
         body_types :[0],
         position : "right_pauldron_icons",
-        role_type : ["libs"],
+        role_type : ["lib"],
     },
     {
         sprite : spr_gear_librarian_term,
         body_types :[2],
         position : "right_pauldron_icons",
-        role_type : ["libs"],
+        role_type : ["lib"],
     },
     {
         sprite : spr_roman_centurian_crest,
@@ -545,7 +545,7 @@ global.modular_drawing_items = [
         sprite : spr_gear_hood2,
         body_types :[0],
         position : "mouth_variants", 
-        role_type : ["libs"],
+        role_type : ["lib"],
         chapter_disadv : ["Warp Tainted"],    
     },
     {

--- a/scripts/scr_culture_visuals/scr_culture_visuals.gml
+++ b/scripts/scr_culture_visuals/scr_culture_visuals.gml
@@ -801,8 +801,8 @@ function DummyMarine()constructor{
             return mobi[100][livery_picker.role_set > 0  ? livery_picker.role_set :eROLE.Tactical];
         }
     }
-    static IsSpecialist = function(search_type="standard",include_trainee=false){
-        return is_specialist(role(), search_type,include_trainee)
+    static IsSpecialist = function(search_type="standard",include_trainee=true, include_heads=true){
+        return is_specialist(role(), search_type,include_trainee, include_heads);
     }
     static has_trait = marine_has_trait;
 

--- a/scripts/scr_culture_visuals/scr_culture_visuals.gml
+++ b/scripts/scr_culture_visuals/scr_culture_visuals.gml
@@ -801,7 +801,7 @@ function DummyMarine()constructor{
             return mobi[100][livery_picker.role_set > 0  ? livery_picker.role_set :eROLE.Tactical];
         }
     }
-    static IsSpecialist = function(search_type="standard",include_trainee=true, include_heads=true){
+    static IsSpecialist = function(search_type="standard",include_trainee=false, include_heads=true){
         return is_specialist(role(), search_type,include_trainee, include_heads);
     }
     static has_trait = marine_has_trait;

--- a/scripts/scr_draw_unit_image/scr_draw_unit_image.gml
+++ b/scripts/scr_draw_unit_image/scr_draw_unit_image.gml
@@ -324,7 +324,7 @@ function scr_draw_unit_image(_background = false) {
             // // Honour Guard
             // else if (unit_role==obj_ini.role[100,2]){unit_specialization=14;}
             // Chaplain
-            if (is_specialist(unit_role, "chap")) {
+            if (is_specialist(unit_role, "chap", true)) {
                 if (unit_chapter == "Iron Hands") {
                     unit_specialization = UnitSpecialization.IronFather;
                 } else if (unit_chapter == "Space Wolves") {
@@ -333,21 +333,21 @@ function scr_draw_unit_image(_background = false) {
                     unit_specialization = UnitSpecialization.Chaplain;
                 }
             } else // Techmarine
-                if (is_specialist(unit_role, "forge")) {
+                if (is_specialist(unit_role, "forge", true)) {
                     if (unit_chapter == "Iron Hands") {
                         unit_specialization = UnitSpecialization.IronFather;
                     } else {
                         unit_specialization = UnitSpecialization.Techmarine;
                     }
                 } else // Apothecary
-                    if (is_specialist(unit_role, "apoth")) {
+                    if (is_specialist(unit_role, "apoth", true)) {
                         if (unit_chapter == "Space Wolves") {
                             unit_specialization = UnitSpecialization.WolfPriest;
                         } else {
                             unit_specialization = UnitSpecialization.Apothecary;
                         }
                     } else // Librarian
-                        if (is_specialist(unit_role, "lib")) {
+                        if (is_specialist(unit_role, "lib", true)) {
                             unit_specialization = UnitSpecialization.Librarian;
                         } else // Death Company
                             if (unit_role == "Death Company") {

--- a/scripts/scr_draw_unit_image/scr_draw_unit_image.gml
+++ b/scripts/scr_draw_unit_image/scr_draw_unit_image.gml
@@ -347,7 +347,7 @@ function scr_draw_unit_image(_background = false) {
                             unit_specialization = UnitSpecialization.Apothecary;
                         }
                     } else // Librarian
-                        if (is_specialist(unit_role, "libs")) {
+                        if (is_specialist(unit_role, "lib")) {
                             unit_specialization = UnitSpecialization.Librarian;
                         } else // Death Company
                             if (unit_role == "Death Company") {

--- a/scripts/scr_draw_unit_image/scr_draw_unit_image.gml
+++ b/scripts/scr_draw_unit_image/scr_draw_unit_image.gml
@@ -324,7 +324,7 @@ function scr_draw_unit_image(_background = false) {
             // // Honour Guard
             // else if (unit_role==obj_ini.role[100,2]){unit_specialization=14;}
             // Chaplain
-            if (is_specialist(unit_role, "chap", true)) {
+            if (is_specialist(unit_role, "chap")) {
                 if (unit_chapter == "Iron Hands") {
                     unit_specialization = UnitSpecialization.IronFather;
                 } else if (unit_chapter == "Space Wolves") {
@@ -333,21 +333,21 @@ function scr_draw_unit_image(_background = false) {
                     unit_specialization = UnitSpecialization.Chaplain;
                 }
             } else // Techmarine
-                if (is_specialist(unit_role, "forge", true)) {
+                if (is_specialist(unit_role, "forge")) {
                     if (unit_chapter == "Iron Hands") {
                         unit_specialization = UnitSpecialization.IronFather;
                     } else {
                         unit_specialization = UnitSpecialization.Techmarine;
                     }
                 } else // Apothecary
-                    if (is_specialist(unit_role, "apoth", true)) {
+                    if (is_specialist(unit_role, "apoth")) {
                         if (unit_chapter == "Space Wolves") {
                             unit_specialization = UnitSpecialization.WolfPriest;
                         } else {
                             unit_specialization = UnitSpecialization.Apothecary;
                         }
                     } else // Librarian
-                        if (is_specialist(unit_role, "libs", true)) {
+                        if (is_specialist(unit_role, "libs")) {
                             unit_specialization = UnitSpecialization.Librarian;
                         } else // Death Company
                             if (unit_role == "Death Company") {

--- a/scripts/scr_drop_fiddle/scr_drop_fiddle.gml
+++ b/scripts/scr_drop_fiddle/scr_drop_fiddle.gml
@@ -51,7 +51,7 @@ function scr_drop_fiddle(argument0, argument1, argument2, argument3) {
 	
 					if (obj_ini.role[comp][i] == obj_ini.role[100][5]) then capts++;
 					if (unit.IsSpecialist("chap", true)) then chaplains++;
-					if (unit.IsSpecialist("libs", true)) then psykers++;
+					if (unit.IsSpecialist("lib", true)) then psykers++;
 					if (unit.IsSpecialist("apoth", true)) then apothecaries++;
 					if (unit.IsSpecialist("forge", true)) then techmarines++;
 	
@@ -119,7 +119,7 @@ function scr_drop_fiddle(argument0, argument1, argument2, argument3) {
 	
 					if (obj_ini.role[comp][i] == obj_ini.role[100][5]) then capts--;
 					if (unit.IsSpecialist("chap", true)) then chaplains--;
-					if (unit.IsSpecialist("libs", true)) then psykers--;
+					if (unit.IsSpecialist("lib", true)) then psykers--;
 					if (unit.IsSpecialist("apoth", true)) then apothecaries--;
 					if (unit.IsSpecialist("forge", true)) then techmarines--;
 	

--- a/scripts/scr_manage_task_selector/scr_manage_task_selector.gml
+++ b/scripts/scr_manage_task_selector/scr_manage_task_selector.gml
@@ -83,6 +83,81 @@ function scr_manage_task_selector(){
 		                			update_general_manage_view();
 		                			exit;
 	                				break;
+								case "chaplain_promote":
+		                			unit = display_unit[i];
+		                			unit.squad="none";
+		                			var start_company = unit.company;
+		                			var end_company =  selection_data.system;
+		                			var endslot = 0;
+		                			for (i=0;i<array_length(obj_ini.name[end_company]);i++){
+		                				if (obj_ini.name[end_company][i]==""){
+		                					endslot=i;
+		                					break;
+		                				}
+		                			}
+		                			scr_move_unit_info(start_company, end_company, unit.marine_number,endslot);
+		                			with (obj_ini){
+		                				scr_company_order(start_company);
+		                				scr_company_order(end_company);
+		                			}
+		                			managing = end_company;
+		                			update_general_manage_view();
+		                			exit;
+	                				break;
+								case "apothecary_promote":
+		                			unit = display_unit[i];
+		                			unit.squad="none";
+		                			var start_company = unit.company;
+		                			var end_company =  selection_data.system;
+		                			var endslot = 0;
+		                			for (i=0;i<array_length(obj_ini.name[end_company]);i++){
+		                				if (obj_ini.name[end_company][i]==""){
+		                					endslot=i;
+		                					break;
+		                				}
+		                			}
+		                			scr_move_unit_info(start_company, end_company, unit.marine_number,endslot);
+		                			with (obj_ini){
+		                				scr_company_order(start_company);
+		                				scr_company_order(end_company);
+		                			}
+		                			managing = end_company;
+		                			update_general_manage_view();
+		                			exit;
+	                				break;
+								case "tech_marine_promote":
+		                			unit = display_unit[i];
+		                			unit.squad="none";
+		                			var start_company = unit.company;
+		                			var end_company =  selection_data.system;
+		                			var endslot = 0;
+		                			for (i=0;i<array_length(obj_ini.name[end_company]);i++){
+		                				if (obj_ini.name[end_company][i]==""){
+		                					endslot=i;
+		                					break;
+		                				}
+		                			}
+		                			scr_move_unit_info(start_company, end_company, unit.marine_number,endslot);
+		                			with (obj_ini){
+		                				scr_company_order(start_company);
+		                				scr_company_order(end_company);
+		                			}
+		                			managing = end_company;
+		                			update_general_manage_view();
+		                			exit;
+	                				break;
+								case "librarian_promote":
+		                			unit = display_unit[i];
+		                			unit.squad="none";
+		                			var start_company = unit.company;
+		                			var end_company =  selection_data.system;
+		                			var endslot = 0;
+		                			for (i=0;i<array_length(obj_ini.name[end_company]);i++){
+		                				if (obj_ini.name[end_company][i]==""){
+		                					endslot=i;
+		                					break;
+		                				}
+                                                                }
 	                			case "hunt_beast":
 	                			case "train_forces":
 	                				unit = display_unit[i];

--- a/scripts/scr_manage_task_selector/scr_manage_task_selector.gml
+++ b/scripts/scr_manage_task_selector/scr_manage_task_selector.gml
@@ -157,7 +157,16 @@ function scr_manage_task_selector(){
 		                					endslot=i;
 		                					break;
 		                				}
-                                                                }
+		                			}
+		                			scr_move_unit_info(start_company, end_company, unit.marine_number,endslot);
+		                			with (obj_ini){
+		                				scr_company_order(start_company);
+		                				scr_company_order(end_company);
+		                			}
+		                			managing = end_company;
+		                			update_general_manage_view();
+		                			exit;
+	                				break;
 	                			case "hunt_beast":
 	                			case "train_forces":
 	                				unit = display_unit[i];

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -503,7 +503,7 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
         return string(temp_role);
     };
 
-    static IsSpecialist = function(search_type = "standard", include_trainee = true, include_heads = true) {
+    static IsSpecialist = function(search_type = "standard", include_trainee = false, include_heads = true) {
         return is_specialist(role(), search_type, include_trainee, include_heads);
     };
 

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -503,8 +503,8 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
         return string(temp_role);
     };
 
-    static IsSpecialist = function(search_type = "standard", include_trainee = false) {
-        return is_specialist(role(), search_type, include_trainee);
+    static IsSpecialist = function(search_type = "standard", include_trainee = true, include_heads = true) {
+        return is_specialist(role(), search_type, include_trainee, include_heads);
     };
 
     static update_role = function(new_role) {

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -466,7 +466,7 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
         experience = new_val;
         var _powers_learned = 0;
 
-        if (IsSpecialist("libs")) {
+        if (IsSpecialist("lib")) {
             _powers_learned = update_powers();
         }
 
@@ -974,7 +974,7 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
             var _cloak_chance = 5;
             if (role() == obj_ini.role[100][eROLE.Chaplain]) {
                 _cloak_chance += 25;
-            } else if (IsSpecialist("libs")) {
+            } else if (IsSpecialist("lib")) {
                 _cloak_chance += 75;
             }
             if (irandom(100) <= _cloak_chance) {
@@ -1680,7 +1680,7 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
                 var psychic_bonus = psionic * 20;
                 psychic_bonus *= 0.5 + (wisdom / 100);
                 psychic_bonus *= 0.5 + (experience / 100);
-                psychic_bonus *= IsSpecialist("libs") ? 1 : 0.25;
+                psychic_bonus *= IsSpecialist("lib") ? 1 : 0.25;
                 psychic_bonus = round(psychic_bonus);
                 primary_weapon.attack += psychic_bonus;
                 basic_wep_string += $"Psychic Power: +{psychic_bonus}#";

--- a/scripts/scr_player_combat_weapon_stacks/scr_player_combat_weapon_stacks.gml
+++ b/scripts/scr_player_combat_weapon_stacks/scr_player_combat_weapon_stacks.gml
@@ -173,7 +173,7 @@ function scr_player_combat_weapon_stacks() {
                     add_second_profiles_to_stack(armour_item);
                 }
 
-                if (unit.IsSpecialist("libs", true) || (unit.role() == "Chapter Master" && obj_ncombat.chapter_master_psyker == 1)) {
+                if (unit.IsSpecialist("lib", true) || (unit.role() == "Chapter Master" && obj_ncombat.chapter_master_psyker == 1)) {
                     if (marine_casting_cooldown[g] == 0) {
                         if (array_length(unit.powers_known) > 0) {
                             if (marine_casting[g] == true) {

--- a/scripts/scr_random_marine/scr_random_marine.gml
+++ b/scripts/scr_random_marine/scr_random_marine.gml
@@ -8,7 +8,7 @@ function scr_random_marine(role, exp_req, search_params="none"){
 	company=0;i=0;
 	var company_list = [0,1,2,3,4,5,6,7,8,9,10]
 	if (role == "lib"){
-		role = role_groups("");
+		role = role_groups("lib");
 	}
 	for (var comp_shuffle=0;comp_shuffle<11;comp_shuffle++){
 		// this ensures that companies are searched randomly

--- a/scripts/scr_random_marine/scr_random_marine.gml
+++ b/scripts/scr_random_marine/scr_random_marine.gml
@@ -8,7 +8,7 @@ function scr_random_marine(role, exp_req, search_params="none"){
 	company=0;i=0;
 	var company_list = [0,1,2,3,4,5,6,7,8,9,10]
 	if (role == "lib"){
-		role = role_groups("lib");
+		role = role_groups("");
 	}
 	for (var comp_shuffle=0;comp_shuffle<11;comp_shuffle++){
 		// this ensures that companies are searched randomly

--- a/scripts/scr_roster/scr_roster.gml
+++ b/scripts/scr_roster/scr_roster.gml
@@ -543,7 +543,7 @@ function add_unit_to_battle(unit,meeting, is_local){
 
         //librarium roles
 
-    }else if (unit.IsSpecialist("libs",true)){
+    }else if (unit.IsSpecialist("lib",true)){
         col = obj_controller.bat_librarian_column;                  //librarium
         new_combat.librarians++;
         moov = 1;

--- a/scripts/scr_special_view/scr_special_view.gml
+++ b/scripts/scr_special_view/scr_special_view.gml
@@ -66,7 +66,7 @@ function scr_special_view(command_group) {
 
 	v=0;
 	if (command_group==13) or (command_group==0){// Librarium
-		var libs = collect_role_group(["libs",true]);
+		var libs = collect_role_group(["lib",true]);
 		for (var i=0;i<array_length(libs);i++){
 			unit = libs[i];
 			add_man_to_manage_arrays(libs[i]);

--- a/scripts/scr_ui_manage/scr_ui_manage.gml
+++ b/scripts/scr_ui_manage/scr_ui_manage.gml
@@ -95,22 +95,21 @@ function special_role_slot_open(xx, yy, search_params, role_group_params, purpos
     draw_rectangle(xx + 25, yy + 64, xx + 974, yy + 85, 1);
     draw_set_halign(fa_center);
     draw_set_color(c_yellow);
-    draw_text(xx + 500, yy + 66, $"++{{tab_text}}++");
+    draw_text(xx + 500, yy + 66, $"++{tab_text}++");
     draw_set_halign(fa_left);
     draw_set_color(c_gray);
     if (point_and_click([xx + 25, yy + 64, xx + 974, yy + 85])) {
         var candidates = collect_role_group(role_group_params.group, role_group_params.location, role_group_params.opposite, search_params);
         group_selection(candidates, {
             purpose: purpose,
-            purpose_code: "purpose_code,
+            purpose_code: purpose_code,
             number: 1,
             system: managing,
             feature: "none",
             planet: 0,
             selections: []
         });
-        exit;
-    }    
+    } 
 }
 
 function alternative_manage_views(x1, y1) {
@@ -687,7 +686,7 @@ function scr_ui_manage() {
             }
             for (var i = 0; i < repetitions; i++) {
                 if (managing > 0 && managing <= 10 && (!cap_slot || !champ_slot || !ancient_slot || !chaplain_slot|| !tech_marine_slot || !apothecary_slot|| !lib_slot)) {
-                    if (company_data.captain == "none") {
+                    if (!cap_slot) {
                         special_role_slot_open(
                             xx,
                             yy,
@@ -705,6 +704,7 @@ function scr_ui_manage() {
                         );
                         yy += 20;
                         cap_slot = true;
+                        if (managing == -1) then exit;
                         continue;
                     }
                     if (!champ_slot) {
@@ -729,6 +729,7 @@ function scr_ui_manage() {
 
                         yy += 20;
                         champ_slot = true;
+                        if (managing == -1) then exit;
                         continue;
                     }
                     if (!ancient_slot) {
@@ -750,6 +751,7 @@ function scr_ui_manage() {
 
                         yy += 20;
                         ancient_slot = true;
+                        if (managing == -1) then exit;
                         continue;
                     }
                      if (!chaplain_slot) {
@@ -757,10 +759,10 @@ function scr_ui_manage() {
                             xx,
                             yy,
                             {
-                                companies: [managing,0];
+                                companies: [managing,0],
                             },
                             {
-                                group:"chaplain_candidates",
+                                group:["chap",false, false],
                                 location: "",
                                 opposite : false,
                             },
@@ -770,6 +772,7 @@ function scr_ui_manage() {
                         );                         
                         yy += 20;
                         chaplain_slot = true;
+                        if (managing == -1) then exit;
                         continue;
                     }
                     if (!apothecary_slot) {
@@ -777,10 +780,10 @@ function scr_ui_manage() {
                             xx,
                             yy,
                             {
-                                companies: [managing,0];
+                                companies: [managing,0],
                             },
                             {
-                                group:"apothecary_candidates",
+                                group:["apoth",false, false],
                                 location: "",
                                 opposite : false,
                             },
@@ -790,6 +793,7 @@ function scr_ui_manage() {
                         );
                         yy += 20;
                         apothecary_slot = true;
+                        if (managing == -1) then exit;
                         continue;
                     }
                     if (!tech_marine_slot) {
@@ -797,10 +801,10 @@ function scr_ui_manage() {
                             xx,
                             yy,
                             {
-                                companies: [managing,0];
+                                companies: [managing,0],
                             },
                             {
-                                group:"tech_marine_candidates",
+                                group:["forge",false, false],
                                 location: "",
                                 opposite : false,
                             },
@@ -810,6 +814,7 @@ function scr_ui_manage() {
                         );                        
                         yy += 20;
                         tech_marine_slot = true;
+                        if (managing == -1) then exit;
                         continue;
                     }
                     if (!lib_slot) {
@@ -817,10 +822,10 @@ function scr_ui_manage() {
                             xx,
                             yy,
                             {
-                                companies: [managing,0];
+                                companies: [managing,0],
                             },
                             {
-                                group:"librarian_candidates",
+                                group:["libs",false, false],
                                 location: "",
                                 opposite : false,
                             },
@@ -830,6 +835,7 @@ function scr_ui_manage() {
                         );                        
                         yy += 20;
                         lib_slot = true;
+                        if (managing == -1) then exit;
                         continue;
                     }
                 }

--- a/scripts/scr_ui_manage/scr_ui_manage.gml
+++ b/scripts/scr_ui_manage/scr_ui_manage.gml
@@ -655,9 +655,13 @@ function scr_ui_manage() {
                 var cap_slot = company_data.captain != "none";
                 var champ_slot = company_data.champion != "none";
                 var ancient_slot = company_data.ancient != "none";
+		var chaplain_slot = company_data.chaplain != "none";
+		var apothecary_slot = company_data.apothecary != "none";
+		var tech_marine_slot = company_data.tech_marine != "none";
+		var lib_slot = company_data.lib != "none";
             }
             for (var i = 0; i < repetitions; i++) {
-                if (managing > 0 && managing <= 10 && (!cap_slot || !champ_slot || !ancient_slot)) {
+                if (managing > 0 && managing <= 10 && (!cap_slot || !champ_slot || !ancient_slot || !chaplain_slot|| !tech_marine_slot || !apothecary_slot|| !lib_slot)) {
                     if (!cap_slot) {
                         draw_set_color(c_black);
                         draw_rectangle(xx + 25, yy + 64, xx + 974, yy + 85, 0);
@@ -746,6 +750,126 @@ function scr_ui_manage() {
                         }
                         yy += 20;
                         ancient_slot = true;
+                        continue;
+                    }
+                     if (!chaplain_slot) {
+                        draw_set_color(c_black);
+                        draw_rectangle(xx + 25, yy + 64, xx + 974, yy + 85, 0);
+                        draw_set_color(c_gray);
+                        draw_rectangle(xx + 25, yy + 64, xx + 974, yy + 85, 1);
+                        draw_set_halign(fa_center);
+                        draw_set_color(c_yellow);
+                        draw_text(xx + 500, yy + 66, "++New Chaplain Required++");
+                        draw_set_halign(fa_left);
+                        draw_set_color(c_gray);
+                        if (point_and_click([xx + 25, yy + 64, xx + 974, yy + 85])) {
+                            var search_params = {
+                                companies: managing
+                            };
+                            var candidates = collect_role_group("chap_candidates");
+                            group_selection(candidates, {
+                                purpose: $"{scr_roman_numerals()[managing - 1]} Company Chaplain Candidates",
+                                purpose_code: "chaplain_promote",
+                                number: 1,
+                                system: managing,
+                                feature: "none",
+                                planet: 0,
+                                selections: []
+                            });
+                            exit;
+                        }
+                        yy += 20;
+                        chaplain_slot = true;
+                        continue;
+                    }
+                    if (!apothecary_slot) {
+                        draw_set_color(c_black);
+                        draw_rectangle(xx + 25, yy + 64, xx + 974, yy + 85, 0);
+                        draw_set_color(c_gray);
+                        draw_rectangle(xx + 25, yy + 64, xx + 974, yy + 85, 1);
+                        draw_set_halign(fa_center);
+                        draw_set_color(c_yellow);
+                        draw_text(xx + 500, yy + 66, "++New Apothecary Required++");
+                        draw_set_halign(fa_left);
+                        draw_set_color(c_gray);
+                        if (point_and_click([xx + 25, yy + 64, xx + 974, yy + 85])) {
+                            var search_params = {
+                                companies: managing
+                            };
+                            var candidates = collect_role_group("apothecary_candidates");
+                            group_selection(candidates, {
+                                purpose: $"{scr_roman_numerals()[managing - 1]} Company Apothecary Candidates",
+                                purpose_code: "apothecary_promote",
+                                number: 1,
+                                system: managing,
+                                feature: "none",
+                                planet: 0,
+                                selections: []
+                            });
+                            exit;
+                        }
+                        yy += 20;
+                        apothecary_slot = true;
+                        continue;
+                    }
+                    if (!tech_marine_slot) {
+                        draw_set_color(c_black);
+                        draw_rectangle(xx + 25, yy + 64, xx + 974, yy + 85, 0);
+                        draw_set_color(c_gray);
+                        draw_rectangle(xx + 25, yy + 64, xx + 974, yy + 85, 1);
+                        draw_set_halign(fa_center);
+                        draw_set_color(c_yellow);
+                        draw_text(xx + 500, yy + 66, "++New Tech Marine Required++");
+                        draw_set_halign(fa_left);
+                        draw_set_color(c_gray);
+                        if (point_and_click([xx + 25, yy + 64, xx + 974, yy + 85])) {
+                            var search_params = {
+                                companies: managing
+                            };
+                            var candidates = collect_role_group("tech_marine_candidates");
+                            group_selection(candidates, {
+                                purpose: $"{scr_roman_numerals()[managing - 1]} Company Tech Marine Candidates",
+                                purpose_code: "tech_marine_promote",
+                                number: 1,
+                                system: managing,
+                                feature: "none",
+                                planet: 0,
+                                selections: []
+                            });
+                            exit;
+                        }
+                        yy += 20;
+                        tech_marine_slot = true;
+                        continue;
+                    }
+                    if (!lib_slot) {
+                        draw_set_color(c_black);
+                        draw_rectangle(xx + 25, yy + 64, xx + 974, yy + 85, 0);
+                        draw_set_color(c_gray);
+                        draw_rectangle(xx + 25, yy + 64, xx + 974, yy + 85, 1);
+                        draw_set_halign(fa_center);
+                        draw_set_color(c_yellow);
+                        draw_text(xx + 500, yy + 66, "++New Librarian Required++");
+                        draw_set_halign(fa_left);
+                        draw_set_color(c_gray);
+                        if (point_and_click([xx + 25, yy + 64, xx + 974, yy + 85])) {
+                            var search_params = {
+                                companies: managing
+                            };
+                            var candidates = collect_role_group("librarian_candidates");
+                            group_selection(candidates, {
+                                purpose: $"{scr_roman_numerals()[managing - 1]} Company Librarian Candidates",
+                                purpose_code: "librarian_promote",
+                                number: 1,
+                                system: managing,
+                                feature: "none",
+                                planet: 0,
+                                selections: []
+                            });
+                            exit;
+                        }
+                        yy += 20;
+                        lib_slot = true;
                         continue;
                     }
                 }

--- a/scripts/scr_ui_manage/scr_ui_manage.gml
+++ b/scripts/scr_ui_manage/scr_ui_manage.gml
@@ -783,7 +783,7 @@ function scr_ui_manage() {
                         special_role_slot_open(xx, yy, {
                             companies: [managing, 0]
                         }, {
-                            group: ["libs", false, false],
+                            group: ["lib", false, false],
                             location: "",
                             opposite: false
                         }, $"{scr_roman_numerals()[managing - 1]} Company Librarian Candidates", "librarian_promote", "New Company Librarian Required");

--- a/scripts/scr_ui_manage/scr_ui_manage.gml
+++ b/scripts/scr_ui_manage/scr_ui_manage.gml
@@ -88,6 +88,31 @@ function load_marines_into_ship(system, ship, units, reload = false) {
     }
 }
 
+function special_role_slot_open(xx, yy, search_params, role_group_params, purpose, purpose_code, tab_text){
+    draw_set_color(c_black);
+    draw_rectangle(xx + 25, yy + 64, xx + 974, yy + 85, 0);
+    draw_set_color(c_gray);
+    draw_rectangle(xx + 25, yy + 64, xx + 974, yy + 85, 1);
+    draw_set_halign(fa_center);
+    draw_set_color(c_yellow);
+    draw_text(xx + 500, yy + 66, $"++{{tab_text}}++");
+    draw_set_halign(fa_left);
+    draw_set_color(c_gray);
+    if (point_and_click([xx + 25, yy + 64, xx + 974, yy + 85])) {
+        var candidates = collect_role_group(role_group_params.group, role_group_params.location, role_group_params.opposite, search_params);
+        group_selection(candidates, {
+            purpose: purpose,
+            purpose_code: "purpose_code,
+            number: 1,
+            system: managing,
+            feature: "none",
+            planet: 0,
+            selections: []
+        });
+        exit;
+    }    
+}
+
 function alternative_manage_views(x1, y1) {
     var _squad_button = management_buttons.squad_toggle;
     _squad_button.update({
@@ -655,219 +680,154 @@ function scr_ui_manage() {
                 var cap_slot = company_data.captain != "none";
                 var champ_slot = company_data.champion != "none";
                 var ancient_slot = company_data.ancient != "none";
-		var chaplain_slot = company_data.chaplain != "none";
-		var apothecary_slot = company_data.apothecary != "none";
-		var tech_marine_slot = company_data.tech_marine != "none";
-		var lib_slot = company_data.lib != "none";
+        		var chaplain_slot = company_data.chaplain != "none";
+        		var apothecary_slot = company_data.apothecary != "none";
+        		var tech_marine_slot = company_data.tech_marine != "none";
+        		var lib_slot = company_data.lib != "none";
             }
             for (var i = 0; i < repetitions; i++) {
                 if (managing > 0 && managing <= 10 && (!cap_slot || !champ_slot || !ancient_slot || !chaplain_slot|| !tech_marine_slot || !apothecary_slot|| !lib_slot)) {
-                    if (!cap_slot) {
-                        draw_set_color(c_black);
-                        draw_rectangle(xx + 25, yy + 64, xx + 974, yy + 85, 0);
-                        draw_set_color(c_gray);
-                        draw_rectangle(xx + 25, yy + 64, xx + 974, yy + 85, 1);
-                        draw_set_halign(fa_center);
-                        draw_set_color(c_yellow);
-                        draw_text(xx + 500, yy + 66, "++New Captain Required++");
-                        draw_set_halign(fa_left);
-                        draw_set_color(c_gray);
-                        if (point_and_click([xx + 25, yy + 64, xx + 974, yy + 85])) {
-                            var candidates = collect_role_group("captain_candidates");
-                            group_selection(candidates, {
-                                purpose: $"{scr_roman_numerals()[managing - 1]} Company Captain Candidates",
-                                purpose_code: "captain_promote",
-                                number: 1,
-                                system: managing,
-                                feature: "none",
-                                planet: 0,
-                                selections: []
-                            });
-                            exit;
-                        }
+                    if (company_data.captain == "none") {
+                        special_role_slot_open(
+                            xx,
+                            yy,
+                            {
+
+                            },
+                            {
+                                group:"captain_candidates",
+                                location: "",
+                                opposite : false,
+                            },
+                            $"{scr_roman_numerals()[managing - 1]} Company Captain Candidates",
+                            "captain_promote",
+                            "New Captain Required"
+                        );
                         yy += 20;
                         cap_slot = true;
                         continue;
                     }
                     if (!champ_slot) {
-                        draw_set_color(c_black);
-                        draw_rectangle(xx + 25, yy + 64, xx + 974, yy + 85, 0);
-                        draw_set_color(c_gray);
-                        draw_rectangle(xx + 25, yy + 64, xx + 974, yy + 85, 1);
-                        draw_set_halign(fa_center);
-                        draw_set_color(c_yellow);
-                        draw_text(xx + 500, yy + 66, "++New Champion Required++");
-                        draw_set_halign(fa_left);
-                        draw_set_color(c_gray);
-                        if (point_and_click([xx + 25, yy + 64, xx + 974, yy + 85])) {
-                            var search_params = {
+                        special_role_slot_open(
+                            xx,
+                            yy,
+                            {
                                 companies: managing,
                                 "stat": [
                                     ["weapon_skill", 44, "more"]
                                 ]
-                            };
-                            var candidates = collect_role_group("standard", "", true, search_params);
-                            group_selection(candidates, {
-                                purpose: $"{scr_roman_numerals()[managing - 1]} Champion Candidates",
-                                purpose_code: "champion_promote",
-                                number: 1,
-                                system: managing,
-                                feature: "none",
-                                planet: 0,
-                                selections: []
-                            });
-                            exit;
-                        }
+                            },
+                            {
+                                group:"standard",
+                                location: "",
+                                opposite : false,
+                            },
+                            $"{scr_roman_numerals()[managing - 1]} Champion Candidates",
+                            "champion_promote",
+                            "New Champion Required"
+                        );
+
                         yy += 20;
                         champ_slot = true;
                         continue;
                     }
                     if (!ancient_slot) {
-                        draw_set_color(c_black);
-                        draw_rectangle(xx + 25, yy + 64, xx + 974, yy + 85, 0);
-                        draw_set_color(c_gray);
-                        draw_rectangle(xx + 25, yy + 64, xx + 974, yy + 85, 1);
-                        draw_set_halign(fa_center);
-                        draw_set_color(c_yellow);
-                        draw_text(xx + 500, yy + 66, "++New Ancient Required++");
-                        draw_set_halign(fa_left);
-                        draw_set_color(c_gray);
-                        if (point_and_click([xx + 25, yy + 64, xx + 974, yy + 85])) {
-                            var search_params = {
+                        special_role_slot_open(
+                            xx,
+                            yy,
+                            {
                                 companies: managing
-                            };
-                            var candidates = collect_role_group("standard", "", true, search_params);
-                            group_selection(candidates, {
-                                purpose: $"{scr_roman_numerals()[managing - 1]} Company Ancient Candidates",
-                                purpose_code: "ancient_promote",
-                                number: 1,
-                                system: managing,
-                                feature: "none",
-                                planet: 0,
-                                selections: []
-                            });
-                            exit;
-                        }
+                            },
+                            {
+                                group:"standard",
+                                location: "",
+                                opposite : true,
+                            },
+                            $"{scr_roman_numerals()[managing - 1]} Company Ancient Candidates",
+                            "ancient_promote",
+                            "New Ancient Required"
+                        );                        
+
                         yy += 20;
                         ancient_slot = true;
                         continue;
                     }
                      if (!chaplain_slot) {
-                        draw_set_color(c_black);
-                        draw_rectangle(xx + 25, yy + 64, xx + 974, yy + 85, 0);
-                        draw_set_color(c_gray);
-                        draw_rectangle(xx + 25, yy + 64, xx + 974, yy + 85, 1);
-                        draw_set_halign(fa_center);
-                        draw_set_color(c_yellow);
-                        draw_text(xx + 500, yy + 66, "++New Chaplain Required++");
-                        draw_set_halign(fa_left);
-                        draw_set_color(c_gray);
-                        if (point_and_click([xx + 25, yy + 64, xx + 974, yy + 85])) {
-                            var search_params = {
-                                companies: managing
-                            };
-                            var candidates = collect_role_group("chap_candidates");
-                            group_selection(candidates, {
-                                purpose: $"{scr_roman_numerals()[managing - 1]} Company Chaplain Candidates",
-                                purpose_code: "chaplain_promote",
-                                number: 1,
-                                system: managing,
-                                feature: "none",
-                                planet: 0,
-                                selections: []
-                            });
-                            exit;
-                        }
+                        special_role_slot_open(
+                            xx,
+                            yy,
+                            {
+                                companies: [managing,0];
+                            },
+                            {
+                                group:"chaplain_candidates",
+                                location: "",
+                                opposite : false,
+                            },
+                            $"{scr_roman_numerals()[managing - 1]} Company Chaplain Candidates",
+                            "chaplain_promote",
+                            "New Company Chaplain Required"
+                        );                         
                         yy += 20;
                         chaplain_slot = true;
                         continue;
                     }
                     if (!apothecary_slot) {
-                        draw_set_color(c_black);
-                        draw_rectangle(xx + 25, yy + 64, xx + 974, yy + 85, 0);
-                        draw_set_color(c_gray);
-                        draw_rectangle(xx + 25, yy + 64, xx + 974, yy + 85, 1);
-                        draw_set_halign(fa_center);
-                        draw_set_color(c_yellow);
-                        draw_text(xx + 500, yy + 66, "++New Apothecary Required++");
-                        draw_set_halign(fa_left);
-                        draw_set_color(c_gray);
-                        if (point_and_click([xx + 25, yy + 64, xx + 974, yy + 85])) {
-                            var search_params = {
-                                companies: managing
-                            };
-                            var candidates = collect_role_group("apothecary_candidates");
-                            group_selection(candidates, {
-                                purpose: $"{scr_roman_numerals()[managing - 1]} Company Apothecary Candidates",
-                                purpose_code: "apothecary_promote",
-                                number: 1,
-                                system: managing,
-                                feature: "none",
-                                planet: 0,
-                                selections: []
-                            });
-                            exit;
-                        }
+                        special_role_slot_open(
+                            xx,
+                            yy,
+                            {
+                                companies: [managing,0];
+                            },
+                            {
+                                group:"apothecary_candidates",
+                                location: "",
+                                opposite : false,
+                            },
+                            $"{scr_roman_numerals()[managing - 1]} Company Apothecary Candidates",
+                            "apothecary_promote",
+                            "New Company Apothecary Required"
+                        );
                         yy += 20;
                         apothecary_slot = true;
                         continue;
                     }
                     if (!tech_marine_slot) {
-                        draw_set_color(c_black);
-                        draw_rectangle(xx + 25, yy + 64, xx + 974, yy + 85, 0);
-                        draw_set_color(c_gray);
-                        draw_rectangle(xx + 25, yy + 64, xx + 974, yy + 85, 1);
-                        draw_set_halign(fa_center);
-                        draw_set_color(c_yellow);
-                        draw_text(xx + 500, yy + 66, "++New Tech Marine Required++");
-                        draw_set_halign(fa_left);
-                        draw_set_color(c_gray);
-                        if (point_and_click([xx + 25, yy + 64, xx + 974, yy + 85])) {
-                            var search_params = {
-                                companies: managing
-                            };
-                            var candidates = collect_role_group("tech_marine_candidates");
-                            group_selection(candidates, {
-                                purpose: $"{scr_roman_numerals()[managing - 1]} Company Tech Marine Candidates",
-                                purpose_code: "tech_marine_promote",
-                                number: 1,
-                                system: managing,
-                                feature: "none",
-                                planet: 0,
-                                selections: []
-                            });
-                            exit;
-                        }
+                        special_role_slot_open(
+                            xx,
+                            yy,
+                            {
+                                companies: [managing,0];
+                            },
+                            {
+                                group:"tech_marine_candidates",
+                                location: "",
+                                opposite : false,
+                            },
+                            $"{scr_roman_numerals()[managing - 1]} Company Tech Marine Candidates",
+                            "tech_marine_promote",
+                            "New Company Tech Marine Required"
+                        );                        
                         yy += 20;
                         tech_marine_slot = true;
                         continue;
                     }
                     if (!lib_slot) {
-                        draw_set_color(c_black);
-                        draw_rectangle(xx + 25, yy + 64, xx + 974, yy + 85, 0);
-                        draw_set_color(c_gray);
-                        draw_rectangle(xx + 25, yy + 64, xx + 974, yy + 85, 1);
-                        draw_set_halign(fa_center);
-                        draw_set_color(c_yellow);
-                        draw_text(xx + 500, yy + 66, "++New Librarian Required++");
-                        draw_set_halign(fa_left);
-                        draw_set_color(c_gray);
-                        if (point_and_click([xx + 25, yy + 64, xx + 974, yy + 85])) {
-                            var search_params = {
-                                companies: managing
-                            };
-                            var candidates = collect_role_group("librarian_candidates");
-                            group_selection(candidates, {
-                                purpose: $"{scr_roman_numerals()[managing - 1]} Company Librarian Candidates",
-                                purpose_code: "librarian_promote",
-                                number: 1,
-                                system: managing,
-                                feature: "none",
-                                planet: 0,
-                                selections: []
-                            });
-                            exit;
-                        }
+                        special_role_slot_open(
+                            xx,
+                            yy,
+                            {
+                                companies: [managing,0];
+                            },
+                            {
+                                group:"librarian_candidates",
+                                location: "",
+                                opposite : false,
+                            },
+                            $"{scr_roman_numerals()[managing - 1]} Company Librarian Candidates",
+                            "librarian_promote",
+                            "New Company Librarian Required"
+                        );                        
                         yy += 20;
                         lib_slot = true;
                         continue;

--- a/scripts/scr_ui_manage/scr_ui_manage.gml
+++ b/scripts/scr_ui_manage/scr_ui_manage.gml
@@ -685,160 +685,117 @@ function scr_ui_manage() {
         		var lib_slot = company_data.lib != "none";
             }
             for (var i = 0; i < repetitions; i++) {
-                if (managing > 0 && managing <= 10 && (!cap_slot || !champ_slot || !ancient_slot || !chaplain_slot|| !tech_marine_slot || !apothecary_slot|| !lib_slot)) {
+                if (managing > 0 && managing <= 10 && (!cap_slot || !champ_slot || !ancient_slot || !chaplain_slot || !tech_marine_slot || !apothecary_slot || !lib_slot)) {
                     if (!cap_slot) {
-                        special_role_slot_open(
-                            xx,
-                            yy,
-                            {
-
-                            },
-                            {
-                                group:"captain_candidates",
-                                location: "",
-                                opposite : false,
-                            },
-                            $"{scr_roman_numerals()[managing - 1]} Company Captain Candidates",
-                            "captain_promote",
-                            "New Captain Required"
-                        );
+                        special_role_slot_open(xx, yy, {}, {
+                            group: "captain_candidates",
+                            location: "",
+                            opposite: false
+                        }, $"{scr_roman_numerals()[managing - 1]} Company Captain Candidates", "captain_promote", "New Captain Required");
                         yy += 20;
                         cap_slot = true;
-                        if (managing == -1) then exit;
+                        if (managing == -1) {
+                            exit;
+                        }
                         continue;
                     }
                     if (!champ_slot) {
-                        special_role_slot_open(
-                            xx,
-                            yy,
-                            {
-                                companies: managing,
-                                "stat": [
-                                    ["weapon_skill", 44, "more"]
-                                ]
-                            },
-                            {
-                                group:"standard",
-                                location: "",
-                                opposite : false,
-                            },
-                            $"{scr_roman_numerals()[managing - 1]} Champion Candidates",
-                            "champion_promote",
-                            "New Champion Required"
-                        );
-
+                        special_role_slot_open(xx, yy, {
+                            companies: managing,
+                            "stat": [
+                                ["weapon_skill", 44, "more"]
+                            ]
+                        }, {
+                            group: "standard",
+                            location: "",
+                            opposite: false
+                        }, $"{scr_roman_numerals()[managing - 1]} Champion Candidates", "champion_promote", "New Champion Required");
+                
                         yy += 20;
                         champ_slot = true;
-                        if (managing == -1) then exit;
+                        if (managing == -1) {
+                            exit;
+                        }
                         continue;
                     }
                     if (!ancient_slot) {
-                        special_role_slot_open(
-                            xx,
-                            yy,
-                            {
-                                companies: managing
-                            },
-                            {
-                                group:"standard",
-                                location: "",
-                                opposite : true,
-                            },
-                            $"{scr_roman_numerals()[managing - 1]} Company Ancient Candidates",
-                            "ancient_promote",
-                            "New Ancient Required"
-                        );                        
-
+                        special_role_slot_open(xx, yy, {
+                            companies: managing
+                        }, {
+                            group: "standard",
+                            location: "",
+                            opposite: true
+                        }, $"{scr_roman_numerals()[managing - 1]} Company Ancient Candidates", "ancient_promote", "New Ancient Required");
+                
                         yy += 20;
                         ancient_slot = true;
-                        if (managing == -1) then exit;
+                        if (managing == -1) {
+                            exit;
+                        }
                         continue;
                     }
-                     if (!chaplain_slot) {
-                        special_role_slot_open(
-                            xx,
-                            yy,
-                            {
-                                companies: [managing,0],
-                            },
-                            {
-                                group:["chap",false, false],
-                                location: "",
-                                opposite : false,
-                            },
-                            $"{scr_roman_numerals()[managing - 1]} Company Chaplain Candidates",
-                            "chaplain_promote",
-                            "New Company Chaplain Required"
-                        );                         
+                    if (!chaplain_slot) {
+                        special_role_slot_open(xx, yy, {
+                            companies: [managing, 0]
+                        }, {
+                            group: ["chap", false, false],
+                            location: "",
+                            opposite: false
+                        }, $"{scr_roman_numerals()[managing - 1]} Company Chaplain Candidates", "chaplain_promote", "New Company Chaplain Required");
                         yy += 20;
                         chaplain_slot = true;
-                        if (managing == -1) then exit;
+                        if (managing == -1) {
+                            exit;
+                        }
                         continue;
                     }
                     if (!apothecary_slot) {
-                        special_role_slot_open(
-                            xx,
-                            yy,
-                            {
-                                companies: [managing,0],
-                            },
-                            {
-                                group:["apoth",false, false],
-                                location: "",
-                                opposite : false,
-                            },
-                            $"{scr_roman_numerals()[managing - 1]} Company Apothecary Candidates",
-                            "apothecary_promote",
-                            "New Company Apothecary Required"
-                        );
+                        special_role_slot_open(xx, yy, {
+                            companies: [managing, 0]
+                        }, {
+                            group: ["apoth", false, false],
+                            location: "",
+                            opposite: false
+                        }, $"{scr_roman_numerals()[managing - 1]} Company Apothecary Candidates", "apothecary_promote", "New Company Apothecary Required");
                         yy += 20;
                         apothecary_slot = true;
-                        if (managing == -1) then exit;
+                        if (managing == -1) {
+                            exit;
+                        }
                         continue;
                     }
                     if (!tech_marine_slot) {
-                        special_role_slot_open(
-                            xx,
-                            yy,
-                            {
-                                companies: [managing,0],
-                            },
-                            {
-                                group:["forge",false, false],
-                                location: "",
-                                opposite : false,
-                            },
-                            $"{scr_roman_numerals()[managing - 1]} Company Tech Marine Candidates",
-                            "tech_marine_promote",
-                            "New Company Tech Marine Required"
-                        );                        
+                        special_role_slot_open(xx, yy, {
+                            companies: [managing, 0]
+                        }, {
+                            group: ["forge", false, false],
+                            location: "",
+                            opposite: false
+                        }, $"{scr_roman_numerals()[managing - 1]} Company Tech Marine Candidates", "tech_marine_promote", "New Company Tech Marine Required");
                         yy += 20;
                         tech_marine_slot = true;
-                        if (managing == -1) then exit;
+                        if (managing == -1) {
+                            exit;
+                        }
                         continue;
                     }
                     if (!lib_slot) {
-                        special_role_slot_open(
-                            xx,
-                            yy,
-                            {
-                                companies: [managing,0],
-                            },
-                            {
-                                group:["libs",false, false],
-                                location: "",
-                                opposite : false,
-                            },
-                            $"{scr_roman_numerals()[managing - 1]} Company Librarian Candidates",
-                            "librarian_promote",
-                            "New Company Librarian Required"
-                        );                        
+                        special_role_slot_open(xx, yy, {
+                            companies: [managing, 0]
+                        }, {
+                            group: ["libs", false, false],
+                            location: "",
+                            opposite: false
+                        }, $"{scr_roman_numerals()[managing - 1]} Company Librarian Candidates", "librarian_promote", "New Company Librarian Required");
                         yy += 20;
                         lib_slot = true;
-                        if (managing == -1) then exit;
+                        if (managing == -1) {
+                            exit;
+                        }
                         continue;
                     }
                 }
+                
                 if (sel >= array_length(display_unit)) {
                     break;
                 }
@@ -860,7 +817,6 @@ function scr_ui_manage() {
                         man_current++;
                     }
                 }
-
                 yy += 20;
                 sel += 1;
             }

--- a/scripts/scr_ui_manage/scr_ui_manage.gml
+++ b/scripts/scr_ui_manage/scr_ui_manage.gml
@@ -88,6 +88,14 @@ function load_marines_into_ship(system, ship, units, reload = false) {
     }
 }
 
+/// @desc Displays a selectable prompt for special roles to be assigned.
+/// @param {number} xx - X coordinate for the UI element
+/// @param {number} yy - Y coordinate for the UI element
+/// @param {struct} search_params - Criteria for the role search
+/// @param {struct} role_group_params - Parameters defining the role group
+/// @param {string} purpose - Display purpose for the selection
+/// @param {string} purpose_code - Code that identifies the selection’s purpose
+/// @param {string} tab_text - The prompt text displayed in the UI
 function special_role_slot_open(xx, yy, search_params, role_group_params, purpose, purpose_code, tab_text){
     draw_set_color(c_black);
     draw_rectangle(xx + 25, yy + 64, xx + 974, yy + 85, 0);


### PR DESCRIPTION
### Purpose of changes
<!-- With a few sentences, describe your reasons for making these changes. -->
- Removes the need to use transfer to assign support command.

### Describe the solution
<!-- How does the feature work, or how does this fix a bug? -->
- Specialists can now be selected with the same buttons as captains and other command squad marines.
- `special_role_slot_open` function.
- Refactor `role_groups` and `is_specialist` functions.

### Describe alternatives you've considered
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
None

### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
Loading executing marines then reassigning the roles.
Assigning on empty companies.
Reading on attack and raid tooltip/

### Related links
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
None

### Custom player notes entry
<!-- This will be added to the PR description in the release notes. List changes that players may be interested in, in simple words. -->
Use the PR title.

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->
<!--- "Inspired" by the CDDA PR template -->
