### PR TITLE
ci: Remove the specific runtime ver, it should parse it by itself now

### DIFF
--- a/.github/workflows/gamemaker_build.yml
+++ b/.github/workflows/gamemaker_build.yml
@@ -91,7 +91,6 @@ jobs:
         name: Setup Igor
         uses: bscotch/igor-setup@v1.1.0
         with:
-          runtime-version: 2024.1300.0.781
           target-yyp: ${{ steps.find_yyp.outputs.yyp-path }}
           access-key: ${{ secrets.GM_ACCESS_KEY }}
           


### PR DESCRIPTION
### Purpose of changes
<!-- With a few sentences, describe your reasons for making these changes. -->
- Not have to edit the runtime ver every time we update.

### Describe the solution
<!-- How does the feature work, or how does this fix a bug? -->
- Remove the related line from the workflow.
  - It should automatically parse it from the yyp file. Before it didn't work, because of the old yyp format, now it should.

### Describe alternatives you've considered
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
None

### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
None

### Related links
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
None

### Custom player notes entry
<!-- This will be added to the PR description in the release notes. List changes that players may be interested in, in simple words. -->
Use the PR title.

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->
<!--- "Inspired" by the CDDA PR template -->
