### PR TITLE
fix: Single enemy fight crash, due to column colour

### DIFF
--- a/objects/obj_enunit/Create_0.gml
+++ b/objects/obj_enunit/Create_0.gml
@@ -24,6 +24,12 @@ x1 = pos + (centerline_offset * 2);
 y1 = 450 - (draw_size / 2);
 x2 = pos + (centerline_offset * 2) + 10;
 y2 = 450 + (draw_size / 2);
+if (obj_ncombat.enemy < array_length(global.star_name_colors) && obj_ncombat.enemy >= 0) {
+    column_draw_colour = global.star_name_colors[obj_ncombat.enemy];
+} else {
+    column_draw_colour = c_dkgrey;
+}
+
 
 enemy=0;
 enemy2=0;

--- a/objects/obj_enunit/Draw_0.gml
+++ b/objects/obj_enunit/Draw_0.gml
@@ -2,7 +2,7 @@ draw_size = min(400, column_size);
 
 if (draw_size > 0){
     draw_set_alpha(1);
-    draw_set_color(global.star_name_colors[obj_ncombat.enemy]);
+    draw_set_color(column_draw_colour);
 
     if (instance_exists(obj_centerline)){
         centerline_offset=x-obj_centerline.x;


### PR DESCRIPTION
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
### Purpose
<!-- With a few sentences, describe why you decided to make these changes/additions. -->
- Fix a crash.

### Describe your changes/additions
<!-- What your changes do and how. No need to get too technical. Some stuff from this list will also be used for the player release notes. -->
- Move the color selection to create event.
- Keep the column color within the planet colors array size, and set it to gray if it goes beyond.

### What can/needs to be improved/changed
<!-- Is there anything that you think can/needs to be improved, or perhaps done using a different approach. -->
- Not sure if anything should be done about having single enemies as `enemy=30`.

### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- None and I understand the risks.

### Related things and/or additional context
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, screenshots etc. -->
- The bug: https://discord.com/channels/714022226810372107/1356776712410763584

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->

<!--- "Inspired" by the CDDA PR template -->
