### PR TITLE
feat: More squad marker colors

### DIFF
--- a/scripts/scr_draw_management_unit/scr_draw_management_unit.gml
+++ b/scripts/scr_draw_management_unit/scr_draw_management_unit.gml
@@ -200,9 +200,39 @@ function scr_draw_management_unit(selected, yy = 0, xx = 0, draw = true) {
         // Squads
         var sqi = "";
         draw_set_color(c_black);
-        var squad_colours = [c_teal, c_red, c_green, c_orange, c_aqua, c_fuchsia, c_green, c_blue, c_fuchsia, c_maroon];
+        var squad_colours = [
+        #ff0000,    // Red (HSL: 0, 100%, 50%)
+        #ff8000,    // Orange (HSL: 30, 100%, 50%)
+        #ffff00,    // Yellow (HSL: 60, 100%, 50%)
+        #00ff00,    // Green (HSL: 120, 100%, 50%)
+        #00ffff,    // Cyan (HSL: 180, 100%, 50%)
+        #0080ff,    // Light Blue (HSL: 210, 100%, 50%)
+        #0000ff,    // Blue (HSL: 240, 100%, 50%)
+        #8000ff,    // Purple (HSL: 270, 100%, 50%)
+        #ff00ff,    // Magenta (HSL: 300, 100%, 50%)
+
+        #b20000,    // Red (HSL: 0, 100%, 25%)
+        #b26e00,    // Orange (HSL: 30, 100%, 25%)
+        #b2b200,    // Yellow (HSL: 60, 100%, 25%)
+        #00b200,    // Green (HSL: 120, 100%, 25%)
+        #00b2b2,    // Cyan (HSL: 180, 100%, 25%)
+        #004db2,    // Light Blue (HSL: 210, 100%, 25%)
+        #0000b2,    // Blue (HSL: 240, 100%, 25%)
+        #4d00b2,    // Purple (HSL: 270, 100%, 25%)
+        #b200b2,    // Magenta (HSL: 300, 100%, 25%)
+
+        #ff4d4d,    // Red (HSL: 0, 50%, 50%)
+        #ffb84d,    // Orange (HSL: 30, 50%, 50%)
+        #ffff66,    // Yellow (HSL: 60, 50%, 50%)
+        #66ff66,    // Green (HSL: 120, 50%, 50%)
+        #66ffff,    // Cyan (HSL: 180, 50%, 50%)
+        #6680ff,    // Light Blue (HSL: 210, 50%, 50%)
+        #6666ff,    // Blue (HSL: 240, 50%, 50%)
+        #b366ff,    // Purple (HSL: 270, 50%, 50%)
+        #ff66ff,    // Magenta (HSL: 300, 50%, 50%)
+        ];
         if (squad[selected] != -1) {
-            var _squad_modulo = squad[selected] % 10;
+            var _squad_modulo = squad[selected] % array_length(squad_colours);
             draw_set_color(squad_colours[_squad_modulo]);
         }
 


### PR DESCRIPTION
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
### Purpose
<!-- With a few sentences, describe why you decided to make these changes/additions. -->
- Stop squad colors from repeating, at least a bit.

### Describe your changes/additions
<!-- What your changes do and how. No need to get too technical. Some stuff from this list will also be used for the player release notes. -->
- Squad colors array is now made of 27 colors, vs 10.
- First 9 colors are hue shifts, with some colors removed, due to very close similarity. Next 9 have the same hue, but lightness value reduced by half. Next 9 have their saturation reduced by half instead.

### What can/needs to be improved/changed
<!-- Is there anything that you think can/needs to be improved, or perhaps done using a different approach. -->
- More **distinct** colors.

### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- Checked how the squads look - it's okay, but can be better.

### Related things and/or additional context
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, screenshots etc. -->
- None.

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->

<!--- "Inspired" by the CDDA PR template -->
