### PR TITLE
fix: Proper tooltip offset from the cursor and flipping

### DIFF
--- a/objects/obj_tooltip/Draw_75.gml
+++ b/objects/obj_tooltip/Draw_75.gml
@@ -20,6 +20,7 @@ for (var i=0;i<array_length(queue);i++){
 	var _screen_hpadding = 60;
 	var _header_h=0;
 	var _header_w=0;
+	var _cursor_offset = 20;
 
 	// Remember global variables
 	var _curr_font = draw_get_font();
@@ -68,16 +69,16 @@ for (var i=0;i<array_length(queue);i++){
 
 	// Check if the tooltip goes over the right part of the screen and flip left if so
 	if (_rect_x + _rect_w > display_get_gui_width() - _screen_hpadding) {
-		_rect_x = _coords[0] - _rect_w - 20;
+		_rect_x = _coords[0] - _rect_w - _cursor_offset;
 	} else {
-		_rect_x += 20;
+		_rect_x += _cursor_offset;
 	}
 
 	// Check if the tooltip goes over the bottom part of the screen and flip up if so
 	if (_rect_y + _rect_h > display_get_gui_height() - _screen_vpadding) {
-		_rect_y = _coords[1] - _rect_h - 20;
+		_rect_y = _coords[1] - _rect_h - _cursor_offset;
 	} else {
-		_rect_y += 20;
+		_rect_y += _cursor_offset;
 	}
 
 	// Draw the tooltip background

--- a/objects/obj_tooltip/Draw_75.gml
+++ b/objects/obj_tooltip/Draw_75.gml
@@ -68,12 +68,16 @@ for (var i=0;i<array_length(queue);i++){
 
 	// Check if the tooltip goes over the right part of the screen and flip left if so
 	if (_rect_x + _rect_w > display_get_gui_width() - _screen_hpadding) {
-		_rect_x = _coords[0] - _rect_w - _screen_hpadding;
+		_rect_x = _coords[0] - _rect_w - 20;
+	} else {
+		_rect_x += 20;
 	}
 
 	// Check if the tooltip goes over the bottom part of the screen and flip up if so
 	if (_rect_y + _rect_h > display_get_gui_height() - _screen_vpadding) {
-		_rect_y = max(_screen_vpadding, _coords[1] - _rect_h - _screen_vpadding);
+		_rect_y = _coords[1] - _rect_h - 20;
+	} else {
+		_rect_y += 20;
 	}
 
 	// Draw the tooltip background

--- a/scripts/scr_hit/scr_hit.gml
+++ b/scripts/scr_hit/scr_hit.gml
@@ -91,5 +91,5 @@ function mouse_distance_less(xx, yy, distance){
 
 function return_mouse_consts_tooltip(){
 	var consts = return_mouse_consts();
-	return [consts[0]+20, consts[1]]
+	return [consts[0], consts[1]]
 }


### PR DESCRIPTION
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
### Purpose
<!-- With a few sentences, describe why you decided to make these changes/additions. -->
- The tooltip offset was not working as intended.
- Flip logic was also a bit broken.
- The tooltip was often covering text/buttons you're hovering over.

### Describe your changes/additions
<!-- What your changes do and how. No need to get too technical. Some stuff from this list will also be used for the player release notes. -->
- Screen padding var no longer affects the offset when flipping.
- The offset from the cursor is 20 pixels, getting properly mirrored when the tooltip is flipped.

### What can/needs to be improved/changed
<!-- Is there anything that you think can/needs to be improved, or perhaps done using a different approach. -->
- The offset and screen edge padding don't take scale and offset (if not in the UI layer) from `scr_tooltip_draw` into account.

### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- Checked that tooltips properly work in the shop and unit view.

### Related things and/or additional context
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, screenshots etc. -->
- None.

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->

<!--- "Inspired" by the CDDA PR template -->
