### PR TITLE
fix: Champion and Ancient broken company assignments

### DIFF
--- a/scripts/scr_company_view/scr_company_view.gml
+++ b/scripts/scr_company_view/scr_company_view.gml
@@ -306,6 +306,7 @@ function other_manage_data() {
                 }
             }
         }
+
         if (_squads == 0) {
             _squads += 1;
             _squad_members = 1;
@@ -313,7 +314,7 @@ function other_manage_data() {
             squad[v] = _squads;
             _squad_loc = _unit_loc;
         }
-        var _company_promotion_limits = [0, 100, 65, 65, 65, 65, 45, 45, 35, 25, 0];
+
         if ((ma_role[v] == obj_ini.role[100][3]) || (ma_role[v] == obj_ini.role[100][4])) {
             if ((_unit.company == 1) && (ma_exp[v] >= 140)) {
                 ma_promote[v] = 1;
@@ -328,8 +329,9 @@ function other_manage_data() {
         } else if (_unit.role() == obj_ini.role[100][16]) {
             ma_promote[v] = 1;
         }
-        var _target_company = 0;
-        if (_unit.IsSpecialist(SPECIALISTS_RANK_AND_FILE)) {
+
+        if (_unit.company > -1 && _unit.IsSpecialist(SPECIALISTS_RANK_AND_FILE)) {
+			var _target_company = 0;
             if (_unit.company >= 8) {
                 _target_company = _unit.company - 1;
             } else if (_unit.company >= 6) {
@@ -337,6 +339,8 @@ function other_manage_data() {
             } else if (_unit.company >= 2) {
                 _target_company = 1;
             }
+
+			var _company_promotion_limits = [0, 100, 65, 65, 65, 65, 45, 45, 35, 25, 0];
             var _promotion_limit = _company_promotion_limits[_target_company];
             if (_unit.experience >= _promotion_limit && _promotion_limit > 0) {
                 ma_promote[v] = 1;
@@ -345,6 +349,7 @@ function other_manage_data() {
                 ma_promote[v] = 10;
             }
         }
+
         if ((!obj_controller.command_set[2]) && (!ma_promote[v])) {
             ma_promote[v] = 1;
         }


### PR DESCRIPTION
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
### Purpose
<!-- With a few sentences, describe why you decided to make these changes/additions. -->
- Fix a bug where Champion and Ancient company assignment screens displayed no or wrong units.

### Describe your changes/additions
<!-- What your changes do and how. No need to get too technical. Some stuff from this list will also be used for the player release notes. -->
- Flip `opposite: false` to `true` for champions and ancients.
- Refactor some code, while I'm here. The proper refactor will come in the next PR.
- Also added a `company > -1` check into `other_manage_data()`, as I saw a crash related to it.

### What can/needs to be improved/changed
<!-- Is there anything that you think can/needs to be improved, or perhaps done using a different approach. -->
- This whole code chunk is not good.

### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- Confirmed that role assignments work correctly.

### Related things and/or additional context
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, screenshots etc. -->
- Bug report: https://discord.com/channels/714022226810372107/1356998884127277156

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->

<!--- "Inspired" by the CDDA PR template -->
