### PR TITLE
fix: non-crash error with tau fleets

### DIFF
--- a/scripts/scr_enemy_ai_b/scr_enemy_ai_b.gml
+++ b/scripts/scr_enemy_ai_b/scr_enemy_ai_b.gml
@@ -390,7 +390,11 @@ function scr_enemy_ai_b() {
 	        		 if (p_owner[s]=8) then tau_chance+=5;
 	        	}
 				
-	            if (flit.owner = eFACTION.Tau){tau_chance+=(flit.image_index*5)-5;}
+				if(flit != "none"){
+					if (flit.owner = eFACTION.Tau){
+						tau_chance+=(flit.image_index*5)-5;
+					}
+				}
             
             
 	            if (tau_chance>=95){/*obj_controller.x=self.x;obj_controller.y=self.y;show_message(string(tau_chance)+" |"+string(p_orks[i])+"|"+string(p_traitors[i]));*/}


### PR DESCRIPTION
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
### Purpose
<!-- With a few sentences, describe why you decided to make these changes/additions. -->
- non-crash error showed up while i was doing save/load testing. 

### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- reloaded save where error was occurring and now it doesnt
