### PR TITLE
fix: Ensure that specialist training only takes unemployed marines

### DIFF
--- a/scripts/scr_random_marine/scr_random_marine.gml
+++ b/scripts/scr_random_marine/scr_random_marine.gml
@@ -146,6 +146,20 @@ function scr_random_marine(role, exp_req, search_params="none"){
                             continue;
                         }
                     }
+
+					if (struct_exists(search_params, "job")) {
+                        match = false;
+						if (unit.job == search_params[$ "job"]){
+							match = true;
+						}
+                        
+
+                        if (!match) {
+                            array_delete(marine_list, list_place, 1);
+                            comp_size--;
+                            continue;
+                        }
+                    }
             	}
             	//if match made exit loop and return unit
 	            if (match){

--- a/scripts/scr_specialist_training/scr_specialist_training.gml
+++ b/scripts/scr_specialist_training/scr_specialist_training.gml
@@ -78,7 +78,10 @@ function specialistfunct (specialist, req_exp) {
 // Returns: Array containing company and position of selected marine, or "none" if no suitable marine found
 function spec_data_set(specialist) {
     var _data = spec_train_data[specialist];
-    var _search = { "stat": _data.req };
+    var _search = {
+		"stat": _data.req,
+		"job": "none"
+	};
 
     if (obj_controller.tagged_training == true) {
         _search.role_tag = _data.name;


### PR DESCRIPTION
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
### Purpose
<!-- With a few sentences, describe why you decided to make these changes/additions. -->
- Hopefully, fix an error.

### Describe your changes/additions
<!-- What your changes do and how. No need to get too technical. Some stuff from this list will also be used for the player release notes. -->
- Add a new possible random_marine requirement - job.
- Set the job requirement to "none" on all specialist training.

### What can/needs to be improved/changed
<!-- Is there anything that you think can/needs to be improved, or perhaps done using a different approach. -->
- Nothing?

### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- None, and I understand the risks.

### Related things and/or additional context
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, screenshots etc. -->
- Bug report: https://discord.com/channels/714022226810372107/1356913362616844349

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->

<!--- "Inspired" by the CDDA PR template -->
