### PR TITLE
fix: Dreadnought mass equip crash

### DIFF
--- a/objects/obj_mass_equip/Draw_0.gml
+++ b/objects/obj_mass_equip/Draw_0.gml
@@ -80,12 +80,10 @@ if (total_role_number > 0 && tab > 0) {
         eROLE.Librarian,
         eROLE.Sergeant,
         eROLE.VeteranSergeant,
+        eROLE.Dreadnought,
     ];
-    if (
-        // hand slots
-        (tab == 1 || tab ==2) &&
-        array_get_index(infanty_roles, obj_controller.settings) >= 0
-    ) {
+    // hand slots
+    if ((tab == 1 || tab ==2) && array_get_index(infanty_roles, obj_controller.settings) >= 0) {
         // Get all available hand weapons
         scr_get_item_names(
             item_name,


### PR DESCRIPTION
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
### Purpose
<!-- With a few sentences, describe why you decided to make these changes/additions. -->
- Fix a crash when trying to mass equip the dreadnought role.

### Describe your changes/additions
<!-- What your changes do and how. No need to get too technical. Some stuff from this list will also be used for the player release notes. -->
- Add the dreadnought to the infantry list, for the purposes of equipment gathering.

### What can/needs to be improved/changed
<!-- Is there anything that you think can/needs to be improved, or perhaps done using a different approach. -->
- Nothing.

### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- Successfully changed dreadnought equipment on the mass equip screen.

### Related things and/or additional context
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, screenshots etc. -->
- None.

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->

<!--- "Inspired" by the CDDA PR template -->
