### PR TITLE
feat: Defend formation will not move forward

### DIFF
--- a/objects/obj_pnunit/Alarm_0.gml
+++ b/objects/obj_pnunit/Alarm_0.gml
@@ -15,7 +15,7 @@ try {
     enemy=instance_nearest(0,y,obj_enunit);// Left most enemy
     enemy2=enemy;
 
-    if (obj_ncombat.defending=false) or (obj_ncombat.dropping=1){
+    if (obj_ncombat.dropping || (!obj_ncombat.defending && obj_ncombat.formation_set != 2)){
         move_unit_block("east");
     }
 


### PR DESCRIPTION
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
### Purpose
<!-- With a few sentences, describe why you decided to make these changes/additions. -->
- I think that's a cool feature?

### Describe your changes/additions
<!-- What your changes do and how. No need to get too technical. Some stuff from this list will also be used for the player release notes. -->
- Change the move check to move if: you're using raid OR (if you're not defending AND not using the second formation (defend)).

### What can/needs to be improved/changed
<!-- Is there anything that you think can/needs to be improved, or perhaps done using a different approach. -->
- A switch on all formations to select whenever to move or not.

### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- Tested in a battle. It seems to work.

### Related things and/or additional context
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, screenshots etc. -->
- None.

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->

<!--- "Inspired" by the CDDA PR template -->
