### PR TITLE
feat: Sternguard and Vanguard > Veteran; Loadout adjustments

### DIFF
--- a/objects/obj_popup/Mouse_50.gml
+++ b/objects/obj_popup/Mouse_50.gml
@@ -321,7 +321,7 @@ if (point_in_rectangle(mouse_x, mouse_y, xx+1465, yy+499,xx+1576,yy+518)){// Pro
         variable_struct_set(role_squad_equivilances,obj_ini.role[100][9],"devastator_squad");
         variable_struct_set(role_squad_equivilances,obj_ini.role[100][10],"assault_squad");
         variable_struct_set(role_squad_equivilances,obj_ini.role[100][12],"scout_squad");
-        variable_struct_set(role_squad_equivilances,obj_ini.role[100][3],"sternguard_veteran_squad");
+        variable_struct_set(role_squad_equivilances,obj_ini.role[100][3],"veteran_squad");
         variable_struct_set(role_squad_equivilances,obj_ini.role[100][4],"terminator_squad");
 
         for(i=0;i<array_length(obj_controller.display_unit) && mahreens<500;i++){

--- a/scripts/scr_company_order/scr_company_order.gml
+++ b/scripts/scr_company_order/scr_company_order.gml
@@ -245,8 +245,7 @@ function scr_company_order(company) {
 	var squad_builder = [
 		["tactical_squad",_roles[eROLE.Tactical],5],
 		["devastator_squad",_roles[eROLE.Devastator],5],
-		["sternguard_veteran_squad",_roles[eROLE.Veteran],5],
-		["vanguard_veteran_squad",_roles[eROLE.Veteran],5],
+		["veteran_squad",_roles[eROLE.Veteran],5],
 		["terminator_squad",_roles[eROLE.Terminator],4],
 		["terminator_assault_squad",_roles[eROLE.Terminator],4],
 		["assault_squad",_roles[eROLE.Assault],5],

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -39,22 +39,22 @@ enum ePROGENITOR {
     RANDOM,
 }
 
-#macro WEAPON_LIST_RANGED_HEAVY_TERMINATOR ["Heavy Flamer", "Heavy Flamer", "Assault Cannon", "Assault Cannon", "Multi-Melta", "Plasma Cannon", "Grav-Cannon"]
-#macro WEAPON_LIST_RANGED_HEAVY_LONG ["Heavy Bolter", "Heavy Bolter", "Heavy Bolter", "Missile Launcher", "Missile Launcher", "Lascannon", "Plasma Cannon", "Grav-Cannon"]
-#macro WEAPON_LIST_RANGED_HEAVY_ASSAULT ["Heavy Flamer", "Heavy Flamer", "Multi-Melta"]
+#macro WEAPON_LIST_RANGED_HEAVY_TERMINATOR ["Heavy Flamer", "Heavy Flamer", "Heavy Flamer", "Assault Cannon", "Assault Cannon", "Multi-Melta", "Plasma Cannon", "Grav-Cannon"]
+#macro WEAPON_LIST_RANGED_HEAVY_LONG ["Heavy Bolter", "Heavy Bolter", "Heavy Bolter", "Heavy Bolter", "Missile Launcher", "Missile Launcher", "Missile Launcher", "Lascannon", "Lascannon", "Plasma Cannon", "Grav-Cannon"]
+#macro WEAPON_LIST_RANGED_HEAVY_ASSAULT ["Heavy Flamer", "Heavy Flamer", "Heavy Flamer", "Multi-Melta"]
 #macro WEAPON_LIST_RANGED_HEAVY array_concat(WEAPON_LIST_RANGED_HEAVY_LONG, WEAPON_LIST_RANGED_HEAVY_ASSAULT)
 
 
-#macro WEAPON_LIST_RANGED_SPECIAL_LONG ["Plasma Gun", "Plasma Gun", "Grav-Gun"]
-#macro WEAPON_LIST_RANGED_SPECIAL_ASSAULT ["Flamer", "Flamer", "Meltagun"]
+#macro WEAPON_LIST_RANGED_SPECIAL_LONG ["Plasma Gun", "Plasma Gun", "Plasma Gun", "Grav-Gun"]
+#macro WEAPON_LIST_RANGED_SPECIAL_ASSAULT ["Flamer", "Flamer", "Flamer", "Meltagun"]
 #macro WEAPON_LIST_RANGED_SPECIAL array_concat(WEAPON_LIST_RANGED_SPECIAL_LONG, WEAPON_LIST_RANGED_SPECIAL_ASSAULT)
 
-#macro WEAPON_LIST_RANGED_COMBI_LONG ["Storm Bolter", "Storm Bolter", "Storm Bolter", "Combiplasma", "Combiplasma", "Combigrav"]
-#macro WEAPON_LIST_RANGED_COMBI_ASSAULT ["Combiflamer", "Combiflamer", "Combimelta"]
+#macro WEAPON_LIST_RANGED_COMBI_LONG ["Storm Bolter", "Storm Bolter", "Storm Bolter", "Storm Bolter", "Combiplasma", "Combiplasma", "Combigrav"]
+#macro WEAPON_LIST_RANGED_COMBI_ASSAULT ["Combiflamer", "Combiflamer", "Combiflamer", "Combimelta"]
 #macro WEAPON_LIST_RANGED_COMBI array_concat(WEAPON_LIST_RANGED_COMBI_LONG, WEAPON_LIST_RANGED_COMBI_ASSAULT)
 
 #macro WEAPON_LIST_RANGED_PISTOLS_LONG ["Bolt Pistol", "Bolt Pistol", "Bolt Pistol", "Plasma Pistol", "Plasma Pistol", "Grav-Pistol"]
-#macro WEAPON_LIST_RANGED_PISTOLS_ASSAULT ["Hand Flamer", "Hand Flamer", "Infernus Pistol"]
+#macro WEAPON_LIST_RANGED_PISTOLS_ASSAULT ["Hand Flamer", "Hand Flamer", "Hand Flamer", "Infernus Pistol"]
 #macro WEAPON_LIST_RANGED_PISTOLS array_concat(WEAPON_LIST_RANGED_PISTOLS_LONG, WEAPON_LIST_RANGED_PISTOLS_ASSAULT)
 
 #macro WEAPON_LIST_RANGED_STERNGUARD array_concat(["Bolter", "Bolter", "Bolter"], WEAPON_LIST_RANGED_COMBI)

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -39,12 +39,27 @@ enum ePROGENITOR {
     RANDOM,
 }
 
-#macro WEAPON_LIST_RANGED_HEAVY ["Heavy Bolter", "Heavy Bolter", "Missile Launcher", "Missile Launcher", "Lascannon", "Plasma Cannon", "Multi-Melta", "Grav-Cannon"]
-#macro WEAPON_LIST_RANGED_SPECIAL ["Flamer", "Flamer", "Plasma Gun", "Meltagun", "Grav-Gun"]
-#macro WEAPON_LIST_RANGED_COMBI ["Storm Bolter", "Storm Bolter", "Storm Bolter", "Combiflamer", "Combiflamer", "Combiplasma", "Combimelta", "Combigrav"]
-#macro WEAPON_LIST_RANGED_PISTOLS ["Bolt Pistol", "Bolt Pistol", "Bolt Pistol", "Plasma Pistol", "Plasma Pistol", "Grav-Pistol"]
+#macro WEAPON_LIST_RANGED_HEAVY_TERMINATOR ["Heavy Flamer", "Heavy Flamer", "Assault Cannon", "Assault Cannon", "Multi-Melta", "Plasma Cannon", "Grav-Cannon"]
+#macro WEAPON_LIST_RANGED_HEAVY_LONG ["Heavy Bolter", "Heavy Bolter", "Heavy Bolter", "Missile Launcher", "Missile Launcher", "Lascannon", "Plasma Cannon", "Grav-Cannon"]
+#macro WEAPON_LIST_RANGED_HEAVY_ASSAULT ["Heavy Flamer", "Heavy Flamer", "Multi-Melta"]
+#macro WEAPON_LIST_RANGED_HEAVY array_concat(WEAPON_LIST_RANGED_HEAVY_LONG, WEAPON_LIST_RANGED_HEAVY_ASSAULT)
+
+
+#macro WEAPON_LIST_RANGED_SPECIAL_LONG ["Plasma Gun", "Plasma Gun", "Grav-Gun"]
+#macro WEAPON_LIST_RANGED_SPECIAL_ASSAULT ["Flamer", "Flamer", "Meltagun"]
+#macro WEAPON_LIST_RANGED_SPECIAL array_concat(WEAPON_LIST_RANGED_SPECIAL_LONG, WEAPON_LIST_RANGED_SPECIAL_ASSAULT)
+
+#macro WEAPON_LIST_RANGED_COMBI_LONG ["Storm Bolter", "Storm Bolter", "Storm Bolter", "Combiplasma", "Combiplasma", "Combigrav"]
+#macro WEAPON_LIST_RANGED_COMBI_ASSAULT ["Combiflamer", "Combiflamer", "Combimelta"]
+#macro WEAPON_LIST_RANGED_COMBI array_concat(WEAPON_LIST_RANGED_COMBI_LONG, WEAPON_LIST_RANGED_COMBI_ASSAULT)
+
+#macro WEAPON_LIST_RANGED_PISTOLS_LONG ["Bolt Pistol", "Bolt Pistol", "Bolt Pistol", "Plasma Pistol", "Plasma Pistol", "Grav-Pistol"]
+#macro WEAPON_LIST_RANGED_PISTOLS_ASSAULT ["Hand Flamer", "Hand Flamer", "Infernus Pistol"]
+#macro WEAPON_LIST_RANGED_PISTOLS array_concat(WEAPON_LIST_RANGED_PISTOLS_LONG, WEAPON_LIST_RANGED_PISTOLS_ASSAULT)
+
 #macro WEAPON_LIST_RANGED_STERNGUARD array_concat(["Bolter", "Bolter", "Bolter"], WEAPON_LIST_RANGED_COMBI)
-#macro WEAPON_LIST_RANGED array_concat(WEAPON_LIST_RANGED_PISTOLS, WEAPON_LIST_RANGED_STERNGUARD, WEAPON_LIST_RANGED_COMBI)
+#macro WEAPON_LIST_RANGED array_concat(WEAPON_LIST_RANGED_PISTOLS_LONG, WEAPON_LIST_RANGED_STERNGUARD)
+
 
 #macro WEAPON_LIST_MELEE_BASIC ["Chainsword", "Chainsword", "Chainaxe"]
 #macro WEAPON_LIST_MELEE_1H ["Chainsword", "Chainsword", "Chainsword", "Chainsword", "Chainsword", "Chainsword", "Chainsword", "Chainsword", "Chainsword", "Power Sword", "Power Sword", "Power Sword", "Lightning Claw", "Lightning Claw", "Lightning Claw", "Power Fist", "Power Fist", "Thunder Hammer"]
@@ -1567,9 +1582,21 @@ function scr_initialize_custom() {
 				"role": $"{roles.terminator} {roles.sergeant}",
 				"loadout": {
 					"required": {
-						"wep1": [wep1[defaults_slot][eROLE.Terminator], 1],
-						"wep2": [wep2[defaults_slot][eROLE.Terminator], 1],
+						"wep1": ["", 0],
+						"wep2": ["", 0],
 					},
+					"option": {
+						"wep1": [
+							[
+								["Power Fist", "Chainfist"], 1
+							],
+						],
+						"wep2": [
+							[
+								WEAPON_LIST_RANGED_COMBI, 1
+							],
+						]
+					}
 				}
 			}],
 			// Terminator
@@ -1579,7 +1606,7 @@ function scr_initialize_custom() {
 				"loadout": {
 					"required": {
 						"wep1": ["", 0],
-						"wep2": [wep2[100, 4], 3],
+						"wep2": ["", 0],
 					},
 					"option": {
 						"wep1": [
@@ -1589,9 +1616,14 @@ function scr_initialize_custom() {
 						],
 						"wep2": [
 							[
-								["Assault Cannon", "Heavy Flamer"], 1
+								WEAPON_LIST_RANGED_COMBI, 3
 							],
 						],
+						"wep2": [
+							[
+								WEAPON_LIST_RANGED_HEAVY_TERMINATOR, 1
+							],
+						]
 					}
 				}
 			}],
@@ -1775,7 +1807,7 @@ function scr_initialize_custom() {
 					"option": {
 						"wep1": [
 							[
-								WEAPON_LIST_RANGED_PISTOLS, 1
+								WEAPON_LIST_RANGED_PISTOLS_LONG, 1
 							],
 						],
 						"wep2": [

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -39,20 +39,19 @@ enum ePROGENITOR {
     RANDOM,
 }
 
-#macro WEAPON_LIST_RANGED_HEAVY ["Heavy Bolter", "Heavy Bolter", "Missile Launcher", "Missile Launcher", "Multi-Melta", "Lascannon", "Plasma Cannon", "Grav-Cannon"]
-#macro WEAPON_LIST_RANGED_SPECIAL ["Flamer", "Flamer", "Meltagun", "Meltagun", "Plasma Gun", "Grav-Gun"]
-#macro WEAPON_LIST_RANGED_COMBI ["Storm Bolter", "Storm Bolter", "Storm Bolter", "Combiflamer", "Combiflamer", "Combiplasma", "Combigrav", "Combimelta"]
+#macro WEAPON_LIST_RANGED_HEAVY ["Heavy Bolter", "Heavy Bolter", "Missile Launcher", "Missile Launcher", "Lascannon", "Plasma Cannon", "Multi-Melta", "Grav-Cannon"]
+#macro WEAPON_LIST_RANGED_SPECIAL ["Flamer", "Flamer", "Plasma Gun", "Meltagun", "Grav-Gun"]
+#macro WEAPON_LIST_RANGED_COMBI ["Storm Bolter", "Storm Bolter", "Storm Bolter", "Combiflamer", "Combiflamer", "Combiplasma", "Combimelta", "Combigrav"]
 #macro WEAPON_LIST_RANGED_PISTOLS ["Bolt Pistol", "Bolt Pistol", "Bolt Pistol", "Plasma Pistol", "Plasma Pistol", "Grav-Pistol"]
-#macro WEAPON_LIST_RANGED_VANGUARD ["Bolt Pistol", "Bolt Pistol", "Bolt Pistol", "Bolt Pistol", "Plasma Pistol", "Plasma Pistol", "Grav-Pistol"]
 #macro WEAPON_LIST_RANGED_STERNGUARD array_concat(["Bolter", "Bolter", "Bolter"], WEAPON_LIST_RANGED_COMBI)
 #macro WEAPON_LIST_RANGED array_concat(WEAPON_LIST_RANGED_PISTOLS, WEAPON_LIST_RANGED_STERNGUARD, WEAPON_LIST_RANGED_COMBI)
 
-#macro WEAPON_LIST_MELEE_BASIC ["Chainsword", "Chainsword", "Chainsword", "Chainaxe", "Chainaxe"]
+#macro WEAPON_LIST_MELEE_BASIC ["Chainsword", "Chainsword", "Chainaxe"]
 #macro WEAPON_LIST_MELEE_1H ["Chainsword", "Chainsword", "Chainsword", "Chainsword", "Chainsword", "Chainsword", "Chainsword", "Chainsword", "Chainsword", "Power Sword", "Power Sword", "Power Sword", "Lightning Claw", "Lightning Claw", "Lightning Claw", "Power Fist", "Power Fist", "Thunder Hammer"]
-#macro WEAPON_LIST_MELEE_HEAVY ["Eviscerator"]
+#macro WEAPON_LIST_MELEE_HEAVY ["Eviscerator", "Eviscerator", "Eviscerator", "Eviscerator", "Eviscerator", "Heavy Thunder Hammer"]
 #macro WEAPON_LIST_MELEE_VANGUARD ["Chainsword", "Chainsword", "Chainsword", "Power Sword", "Power Axe", "Lightning Claw", "Lightning Claw", "Power Fist", "Power Fist", "Thunder Hammer"]
 
-#macro WEAPON_LIST_WEIGHTED_RANGED_PISTOLS [["Bolt Pistol", 4], ["Hand Flamer", 2], ["Plasma Pistol", 2], ["Grav-Pistol", 1]]
+#macro WEAPON_LIST_WEIGHTED_RANGED_PISTOLS [["Bolt Pistol", 4], ["Plasma Pistol", 2], ["Grav-Pistol", 1]]
 
 function progenitor_map(){
     var founding_chapters = [

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -57,14 +57,13 @@ enum ePROGENITOR {
 #macro WEAPON_LIST_RANGED_PISTOLS_ASSAULT ["Hand Flamer", "Hand Flamer", "Hand Flamer", "Infernus Pistol"]
 #macro WEAPON_LIST_RANGED_PISTOLS array_concat(WEAPON_LIST_RANGED_PISTOLS_LONG, WEAPON_LIST_RANGED_PISTOLS_ASSAULT)
 
-#macro WEAPON_LIST_RANGED_STERNGUARD array_concat(["Bolter", "Bolter", "Bolter"], WEAPON_LIST_RANGED_COMBI)
-#macro WEAPON_LIST_RANGED array_concat(WEAPON_LIST_RANGED_PISTOLS_LONG, WEAPON_LIST_RANGED_STERNGUARD)
+#macro WEAPON_LIST_RANGED_VETERAN array_concat(["Bolter", "Bolter", "Bolter"], WEAPON_LIST_RANGED_COMBI)
+#macro WEAPON_LIST_RANGED array_concat(WEAPON_LIST_RANGED_PISTOLS_LONG, WEAPON_LIST_RANGED_VETERAN)
 
 
 #macro WEAPON_LIST_MELEE_BASIC ["Chainsword", "Chainsword", "Chainaxe"]
 #macro WEAPON_LIST_MELEE_1H ["Chainsword", "Chainsword", "Chainsword", "Chainsword", "Chainsword", "Chainsword", "Chainsword", "Chainsword", "Chainsword", "Power Sword", "Power Sword", "Power Sword", "Lightning Claw", "Lightning Claw", "Lightning Claw", "Power Fist", "Power Fist", "Thunder Hammer"]
 #macro WEAPON_LIST_MELEE_HEAVY ["Eviscerator", "Eviscerator", "Eviscerator", "Eviscerator", "Eviscerator", "Heavy Thunder Hammer"]
-#macro WEAPON_LIST_MELEE_VANGUARD ["Chainsword", "Chainsword", "Chainsword", "Power Sword", "Power Axe", "Lightning Claw", "Lightning Claw", "Power Fist", "Power Fist", "Thunder Hammer"]
 
 #macro WEAPON_LIST_WEIGHTED_RANGED_PISTOLS [["Bolt Pistol", 4], ["Plasma Pistol", 2], ["Grav-Pistol", 1]]
 
@@ -1551,7 +1550,7 @@ function scr_initialize_custom() {
 					"option": {
 						"wep1": [
 							[
-								WEAPON_LIST_RANGED_STERNGUARD, 5
+								WEAPON_LIST_RANGED_VETERAN, 5
 							],
 						],
 					}
@@ -1686,7 +1685,7 @@ function scr_initialize_custom() {
 					"option": {
 						"wep1": [
 							[
-								WEAPON_LIST_RANGED_STERNGUARD, 1
+								WEAPON_LIST_RANGED_VETERAN, 1
 							],
 						],
 					}
@@ -1704,7 +1703,7 @@ function scr_initialize_custom() {
 					"option": {
 						"wep1": [
 							[
-								WEAPON_LIST_RANGED_STERNGUARD, 7
+								WEAPON_LIST_RANGED_VETERAN, 7
 							],
 							[
 								WEAPON_LIST_RANGED_SPECIAL, 1

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -1944,9 +1944,7 @@ function scr_initialize_custom() {
 						],
 						"wep2": [
 							[
-								["Flamer"], 2, {
-									"wep1":"",
-								}
+								["Flamer"], 2
 							]
 						]
 					}

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -39,13 +39,12 @@ enum ePROGENITOR {
     RANDOM,
 }
 
-#macro WEAPON_LIST_RANGED_BASIC ["Bolter", "Bolter", "Bolter", "Storm Bolter", "Storm Bolter"]
 #macro WEAPON_LIST_RANGED_HEAVY ["Heavy Bolter", "Heavy Bolter", "Missile Launcher", "Missile Launcher", "Multi-Melta", "Lascannon", "Plasma Cannon", "Grav-Cannon"]
 #macro WEAPON_LIST_RANGED_SPECIAL ["Flamer", "Flamer", "Meltagun", "Meltagun", "Plasma Gun", "Grav-Gun"]
-#macro WEAPON_LIST_RANGED_COMBI ["Combiflamer", "Combiplasma", "Combigrav", "Combimelta"]
+#macro WEAPON_LIST_RANGED_COMBI ["Storm Bolter", "Storm Bolter", "Storm Bolter", "Combiflamer", "Combiflamer", "Combiplasma", "Combigrav", "Combimelta"]
 #macro WEAPON_LIST_RANGED_PISTOLS ["Bolt Pistol", "Bolt Pistol", "Bolt Pistol", "Plasma Pistol", "Plasma Pistol", "Grav-Pistol"]
 #macro WEAPON_LIST_RANGED_VANGUARD ["Bolt Pistol", "Bolt Pistol", "Bolt Pistol", "Bolt Pistol", "Plasma Pistol", "Plasma Pistol", "Grav-Pistol"]
-#macro WEAPON_LIST_RANGED_STERNGUARD array_concat(WEAPON_LIST_RANGED_BASIC, WEAPON_LIST_RANGED_COMBI)
+#macro WEAPON_LIST_RANGED_STERNGUARD array_concat(["Bolter", "Bolter", "Bolter"], WEAPON_LIST_RANGED_COMBI)
 #macro WEAPON_LIST_RANGED array_concat(WEAPON_LIST_RANGED_PISTOLS, WEAPON_LIST_RANGED_STERNGUARD, WEAPON_LIST_RANGED_COMBI)
 
 #macro WEAPON_LIST_MELEE_BASIC ["Chainsword", "Chainsword", "Chainsword", "Chainaxe", "Chainaxe"]
@@ -1532,8 +1531,15 @@ function scr_initialize_custom() {
 				"min": 0,
 				"loadout": {
 					"required": {
-						"wep1": [wep1[defaults_slot][eROLE.Veteran], 5],
-						"wep2": [wep2[defaults_slot][eROLE.Veteran], 5],
+						"wep1": ["", 0],
+						"wep2": ["Combat Knife", "max"],
+					},
+					"option": {
+						"wep1": [
+							[
+								WEAPON_LIST_RANGED_STERNGUARD, 5
+							],
+						],
 					}
 				},
 				"role": $"Company {roles.veteran}"
@@ -1636,16 +1642,33 @@ function scr_initialize_custom() {
 			}]
 		],
 
-		"sternguard_veteran_squad": [
-			// Sternguard Veteran
-			[roles.veteran, {
-				"max": 9,
-				"min": 4,
-				"role": $"Sternguard {roles.veteran}",
+		"veteran_squad": [
+			[roles.veteran_sergeant, {
+				"max": 1,
+				"min": 1,
+				"role": $"{roles.veteran_sergeant}",
 				"loadout": {
 					"required": {
 						"wep1": ["", 0],
-						"wep2": ["Combat Knife", max],
+						"wep2": ["Combat Knife", "max"],
+					},
+					"option": {
+						"wep1": [
+							[
+								WEAPON_LIST_RANGED_STERNGUARD, 1
+							],
+						],
+					}
+				},
+			}],
+			[roles.veteran, {
+				"max": 9,
+				"min": 4,
+				"role": $"{roles.veteran}",
+				"loadout": {
+					"required": {
+						"wep1": ["", 0],
+						"wep2": ["Combat Knife", "max"],
 					},
 					"option": {
 						"wep1": [
@@ -1657,80 +1680,15 @@ function scr_initialize_custom() {
 							],
 							[
 								WEAPON_LIST_RANGED_HEAVY, 1, {
-									"wep2":"Combat Knife",
-									"mobi":"Heavy Weapons Pack",
+									"mobi": "Heavy Weapons Pack",
 								}
-							],
-						]
-					}
-				}
-			}],
-			// Sternguard Veteran Sergeant
-			[roles.veteran_sergeant, {
-				"max": 1,
-				"min": 1,
-				"role": $"Sternguard {roles.veteran_sergeant}",
-				"loadout": {
-					"required": {
-						"wep1": ["", 0],
-						"wep2": ["Combat Knife", max],
-					},
-					"option": {
-						"wep1": [
-							[
-								WEAPON_LIST_RANGED_STERNGUARD, 1
 							]
-						]
-					}
-				}
-			}],
-			["type_data", {
-				"display_data": $"Sternguard {roles.veteran} {squad_name}",
-				"formation_options": ["veteran", "assault", "devastator", "scout", "tactical"],
-			}]
-		],
-
-		"vanguard_veteran_squad": [
-			// Vanguard Veterans
-			[roles.veteran, {
-				"max": 9,
-				"min": 4,
-				"role": $"Vanguard {roles.veteran}",
-				"loadout": {
-					"required": {
-						"wep1": ["", 0],
-						"wep2": ["", 0],
-						"mobi": ["Jump Pack", 9]
-					},
-					"option": {
-						"wep1": [
-							[
-								WEAPON_LIST_MELEE_VANGUARD, 9
-							],
 						],
-						"wep2": [
-							[
-								WEAPON_LIST_RANGED_VANGUARD, 9
-							],
-						]
 					}
-				}
-			}],
-			// Vanguard Veteran Sergeant
-			[roles.veteran_sergeant, {
-				"max": 1,
-				"min": 1,
-				"role": $"Vanguard {roles.veteran_sergeant}",
-				"loadout": {
-					"required": {
-						"wep1": ["Thunder Hammer", 1],
-						"wep2": ["Storm Shield", 1],
-						"mobi": ["Jump Pack", 1]
-					},
-				}
-			}],
+				},
+			}, ],
 			["type_data", {
-				"display_data": $"Vanguard {roles.veteran} {squad_name}",
+				"display_data": $"{roles.veteran} {squad_name}",
 				"formation_options": ["veteran", "assault", "devastator", "scout", "tactical"],
 			}]
 		],
@@ -1857,7 +1815,7 @@ function scr_initialize_custom() {
 						],
 						"wep2": [
 							[
-								["Plasma Pistol", "Flamer"], 2
+								["Flamer", "Flamer", "Flamer", "Plasma Pistol"], 2
 							]
 						]
 					}
@@ -1968,59 +1926,36 @@ function scr_initialize_custom() {
 	// show_debug_message($"{st}");
 
 	if (global.chapter_name == "Salamanders") {
-		variable_struct_set(st, "assault_squad", [
+		st[$ "assault_squad"][0] = 
 			[roles.assault, {
 				"max": 9,
 				"min": 4,
-				"loadout": { //assault_marine
-					"required": {
-						"wep1": [wep1[100, 10], 4],
-						"wep2": [wep2[100, 10], 4],
-						"gear": ["Combat Shield", 4]
-					},
-					"option": {
-						"wep1": [
-							[
-								["Power Sword", "Power Axe", "Eviscerator"], 2
-							],
-						],
-						"wep2": [
-							[
-								["Flamer", "Meltagun", "Plasma Pistol", "Bolt Pistol"], 2
-							],
-
-						],
-					}
-				}
-			}],
-			[roles.sergeant, {
-				"max": 1,
-				"min": 1, //sergeant
 				"loadout": {
 					"required": {
-						"wep1": ["Bolt Pistol", 0],
-						"wep2": ["Chainsword", 0],
+						"wep1": [wep1[100, 10], 5],
+						"wep2": [wep2[100, 10], 5],
 					},
 					"option": {
 						"wep1": [
 							[
-								["Power Sword", "Thunder Hammer", "Power Fist", "Chainsword"], 1
-							]
+								["Eviscerator"], 2, {
+									"wep2":"",
+								}
+							],
 						],
 						"wep2": [
 							[
-								["Plasma Pistol", "Combiflamer", "Meltagun"], 1
+								["Flamer"], 2, {
+									"wep1":"",
+								}
 							]
 						]
 					}
-				},
-				"role": $"{roles.sergeant} {roles.assault}"
-			}],
-			["type_data", {
-				"display_data": $"{roles.assault} {squad_name}"
-			}]
-		])
+				}
+			}
+		]
 	}
+
 	if (scr_has_adv("Lightning Warriors")) {
 		variable_struct_set(st, "bikers", [
 			[roles.assault, {
@@ -2028,9 +1963,9 @@ function scr_initialize_custom() {
 				"min": 4,
 				"loadout": { //tactical marine
 						"required": {
-						"wep1": ["", max],
-						"wep2": ["Chainsword", max],
-						"mobi": ["Bike", max]
+						"wep1": ["", "max"],
+						"wep2": ["Chainsword", "max"],
+						"mobi": ["Bike", "max"]
 					}
 				},
 				"role": $"Biker"
@@ -2040,8 +1975,8 @@ function scr_initialize_custom() {
 				"min": 1,
 				"loadout": { //sergeant
 					"required": {
-						"wep1": ["", max],
-						"wep2": ["Chainsword", max],
+						"wep1": ["", "max"],
+						"wep2": ["Chainsword", "max"],
 						"mobi": ["Bike", 1]
 					}
 				},
@@ -2054,6 +1989,7 @@ function scr_initialize_custom() {
 			}]
 		])
 	}
+
 	if (scr_has_adv("Boarders")) {
 		variable_struct_set(st, "breachers", [
 			[roles.tactical, {
@@ -2062,10 +1998,10 @@ function scr_initialize_custom() {
 				"loadout": { //tactical breacher marine
 					"required": {
 						"wep1":[wep1[100, 8], 7],
-						"wep2":["Boarding Shield", max],
-						"armour":["MK3 Iron Armour", max],
-						"gear":["Plasma Bomb", max],
-						"mobi":["", max]
+						"wep2":["Boarding Shield", "max"],
+						"armour":["MK3 Iron Armour", "max"],
+						"gear":["Plasma Bomb", "max"],
+						"mobi":["", "max"]
 					},
 					"option": {
 						"wep1": [
@@ -2082,10 +2018,10 @@ function scr_initialize_custom() {
 				"min": 1,
 				"loadout": { //sergeant 
 					"required": {
-						"wep2":["Boarding Shield", max],
-						"armour":["MK3 Iron Armour", max],
-						"mobi": ["", max],
-						"gear": ["Plasma Bomb", max]
+						"wep2":["Boarding Shield", "max"],
+						"armour":["MK3 Iron Armour", "max"],
+						"mobi": ["", "max"],
+						"gear": ["Plasma Bomb", "max"]
 					},
 					"option": {
 						"wep1": [

--- a/scripts/scr_squads/scr_squads.gml
+++ b/scripts/scr_squads/scr_squads.gml
@@ -697,11 +697,7 @@ function game_start_squads(){
 	last_squad_count = array_length(obj_ini.squads);	
 	while (last_squad_count == array_length(obj_ini.squads)){
 		last_squad_count = (array_length(obj_ini.squads) + 1);
-		if(last_squad_count%2 == 0){
-		create_squad("sternguard_veteran_squad", company);
-	}else{
-		create_squad("vanguard_veteran_squad", company);
-		}
+		create_squad("veteran_squad", company);
 	}
 	company = 10;
 	create_squad("command_squad", company);


### PR DESCRIPTION
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
### Purpose
<!-- With a few sentences, describe why you decided to make these changes/additions. -->
- The idea behind Sternguard and Vanguard is cool and lore friendly, but in my opinion just doesn't work properly atm. 
- What you get, are weird, self assigning units, with no logic behind the assignment.
- I don't think that having them right now, in their current state, outweighs their clunkiness, and I can't bother with properly solving that, as I personally don't need it that much.
- I do think that having them merged, **for now**, is better than maintaining the status quo, and hoping that one day someone will repair them.
- The removal/addition is a couple lines of code, so nothing is really lost.

### Describe your changes/additions
#### Vanguard and Sternguard
<!-- What your changes do and how. No need to get too technical. Some stuff from this list will also be used for the player release notes. -->
- Vanguard and Sternguard squads are converted into normal Veteran squads.
  - The loadout of these new squads is very similar to Sternguard loadout, consider these to be "Tacticals+".
  - If the player wants, they are free to change loadouts of their veteran squads and assign them to different columns.
- What the player loses factually:
  - A bunch of melee starting equipment that Vanguard spawned with.
  - Vanguard and Sternguard role names.
  - Nothing else I can think of.
- What the player gets:
  - No more headache with units jumping into random squads.
  - Ability to manually make their veterans into devastator like squads or assault like squads, or leave the base "tactical" like loadout.
#### Loadout changes
- Adjusted Salamander specific assault loadout to only replace the assault marine equipment. The whole thing is silly, and I see no reason to have it in its current state tbh.
- All other changes to weapon lists can be seen in the diff, I can't list them. Generally, I just tried to stop 1:1 adhering to the TT rules, as they are borderline retarded in some loadout choices.

### What can/needs to be improved/changed
<!-- Is there anything that you think can/needs to be improved, or perhaps done using a different approach. -->
#### If someone will want to properly repair Vanguards and Sternguards
- They are free to do so after these are disabled.
- First, columns of these two should be separate, to allow proper distinguish between the melee and ranged units.
- Second, there should be proper logic as to who gets attached to what squad. Not sure if separate roles are needed or not.
- Third, the player should have full control over the above logic.
- Otherwise, it will still be a good riddance.

### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- Launched the game as UM multiple times while testing and before creating the PR.

### Related things and/or additional context
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, screenshots etc. -->
- None.

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->

<!--- "Inspired" by the CDDA PR template -->
