### PR TITLE
feat: Allow more column options for battleline squads

### DIFF
--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -1787,7 +1787,7 @@ function scr_initialize_custom() {
 			}],
 			["type_data", {
 				"display_data": $"{roles.devastator} {squad_name}",
-				"formation_options": ["devastator"],
+				"formation_options": ["devastator", "tactical", "assault", "scout"],
 			}]
 		],
 
@@ -1945,7 +1945,7 @@ function scr_initialize_custom() {
 			["type_data", {
 				"display_data": $"{roles.scout} {squad_name}",
 				"class": ["scout"],
-				"formation_options": ["scout"],
+				"formation_options": ["scout", "tactical", "assault", "devastator"],
 			}],
 		],
 
@@ -2148,7 +2148,7 @@ function scr_initialize_custom() {
 			}, ],
 			["type_data", {
 				"display_data": $"Breacher {squad_name}",
-				"formation_options": ["tactical"],
+				"formation_options": ["tactical", "assault", "devastator", "scout" ],
 			}]
 		])
 		variable_struct_set(st,"assault_squad", [

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -1898,7 +1898,7 @@ function scr_initialize_custom() {
 			}],
 			["type_data", {
 				"display_data": $"{roles.assault} {squad_name}",
-				"formation_options": ["assault"],
+				"formation_options": ["assault", "tactical", "devastator", "scout"],
 			}]
 		],
 


### PR DESCRIPTION
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
Allow squads widely variable loadouts to be put in different formations. 
<!-- With a few sentences, describe why you decided to make these changes/additions. -->
- Self-descriptive.

### Describe your changes/additions
- Self-descriptive.

### What can/needs to be improved/changed
<!-- Is there anything that you think can/needs to be improved, or perhaps done using a different approach. -->
- Possibly making formation options a general location vs role specific eg (Row 1, 2, 3, & 4) vs (Assault, Tactical, Devastators, Scouts)

### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- None and I understand the risks. This is a very minor change that wont break anything

### Related things and/or additional context
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, screenshots etc. -->
- None.
