### PR TITLE
fix: Daemon artifact ship battle crash and a tip about destroying

### DIFF
--- a/scripts/scr_arti_descr/scr_arti_descr.gml
+++ b/scripts/scr_arti_descr/scr_arti_descr.gml
@@ -146,7 +146,7 @@ function scr_arti_descr() {
 
 	if (has_tag("MINOR")){other_data+="It is more crude and utilitarian than one might expect from an artifact.";}
 	if (has_tag("chaos")){p4="It bears the taint of Chaos.";}
-	if (has_tag("daemonic")){p4="It is infested with a Daemonic entity.";}
+	if (has_tag("daemonic")){p4="It is infested with a Daemonic entity. Destroying it, may cause the entity materialize.";}
 
 	final_description+=mission_data;
 	if (basic_asthetic!="") then final_description+=$"  {basic_asthetic}";

--- a/scripts/scr_arti_descr/scr_arti_descr.gml
+++ b/scripts/scr_arti_descr/scr_arti_descr.gml
@@ -146,7 +146,7 @@ function scr_arti_descr() {
 
 	if (has_tag("MINOR")){other_data+="It is more crude and utilitarian than one might expect from an artifact.";}
 	if (has_tag("chaos")){p4="It bears the taint of Chaos.";}
-	if (has_tag("daemonic")){p4="It is infested with a Daemonic entity. Destroying it, may cause the entity materialize.";}
+	if (has_tag("daemonic")){p4="It is infested with a Daemonic entity. Destroying it, may cause the entity to materialize.";}
 
 	final_description+=mission_data;
 	if (basic_asthetic!="") then final_description+=$"  {basic_asthetic}";

--- a/scripts/scr_ship_battle/scr_ship_battle.gml
+++ b/scripts/scr_ship_battle/scr_ship_battle.gml
@@ -139,7 +139,7 @@ function scr_ship_battle(target_ship_id, cooridor_width) {
                         }
                     }
 
-                    if ((unit.role() == obj_ini.role[100][5]) || (unit.role() == obj_ini.role[100][11]) || (obj_ncombat.role[cooh, va] == obj_ini.role[100][7])) {
+                    if ((unit.role() == obj_ini.role[100][5]) || (unit.role() == obj_ini.role[100][11]) || (unit.role() == obj_ini.role[100][7])) {
                         if (unit.role() == obj_ini.role[100][5]) {
                             obj_ncombat.captains += 1;
                             if (obj_ncombat.big_mofo > 5) {


### PR DESCRIPTION
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
### Purpose
<!-- With a few sentences, describe why you decided to make these changes/additions. -->
- Fix a crash happening at ship battle initialization, following the daemonic artifact destruction.

### Describe your changes/additions
<!-- What your changes do and how. No need to get too technical. Some stuff from this list will also be used for the player release notes. -->
- Role check fix.
- Add a tip into the daemonic artifact description, about what can happen.

### What can/needs to be improved/changed
<!-- Is there anything that you think can/needs to be improved, or perhaps done using a different approach. -->
- The following battle is funny. I think there is only one greater daemon that gets EXPLODED in 1 turn.

### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- Spawned daemonic artifacts and forced the battle - no crash, but the battle is weird, almost broken.

### Related things and/or additional context
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, screenshots etc. -->
- None.

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->

<!--- "Inspired" by the CDDA PR template -->
