### PR TITLE
fix: Mass equip invalid armor failsafe

### DIFF
--- a/objects/obj_mass_equip/Step_0.gml
+++ b/objects/obj_mass_equip/Step_0.gml
@@ -20,30 +20,38 @@ try {
                                 continue;
                             }
                         }
+
                         // ** Start Armour **
-                        var yes = false,
-                            done = "";
                         var unit_armour = unit.get_armour_data();
-                        if (is_struct(unit_armour)) {
-                            if (req_armour == "Power Armour") {
-                                yes = unit_armour.has_tags(["power_armour", "terminator"]);
-                            } else if (req_armour == "Terminator Armour") {
-                                yes = unit_armour.has_tag("terminator");
-                            } else if (req_armour == unit_armour.name) {
-                                yes = true;
+                        var has_valid_armour = is_struct(unit_armour);
+
+                        // Check if unit_armour is a struct and evaluate tag-based or name-based compatibility
+                        if (has_valid_armour) {
+                            switch (req_armour) {
+                                case "Power Armour":
+                                    has_valid_armour = unit_armour.has_tags(["power_armour", "terminator"]);
+                                    break;
+                                case "Terminator Armour":
+                                    has_valid_armour = unit_armour.has_tag("terminator");
+                                    break;
+                                default:
+                                    has_valid_armour = (req_armour == unit_armour.name);
                             }
                         }
-                        if (!is_string(unit.armour(true))) {
-                            yes = true;
-                        }
-                        if (yes == false) {
-                            complete = unit.update_armour(req_armour);
-                            if (complete != "complete" && req_armour == "Power Armour") {
+
+                        // Attempt to equip if not valid
+                        if (!has_valid_armour) {
+                            var result = unit.update_armour(req_armour);
+
+                            // Fallback: If request was for Power Armour but update failed, try Terminator
+                            if (result != "complete" && req_armour == "Power Armour") {
                                 unit.update_armour("Terminator Armour");
                             }
+
+                            // Refresh unit_armour after update
                             unit_armour = unit.get_armour_data();
                         }
-                        // ** End armour **
+                        // ** End Armour **
 
                         // ** Start Weapons **
                         if (unit.weapon_one() != req_wep1) {


### PR DESCRIPTION
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
### Purpose
<!-- With a few sentences, describe why you decided to make these changes/additions. -->
- Fix a weird `Unable to find any instance for object index '0' name 'obj_al_capital'` crash, that I assume is caused by armor not being a struct, but a ship instead? No idea.

### Describe your changes/additions
<!-- What your changes do and how. No need to get too technical. Some stuff from this list will also be used for the player release notes. -->
- Some failsafes to ensure that armor is properly assigned before trying to use methods.

### What can/needs to be improved/changed
<!-- Is there anything that you think can/needs to be improved, or perhaps done using a different approach. -->
- Perhaps having an early return, if it still remains not a struct, may be good, but I rather it fail and shot that something went very wrong.

### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- Mass equipped devastator slots a couple of times.

### Related things and/or additional context
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, screenshots etc. -->
- Bug report: https://discord.com/channels/714022226810372107/1358478404734681259

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->

<!--- "Inspired" by the CDDA PR template -->
