### PR TITLE
fix: ai_b tau fleet scope

### DIFF
--- a/scripts/scr_enemy_ai_b/scr_enemy_ai_b.gml
+++ b/scripts/scr_enemy_ai_b/scr_enemy_ai_b.gml
@@ -432,9 +432,10 @@ function scr_enemy_ai_b() {
                         tau_chance += 5;
                     }
                 }
-
-                if (flit != "none" && flit.owner == eFACTION.Tau) {
-                    tau_chance += (flit.image_index * 5) - 5;
+                if (it != "none"){
+                    if (flit.owner == eFACTION.Tau) {
+                        tau_chance += (flit.image_index * 5) - 5;
+                    }
                 }
 
                 if (tau_chance >= 95) {


### PR DESCRIPTION
fix of a fix whereby the game tried to access the characteristics of a tau fleet before ensuring the tau fleet existed
