### PR TITLE
revert: "fix: Safety tweaks to unit draw surfaces (#715)"

### DIFF
--- a/scripts/scr_complex_colour_kit/scr_complex_colour_kit.gml
+++ b/scripts/scr_complex_colour_kit/scr_complex_colour_kit.gml
@@ -489,7 +489,7 @@ function setup_complex_livery_shader(setup_role, unit = "none"){
                 }
             }
             var _choice = cloth_variation%array_length(_distinct_colours);
-            show_debug_message($"{_choice}")
+            // show_debug_message($"{_choice}")
             set_complex_shader_area(["robes_colour_replace"], _distinct_colours[_choice]);   
         }else {
             shader_set_uniform_f_array(shader_get_uniform(full_livery_shader, "robes_colour_replace"), cloth_col);
@@ -497,7 +497,7 @@ function setup_complex_livery_shader(setup_role, unit = "none"){
     } else {
         shader_set_uniform_f_array(shader_get_uniform(full_livery_shader, "robes_colour_replace"), cloth_col);
     }
-    show_debug_message(data_set);
+    // show_debug_message(data_set);
     var _textures = {
 
     }

--- a/scripts/scr_culture_visuals/scr_culture_visuals.gml
+++ b/scripts/scr_culture_visuals/scr_culture_visuals.gml
@@ -802,11 +802,6 @@ function DummyMarine()constructor{
             } else {
                 _armour = _last_armour;
             }
-            if (!buttons.company_options_toggle.company_view){
-                if (!array_contains(armours, _armour)){
-                   _armour =  "MK7 Aquila";
-                }
-            }
         }
         last_armour = _armour;
         return _armour;

--- a/scripts/scr_draw_unit_image/scr_draw_unit_image.gml
+++ b/scripts/scr_draw_unit_image/scr_draw_unit_image.gml
@@ -858,6 +858,10 @@ function scr_draw_unit_image(_background = false) {
         }
     }
     surface_reset_target();
+    /*shader_set_uniform_i(shader_get_uniform(sReplaceColor, "u_blend_modes"), 2);                
+    texture_set_stage(shader_get_sampler_index(sReplaceColor, "armour_texture"), sprite_get_texture(spr_leopard_sprite, 0)); */
+    //draw_surface(unit_surface, xx+_x1-x_surface_offset,yy+_y1-y_surface_offset);
+    //surface_free(unit_surface);
     shader_reset();
     var _complex_sprite_names = struct_get_names(complex_set);
     for (var i = 0; i < array_length(_complex_sprite_names); i++) {


### PR DESCRIPTION
### Purpose
<!-- With a few sentences, describe why you decided to make these changes/additions. -->
- Revert the PR that is loop softlocking the game with errors on the unit view, when it's compiled with YYC.

### Describe your changes/additions
<!-- What your changes do and how. No need to get too technical. Some stuff from this list will also be used for the player release notes. -->
- Revert the PR and also comment out some debug lines.

### What can/needs to be improved/changed
<!-- Is there anything that you think can/needs to be improved, or perhaps done using a different approach. -->
- Nothing.

### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- Compiled with YYC - the error is no more.

### Related things and/or additional context
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, screenshots etc. -->
```
ERROR in action number 1
of  Step Event0 for object obj_controller:
Unbalanced surface stack. you are trying to pop a surface that has not been set.
gml_Script_draw@anon@23022@ComplexSet@scr_ComplexSet (line 490)
gml_Script_scr_draw_unit_image (line 686)
gml_Object_obj_controller_Step_0 (line 689)

ERROR in action number 1
of  Step Event0 for object obj_controller:
Trying to set a surface target that does not exist.
gml_Script_scr_draw_unit_image (line 860)
gml_Object_obj_controller_Step_0 (line 689)
```

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->

<!--- "Inspired" by the CDDA PR template -->
