### PR TITLE
fix: Rework planet dispo to work with PlanetData

### DIFF
--- a/objects/obj_en_fleet/Alarm_1.gml
+++ b/objects/obj_en_fleet/Alarm_1.gml
@@ -64,13 +64,10 @@ if (navy && action=="") {
 	            trade_goods="recr";
 	            action="";
 	        } else { //this was always a dead path previously since tar could never be bigger than i, now it will
+	        	var _targ = new PlanetData(tar, orbiting);
 	            if (orbiting.p_owner[tar]=eFACTION.Player) and (orbiting.p_player[tar]=0) and (planet_feature_bool(orbiting.p_feature[tar],P_features.Monastery)==0){
-	                if (orbiting.p_first[tar] != eFACTION.Player) {
-						orbiting.p_owner[tar] = orbiting.p_first[tar];
-					} else {
-						orbiting.p_owner[tar]= eFACTION.Imperium;
-					}
-					orbiting.dispo[tar]=-50;
+	                _targ.return_to_first_owner();
+					_targ.add_disposition(-50);
 	                trade_goods="";
 					action="";
 	            }
@@ -117,7 +114,7 @@ if (navy && action=="") {
 	                }
                 
 	                if (bombard){
-						
+						var _orbiting_data = new PlanetData(bombard, orbiting);
 	                    scare=(capital_number*3)+frigate_number;
 
 	                    if (scare>2) then scare=2;
@@ -130,7 +127,7 @@ if (navy && action=="") {
 							kill=scare*15000000; // pop if small
 						}
 
-						var bombard_name = planet_numeral_name(bombard, orbiting);
+						var bombard_name = _orbiting_data.name();
 	                    var bombard_report_string=$"Imperial Battlefleet bombards {bombard_name}.";
 	                    var PDF_loses=min(orbiting.p_pdf[bombard],(scare*15000000)/2);
 						
@@ -166,12 +163,8 @@ if (navy && action=="") {
                     
 	                    if (orbiting.p_population[bombard]+orbiting.p_pdf[bombard]<=0) and (orbiting.p_owner[bombard]=eFACTION.Player){
 	                        if (planet_feature_bool(orbiting.p_feature[bombard], P_features.Monastery)==0) {
-	                            if (orbiting.p_first[bombard]!=eFACTION.Player) {
-									orbiting.p_owner[bombard]=orbiting.p_first[bombard];
-								} else {
-									orbiting.p_owner[bombard]=eFACTION.Imperium;
-								}
-								orbiting.dispo[bombard]=-50;
+	                            _orbiting_data.return_to_first_owner();
+								_orbiting_data.add_disposition(-50)
 	                        } else {
 	                            trade_goods="invade_player";
 	                        }

--- a/objects/obj_p_fleet/Alarm_1.gml
+++ b/objects/obj_p_fleet/Alarm_1.gml
@@ -21,12 +21,8 @@ try_and_report_loop("player alarm 1",function(){
                 }
                 orbiting.visited = 1;
             }
-    		
-            for (var i=1;i<=orbiting.planets;i++){
-                if (orbiting.p_owner[b]<=5) and (orbiting.dispo[b]>-30) and (orbiting.dispo[b]<0){
-                    orbiting.dispo[b]=min(obj_ini.imperium_disposition,obj_controller.disposition[orbiting.p_owner[b]])+irandom(8)-4;
-                } 
-            }
+            
+    		meet_system_governors(orbiting);
         }
     }
 
@@ -86,20 +82,14 @@ try_and_report_loop("player alarm 1",function(){
             // Check to see if there are already player ships in the spot where this object will move to
             // If yes, combine the two of them
             
-            var steh;
-            steh=instance_nearest(action_x,action_y,obj_star);
+            var steh=instance_nearest(action_x,action_y,obj_star);
             if (steh.vision=0) then steh.vision=1;
             steh.present_fleet[1]+=1;
             orbiting=steh;
             // show_message("Present Fleets at alarm[1]: "+string(steh.present_fleets));
             
-            var b=0;
-            for (var i=1;i<=steh.planets;i++){
-                if (steh.p_first[b]<=5) and (steh.dispo[b]>-30) and (steh.dispo[b]<0){
-                    steh.dispo[b]=min(obj_ini.imperium_disposition,obj_controller.disposition[2])+irandom(8)-4;
-                } 
+            meet_system_governors(steh);
 
-            }
             if (steh.p_owner[1]=5) or (steh.p_owner[2]=5) or (steh.p_owner[3]=5) or (steh.p_owner[4]=5){
                 if (obj_controller.faction_defeated[5]=0) and (obj_controller.known[eFACTION.Ecclesiarchy]=0) then obj_controller.known[eFACTION.Ecclesiarchy]=1;
             }

--- a/objects/obj_p_fleet/Alarm_1.gml
+++ b/objects/obj_p_fleet/Alarm_1.gml
@@ -14,11 +14,19 @@ try_and_report_loop("player alarm 1",function(){
         if (spid.vision=0) then spid.vision=1;
         orbiting=spid;
         
-        if (orbiting!=0) and (instance_exists(orbiting) and (orbiting.visited == 0)){
-    		for (var planet_num = 1; planet_num < orbiting.planets; planet_num += 1){
-    			if (array_length(orbiting.p_feature[planet_num])!=0) then with(orbiting){scr_planetary_feature(planet_num);}
-    		}
-    		orbiting.visited = 1;
+        if (orbiting!=0) and (instance_exists(orbiting)){
+            if ((orbiting.visited == 0)){
+                for (var planet_num = 1; planet_num < orbiting.planets; planet_num += 1){
+                    if (array_length(orbiting.p_feature[planet_num])!=0) then with(orbiting){scr_planetary_feature(planet_num);}
+                }
+                orbiting.visited = 1;
+            }
+    		
+            for (var i=1;i<=orbiting.planets;i++){
+                if (orbiting.p_owner[b]<=5) and (orbiting.dispo[b]>-30) and (orbiting.dispo[b]<0){
+                    orbiting.dispo[b]=min(obj_ini.imperium_disposition,obj_controller.disposition[orbiting.p_owner[b]])+irandom(8)-4;
+                } 
+            }
         }
     }
 

--- a/objects/obj_star/Alarm_1.gml
+++ b/objects/obj_star/Alarm_1.gml
@@ -419,7 +419,9 @@ for(var i=1; i<=4; i++){
         hyu+=1;
         p_owner[i]=9;
     }
-    if (p_first[i]<=5) and (dispo[i]>-5000) then dispo[i]=-20;
+    if (p_first[i]<=5) and (dispo[i]>-5000){
+        dispo[i]=-20;
+    }
 }
 if (hyu==0) and (owner == eFACTION.Tyranids) then owner = eFACTION.Imperium;
 

--- a/scripts/scr_PlanetData/scr_PlanetData.gml
+++ b/scripts/scr_PlanetData/scr_PlanetData.gml
@@ -33,6 +33,24 @@ function PlanetData(planet, system) constructor{
         system.dispo[planet] = player_disposition;
     }
 
+    static set_population = function(new_population){
+    	population = new_population;
+    	system.p_population[planet] = population;
+    }
+
+    static edit_population = function(edit_val){
+    	population = population + edit_val >= 0 ? population + edit_val : 0;
+    	system.p_population[planet] = population;
+    }
+
+    //assumes a large pop figure and changes down if small pop planet
+    static population_small_conversion= function(pop_value){
+    	if (!large_population){
+    		pop_value *= 100000000;
+    	}
+    	return pop_value;
+    }
+
     static return_to_first_owner = function(allow_player = false){
     	if (!allow_player && origional_owner == eFACTION.Player){
     		system.p_owner[planet]= eFACTION.Imperium;
@@ -787,26 +805,24 @@ function PlanetData(planet, system) constructor{
         }		
 	}
 
-	static suffer_bombard = function(strength){
+	static suffer_navy_bombard = function(strength){
                 
                 
     	var kill = 0;
         // Eh heh heh
         if  (planet_forces[eFACTION.Tyranids]>0){
-            if (strength>2) then strength=2;
-            if (strength<1) then strength=0;
+            strength = strength>2 ? 2 : 0;
             system.p_tyranids[planet]-=2;
         }
         else if  (planet_forces[eFACTION.Ork]>0){
             if (strength>2) then strength=2;if (strength<1) then strength=0;
             system.p_orks[planet]-=2;
         }
-        else if  (current_owner=8) and (planet_forces[eFACTION.Tau]>0){
-            if (strength>2) then strength=2;if (strength<1) then strength=0;
+        else if  (current_owner=eFACTION.Tau) and (planet_forces[eFACTION.Tau]>0){
+            strength = strength>2 ? 2 : 0;
             system.p_tau[planet]-=2;
-        
-            if (system.p_large[planet]=0) then kill=strength*15000000;// Population if normal
-            if (system.p_large[planet]=1) then kill=strength*0.15;// Population if large
+        	
+        	kill = large_population ? strength*0.15 : strength*15000000
         }
         else if  (current_owner=8) and (pdf>0){
             wob=strength*(irandom_range(49, 51) * 100000);
@@ -818,18 +834,18 @@ function PlanetData(planet, system) constructor{
         	kill = large_population ? strength*0.15 : strength*15000000
         }
         else if  (current_owner=10){
-            if (strength>2) then strength=2;if (strength<1) then strength=0;
+
+        	strength = strength>2 ? 2 : 0;
         
-            if (onceh!=2) and (system.p_chaos[planet]>0){system.p_chaos[planet]=max(0,system.p_traitors[planet]-1);}
-            if (onceh!=2) and (system.p_traitors[planet]>0){system.p_traitors[planet]=max(0,system.p_traitors[planet]-2);}
-        
-            if (system.p_large[planet]=0) then kill=strength*15000000;// Population if normal
-            if (system.p_large[planet]=1) then kill=strength*0.15;// Population if large
+            if  (system.p_chaos[planet]>0){
+            	system.p_chaos[planet]=max(0,system.p_traitors[planet]-1);
+            } else if  (system.p_traitors[planet]>0){
+            	system.p_traitors[planet]=max(0,system.p_traitors[planet]-2);
+            }
+        	kill = strength * population_small_conversion(0.15);
             if (system.p_heresy[planet]>0) then system.p_heresy[planet]=max(0,system.p_heresy[planet]-5);
         }
-    
-        system.p_population[planet]-=kill;
-        if (system.p_population[planet]<0) then system.p_population[planet]=0;
+    	edit_population(kill*-1);
         if (system.p_pdf[planet]<0) then system.p_pdf[planet]=0;
     
         if (population+pdf<=0) and (current_owner=1) and (obj_controller.faction_status[eFACTION.Imperium]="War"){
@@ -839,6 +855,5 @@ function PlanetData(planet, system) constructor{
             }
         }		
 	}
-
 
 }

--- a/scripts/scr_imperial_navy_functions/scr_imperial_navy_functions.gml
+++ b/scripts/scr_imperial_navy_functions/scr_imperial_navy_functions.gml
@@ -163,52 +163,11 @@ function imperial_navy_bombard(){
                 }
             
                 if (bombard>0){
-                    scare=(capital_number*3)+frigate_number;
-                
-                
-                
-                    // Eh heh heh
-                    if (onceh<2) and (orbiting.p_tyranids[bombard]>0){
-                        if (scare>2) then scare=2;if (scare<1) then scare=0;
-                        orbiting.p_tyranids[bombard]-=2;onceh=2;
-                    }
-                    if (onceh<2) and (orbiting.p_orks[bombard]>0){
-                        if (scare>2) then scare=2;if (scare<1) then scare=0;
-                        orbiting.p_orks[bombard]-=2;onceh=2;
-                    }
-                    if (onceh<2) and (orbiting.p_owner[bombard]=8) and (orbiting.p_tau[bombard]>0){
-                        if (scare>2) then scare=2;if (scare<1) then scare=0;
-                        orbiting.p_tau[bombard]-=2;onceh=2;
-                    
-                        if (orbiting.p_large[bombard]=0) then kill=scare*15000000;// Population if normal
-                        if (orbiting.p_large[bombard]=1) then kill=scare*0.15;// Population if large
-                    }
-                    if (onceh<2) and (orbiting.p_owner[bombard]=8) and (orbiting.p_pdf[bombard]>0){
-                        wob=scare*5000000+choose(floor(random(100000)),floor(random(100000))*-1);
-                        orbiting.p_pdf[bombard]-=wob;
-                        if (orbiting.p_pdf[bombard]<0) then orbiting.p_pdf[bombard]=0;
-                    
-                        if (orbiting.p_large[bombard]=0) then kill=scare*15000000;// Population if normal
-                        if (orbiting.p_large[bombard]=1) then kill=scare*0.15;// Population if large
-                    }
-                    if (onceh<2) and (orbiting.p_owner[bombard]=10){
-                        if (scare>2) then scare=2;if (scare<1) then scare=0;
-                    
-                        if (onceh!=2) and (orbiting.p_chaos[bombard]>0){orbiting.p_chaos[bombard]=max(0,orbiting.p_traitors[bombard]-1);onceh=2;}
-                        if (onceh!=2) and (orbiting.p_traitors[bombard]>0){orbiting.p_traitors[bombard]=max(0,orbiting.p_traitors[bombard]-2);onceh=2;}
-                    
-                        if (orbiting.p_large[bombard]=0) then kill=scare*15000000;// Population if normal
-                        if (orbiting.p_large[bombard]=1) then kill=scare*0.15;// Population if large
-                        if (orbiting.p_heresy[bombard]>0) then orbiting.p_heresy[bombard]=max(0,orbiting.p_heresy[bombard]-5);
-                    }
-                
-                    orbiting.p_population[bombard]-=kill;
-                    if (orbiting.p_population[bombard]<0) then orbiting.p_population[bombard]=0;
-                    if (orbiting.p_pdf[bombard]<0) then orbiting.p_pdf[bombard]=0;
-                
-                    if (orbiting.p_population[bombard]+orbiting.p_pdf[bombard]<=0) and (orbiting.p_owner[bombard]=1) and (obj_controller.faction_status[eFACTION.Imperium]="War"){
-                        if (planet_feature_bool(orbiting.p_feature[bombard],P_features.Monastery)==0){orbiting.p_owner[bombard]=2;orbiting.dispo[bombard]=-50;}
-                    }
+
+                	var _p_data = new PlanetData(bombard, orbiting);
+                	scare=(capital_number*3)+frigate_number;
+                	_p_data.suffer_bombard(scare);
+                   
                     exit;
                 }
             }

--- a/scripts/scr_mission_functions/scr_mission_functions.gml
+++ b/scripts/scr_mission_functions/scr_mission_functions.gml
@@ -179,7 +179,7 @@ function complete_garrison_mission(targ_planet, problem_index){
             }
             scr_popup($"Agreed Garrison of {planet_numeral_name(targ_planet)} complete",_mission_string,"","");
         } else {
-            dispo[targ_planet] -= 20;
+        	planet.add_disposition(-20);
             scr_popup($"Agreed Garrison of {planet_numeral_name(targ_planet)}",$"your agreed garrison of  {planet_numeral_name(targ_planet)} was cut short by your chapter the planetary governor has expressed his displeasure (disposition -20)","","");
         }
         remove_planet_problem(targ_planet, "provide_garrison");

--- a/scripts/scr_recruit_data/scr_recruit_data.gml
+++ b/scripts/scr_recruit_data/scr_recruit_data.gml
@@ -75,8 +75,8 @@ function find_recruit_success_chance(local_apothecary_points, system, planet, ui
                 if (droll == 0) {
                     var _planet_name = p_data.name
                     scr_alert(#FF9900, "DIPLOMATIC DISASTER", $"Apothecaries at {_planet_name} has been spotted doing suspicious activities!", system.x, system.y)
-                    scr_event_log(#FF9900, $"Apothecaries at {_planet_name} has been spotted doing suspicious activities!", system.name)
-                    system.dispo[planet]-=25;
+                    scr_event_log(#FF9900, $"Apothecaries at {_planet_name} has been spotted doing suspicious activities!", system.name);
+                    p_data.add_disposition(-25);
                     if (p_data.current_owner != eFACTION.Player) {
                         obj_controller.disposition[p_data.current_owner]-=5;
                     }

--- a/scripts/scr_system_search_helpers/scr_system_search_helpers.gml
+++ b/scripts/scr_system_search_helpers/scr_system_search_helpers.gml
@@ -311,6 +311,17 @@ function scr_faction_string_name(faction){
 	return name;
 }
 
+function meet_system_governors(system){
+	with (system){
+        for (var i=1;i<=planets;i++){
+            if (p_first[i]<=5) and (dispo[i]>-30) and (dispo[i]<0){
+                dispo[i]=min(obj_ini.imperium_disposition,obj_controller.disposition[2])+irandom(8)-4;
+            } 
+
+        }
+	}
+}
+
 function scr_planet_image_numbers(p_type){
 	var image =0;
 	image_map = ["","Lava","Lava", "Desert","Forge","Hive","Death","Agri","Feudal","Temperate","Ice","Dead","Daemon","Craftworld","","Space Hulk", "", "Shrine"];


### PR DESCRIPTION
<!-- With a few sentences, describe why you decided to make these changes/additions. -->
- Creates static methods within PlanetData to alter planet disposition this has two advantages
   - removes the need to use the clunky system.dispo[planet] syntax
   - remove teh need to constatly define clamp(val, 0, 100)
- ensure that planet disposition is set whenever a player fleet is present ata planet removing the ```???``` disposition error that sometimes occurs
### Describe your changes/additions
<!-- What your changes do and how. No need to get too technical. Some stuff from this list will also be used for the player release notes. -->
- Self-descriptive.

### What can/needs to be improved/changed
<!-- Is there anything that you think can/needs to be improved, or perhaps done using a different approach. -->
- Nothing.

### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- Loaded game and played a few turns

### Related things and/or additional context
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, screenshots etc. -->
- None.

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->

<!--- "Inspired" by the CDDA PR template -->
