### PR TITLE
fix: Navy bombard mismatched function name call

### DIFF
--- a/scripts/scr_imperial_navy_functions/scr_imperial_navy_functions.gml
+++ b/scripts/scr_imperial_navy_functions/scr_imperial_navy_functions.gml
@@ -166,7 +166,7 @@ function imperial_navy_bombard(){
 
                 	var _p_data = new PlanetData(bombard, orbiting);
                 	scare=(capital_number*3)+frigate_number;
-                	_p_data.suffer_bombard(scare);
+                	_p_data.suffer_navy_bombard(scare);
                    
                     exit;
                 }


### PR DESCRIPTION
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
i fucked up and changed the name in one place but not in the other
 by the CDDA PR template -->
