### PR TITLE
fix: Destroy a runaway unit_size ds_map

### DIFF
--- a/scripts/scr_unit_size/scr_unit_size.gml
+++ b/scripts/scr_unit_size/scr_unit_size.gml
@@ -34,5 +34,7 @@ function scr_unit_size(armour, role, other_factors, mobility=false) {
         show_debug_message($"Could not find size for vehicle '{role}'");
     }
 
+    ds_map_destroy(vehicle_size_map);
+
     return (_size);
 }


### PR DESCRIPTION
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
### Purpose
<!-- With a few sentences, describe why you decided to make these changes/additions. -->
- Fix a typo? Bug? Mistake?

### Describe your changes/additions
<!-- What your changes do and how. No need to get too technical. Some stuff from this list will also be used for the player release notes. -->
- Destroy the ds_map when it's no longer needed, as it was created on **every** `scr_unit_size` function call and never destroyed, possibly leading to insane memory leaks.

### What can/needs to be improved/changed
<!-- Is there anything that you think can/needs to be improved, or perhaps done using a different approach. -->
- Nothing.

### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- None, and I understand the risks.

### Related things and/or additional context
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, screenshots etc. -->
- https://discord.com/channels/714022226810372107/1121959429546455050/1363869559009837157

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->

<!--- "Inspired" by the CDDA PR template -->
