### PR TITLE
fix: Remove old hover method for viewing marine stats

### DIFF
--- a/scripts/scr_ui_manage/scr_ui_manage.gml
+++ b/scripts/scr_ui_manage/scr_ui_manage.gml
@@ -1220,13 +1220,6 @@ function scr_ui_manage() {
             if ((cn.temp[120].name() != "") && (cn.temp[120].race() != 0)) {
                 draw_set_alpha(1);
                 var xx = __view_get(e__VW.XView, 0) + 0, yy = __view_get(e__VW.YView, 0) + 0;
-                if ((scr_hit(xx + 1208, yy + 210, xx + 1374, yy + 210 + 272) || obj_controller.unit_profile) && !instance_exists(obj_temp3) && !instance_exists(obj_popup)) {
-                    stats_displayed = true;
-                    selected_unit.stat_display(true);
-                    //tooltip_draw(stat_x, stat_y+string_height(stat_display),0,0,100,17);
-                } else {
-                    stats_displayed = false;
-                }
                 with (obj_controller) {
                     if (view_squad && !instance_exists(obj_popup)) {
                         if (managing > 10) {


### PR DESCRIPTION
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
### Purpose
<!-- With a few sentences, describe why you decided to make these changes/additions. -->
- Self-descriptive. Used to be a way of viewing marine stats by hovering the marine image this is now redundant and was causing a crash

### Describe your changes/additions
<!-- What your changes do and how. No need to get too technical. Some stuff from this list will also be used for the player release notes. -->
- Self-descriptive.

### What can/needs to be improved/changed
<!-- Is there anything that you think can/needs to be improved, or perhaps done using a different approach. -->
- Nothing.

### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- None, and I understand the risks.

### Related things and/or additional context
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, screenshots etc. -->
- None.

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->

<!--- "Inspired" by the CDDA PR template -->
