### PR TITLE
fix: Helm sprite memory leak; Surface freeing and clearing

### DIFF
--- a/objects/obj_star/Draw_0.gml
+++ b/objects/obj_star/Draw_0.gml
@@ -86,7 +86,7 @@ if (global.load == -1 && (obj_controller.zoomed || in_camera_view(star_box_shape
         stored_owner = owner;
         var _new_sprite = sprite_create_from_surface(star_tag_surface, 0, 0, surface_get_width(star_tag_surface), surface_get_height(star_tag_surface), false, false, 0, 0);
         ds_map_set(obj_controller.star_sprites, name, _new_sprite);
-        surface_free(star_tag_surface)
+        surface_clear_and_free(star_tag_surface)
     } 
     var _sprite = ds_map_find_value(obj_controller.star_sprites, name)
     draw_sprite_ext(_sprite, 0,  x-(64*scale), y, scale, scale, 1, c_white, 1);

--- a/scripts/scr_ComplexSet/scr_ComplexSet.gml
+++ b/scripts/scr_ComplexSet/scr_ComplexSet.gml
@@ -789,8 +789,7 @@ function ComplexSet(_unit) constructor{
         }else if(unit_role==_role[eROLE.Veteran] || (unit_role==_role[eROLE.Terminator] && unit.company == 1)){
             _complex_helm = _comp_helms.veteran;
         }
-        if (is_struct(_complex_helm) 
-            && struct_exists(self, "head") && draw_helms && !sprite_exists(head)){
+        if (is_struct(_complex_helm) && struct_exists(self, "head") && draw_helms) {
             complex_helms(_complex_helm);
         }
 
@@ -1267,6 +1266,10 @@ function ComplexSet(_unit) constructor{
             //shader_set_uniform_f_array(shader_get_uniform(helm_shader, "replace_colour"), get_shader_array(data.helm_secondary));
             //draw_sprite(spr_helm_stripe, data.helm_pattern==1?0:1, 0, 0);
             surface_reset_target();
+
+            if (sprite_exists(head)) {
+                sprite_delete(head);
+            }
 
             head = sprite_create_from_surface(_head_surface, 0, 0, _surface_width, 60, false, false, 0, 0);
             surface_clear_and_free(_head_surface);

--- a/scripts/scr_ComplexSet/scr_ComplexSet.gml
+++ b/scripts/scr_ComplexSet/scr_ComplexSet.gml
@@ -444,7 +444,6 @@ function ComplexSet(_unit) constructor{
         right_weapon : unit.get_body_data("weapon_variation","right_arm"),
     }
 
-    static base_component_surface = surface_create(600, 600);
     static draw_component = function(component_name, texture_draws={}){
         if (array_contains(banned, component_name)){
             return "banned component";
@@ -474,9 +473,7 @@ function ComplexSet(_unit) constructor{
                     surface_reset_target();                   
                     shader_reset();
 
-                    if (!surface_exists(base_component_surface)) {
-                        base_component_surface = surface_create(600, 600);
-                    }
+                    var base_component_surface = surface_create(600, 600);
                     surface_set_target(base_component_surface);                          
                     shader_set(armour_texture);
                     for (var i=0;i<array_length(_tex_names);i++){
@@ -518,8 +515,7 @@ function ComplexSet(_unit) constructor{
                     draw_sprite(_sprite,choice ?? 0,x_surface_offset,y_surface_offset);
                     draw_surface(base_component_surface, 0, 0);
                     surface_reset_target();
-
-                    clear_and_free_surface(base_component_surface);
+                    surface_clear_and_free(base_component_surface);
 
                     surface_set_target(_return_surface);             
                  } else {
@@ -794,7 +790,7 @@ function ComplexSet(_unit) constructor{
             _complex_helm = _comp_helms.veteran;
         }
         if (is_struct(_complex_helm) 
-            && struct_exists(self, "head") && draw_helms){
+            && struct_exists(self, "head") && draw_helms && !sprite_exists(head)){
             complex_helms(_complex_helm);
         }
 
@@ -884,13 +880,13 @@ function ComplexSet(_unit) constructor{
         if (!surface_exists(prep_surface) || !surface_exists(_final_surface)) {
             draw_sprite(spr_none, 0, 0, 0);
             if (surface_exists(prep_surface)) {
-                surface_free(prep_surface);
+                surface_clear_and_free(prep_surface);
             }
             exit;
          }
          surface_set_target(_final_surface);     
          draw_surface(prep_surface, 0, 0);
-        clear_and_free_surface(prep_surface);
+        surface_clear_and_free(prep_surface);
         shader_set(full_livery_shader);    
     }
     static purity_seals_and_hangings = function(){
@@ -1273,7 +1269,7 @@ function ComplexSet(_unit) constructor{
             surface_reset_target();
 
             head = sprite_create_from_surface(_head_surface, 0, 0, _surface_width, 60, false, false, 0, 0);
-            clear_and_free_surface(_head_surface);
+            surface_clear_and_free(_head_surface);
             shader_set(full_livery_shader);
         }
     }

--- a/scripts/scr_culture_visuals/scr_culture_visuals.gml
+++ b/scripts/scr_culture_visuals/scr_culture_visuals.gml
@@ -59,7 +59,7 @@ function load_symbol_sets(global_area, main_key, sub_sets){
                 }
             }
         }
-        surface_free(_sprite_double_surface);    
+        surface_clear_and_free(_sprite_double_surface);    
     }    
 }
 

--- a/scripts/scr_draw_unit_image/scr_draw_unit_image.gml
+++ b/scripts/scr_draw_unit_image/scr_draw_unit_image.gml
@@ -45,10 +45,11 @@ enum ArmourType {
     None,
 }
 
-function clear_and_free_surface(_surface) {
+function surface_clear_and_free(_surface) {
     surface_set_target(_surface);
     draw_clear_alpha(c_white, 0);
     surface_reset_target();
+    surface_free(_surface);
 }
 
 function UnitImage(_unit_sprite) constructor {
@@ -733,8 +734,7 @@ function scr_draw_unit_image(_background = false) {
     }
 
     var _complete_sprite = sprite_create_from_surface(unit_surface, 0, 0, 600, 600, true, false, 0, 0);
-    clear_and_free_surface(unit_surface);
-    surface_free(unit_surface);
+    surface_clear_and_free(unit_surface);
 
     return new UnitImage(_complete_sprite);
 }


### PR DESCRIPTION
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
### Purpose
<!-- With a few sentences, describe why you decided to make these changes/additions. -->
- Fix sprite creation memory leaks.
- Remove empty leftover surfaces stuck in the memory when not needed anymore.

### Describe your changes/additions
<!-- What your changes do and how. No need to get too technical. Some stuff from this list will also be used for the player release notes. -->
- Rename `clear_and_free_surface` into `surface_clear_and_free`, to be a bit more standardized.
- Replace the remaining `surface_free` calls with `surface_clear_and_free`.
- Free one of the surfaces that was stuck in the memory.
- Only create a helm sprite if one doesn't exist.

### What can/needs to be improved/changed
<!-- Is there anything that you think can/needs to be improved, or perhaps done using a different approach. -->
- Nothing.

### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- Launched the game a lot of times to test each change.

### Related things and/or additional context
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, screenshots etc. -->
- None.

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->

<!--- "Inspired" by the CDDA PR template -->
