### PR TITLE
fix: Marines in no location

### DIFF
--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -1875,7 +1875,7 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
             location_name = obj_ini.loc[company][marine_number]; //system marine is in
         } else {
             location_type = location_types.ship; //marine is on ship
-            location_id = ship_location; //ship array position
+            location_id = ship_location > -1 ? ship_location : 0; //ship array position
             if (location_id < array_length(obj_ini.ship_location)) {
                 location_name = obj_ini.ship_location[location_id]; //location of ship
             } else {


### PR DESCRIPTION
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
### Purpose
simple patch to stop immediate crash from marines being in no location (which should not be happening) by proxying the marine to be on ship index 0.
Will need something better

### Describe your changes/additions
<!-- What your changes do and how. No need to get too technical. Some stuff from this list will also be used for the player release notes. -->
- Self-descriptive.

### What can/needs to be improved/changed
<!-- Is there anything that you think can/needs to be improved, or perhaps done using a different approach. -->
- Nothing.

### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- None, and I understand the risks.

### Related things and/or additional context
https://discord.com/channels/714022226810372107/1365829489086566513
<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->

<!--- "Inspired" by the CDDA PR template -->
