### PR TITLE
feat: Less red in the battlelog

### DIFF
--- a/objects/obj_ncombat/Alarm_3.gml
+++ b/objects/obj_ncombat/Alarm_3.gml
@@ -94,7 +94,6 @@ if ((messages>0) and (messages_shown<24)) and (messages_shown<=100){
         newline=message[that];
         if (message_priority[that]>0) then newline_color="bright";
         if (string_count("lost",newline)>0) then newline_color="red";
-        if (string_count("critically damaged",newline)>0) then newline_color="red";
         if (string_count("^",newline)>0){
             newline=string_replace(newline,"^","");
             newline_color="white";

--- a/objects/obj_ncombat/Alarm_5.gml
+++ b/objects/obj_ncombat/Alarm_5.gml
@@ -115,7 +115,6 @@ var _total_deaths = final_marine_deaths + final_command_deaths;
 var _total_injured = _total_deaths + injured + units_saved_count;
 if (_total_injured > 0) {
     newline = $"{string_plural_count("unit", _total_injured)} {smart_verb("was", _total_injured)} critically injured.";
-    newline_color = "red";
 	scr_newtext();
 
     if (units_saved_count > 0) {
@@ -204,8 +203,7 @@ scr_newtext();
 
 var _total_damaged_count = vehicle_deaths + vehicles_saved_count;
 if (_total_damaged_count > 0) {
-	newline = $"{string_plural_count("vehicle", _total_damaged_count)} {smart_verb("was", _total_damaged_count)} critically damaged during battle.";
-    newline_color="red";
+	newline = $"{string_plural_count("vehicle", _total_damaged_count)} {smart_verb("was", _total_damaged_count)} disabled during battle.";
     scr_newtext();
 
     if (vehicles_saved_count > 0) {

--- a/scripts/scr_flavor2/scr_flavor2.gml
+++ b/scripts/scr_flavor2/scr_flavor2.gml
@@ -336,9 +336,9 @@ function scr_flavor2(lost_units_count, target_type, hostile_range, hostile_weapo
                 if (him != -1) { // found a valid unit
                     obj_ncombat.dead_jims += 1;
                     if (marine_type[him] == obj_ini.role[100][5]) {
-                        obj_ncombat.dead_jim[obj_ncombat.dead_jims] = $"A {marine_type[him]} has been critically injured!";
+                        obj_ncombat.dead_jim[obj_ncombat.dead_jims] = $"A {marine_type[him]} has been lost!";
                     } else {
-                        obj_ncombat.dead_jim[obj_ncombat.dead_jims] = $"{unit_struct[him].name_role()} has been critically injured!";
+                        obj_ncombat.dead_jim[obj_ncombat.dead_jims] = $"{unit_struct[him].name_role()} has been lost!";
                     }
                 }
             }
@@ -355,7 +355,7 @@ function scr_flavor2(lost_units_count, target_type, hostile_range, hostile_weapo
 		var lis, y1, y2;
 		lis = string_rpos(", ", m2);
 		m2 = string_delete(m2, lis, 3); // This clears the last ', ' and replaces it with the end statement
-		if (lost_units_count > 0) then m2 += " critically damaged.";
+		if (lost_units_count > 0) then m2 += " lost.";
 
 		// show_message(m2);
 
@@ -376,7 +376,7 @@ function scr_flavor2(lost_units_count, target_type, hostile_range, hostile_weapo
 		var lis, y1, y2;
 		lis = string_rpos(", ", m2);
 		m2 = string_delete(m2, lis, 3);
-		if (lost_units_count > 0) then m2 += " critically damaged.";
+		if (lost_units_count > 0) then m2 += " lost.";
 	}
 	if (string_count(", ", m2) = 1) and(unce = 0) and(hostile_weapon = "Web Spinner") {
 		var lis, y1, y2;


### PR DESCRIPTION
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
### Purpose
<!-- With a few sentences, describe why you decided to make these changes/additions. -->
- Reduce the amount of unneed red in the battlelog, when units are injured and not yet lost.
![image](https://github.com/user-attachments/assets/89ead263-38a7-4c7e-b80c-198f1063d1dd)

### Describe your changes/additions
<!-- What your changes do and how. No need to get too technical. Some stuff from this list will also be used for the player release notes. -->
- Change coloring of some lines and some text.
- Now, only when units are actually lost, the line will be colored red.

### What can/needs to be improved/changed
<!-- Is there anything that you think can/needs to be improved, or perhaps done using a different approach. -->
- Nothing.

### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- None, and I understand the risks.

### Related things and/or additional context
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, screenshots etc. -->
- None.

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->

<!--- "Inspired" by the CDDA PR template -->
