### PR TITLE
fix: NameGenerator breakage

### DIFF
--- a/objects/obj_creation/Create_0.gml
+++ b/objects/obj_creation/Create_0.gml
@@ -9,6 +9,8 @@ try{
     handle_exception(_exception);
 }
 
+global.name_generator = new NameGenerator();
+
 #region Global Settings: volume, fullscreen etc
 ini_open("saves.ini");
 master_volume=ini_read_real("Settings","master_volume",1);

--- a/scripts/NameGenerator/NameGenerator.gml
+++ b/scripts/NameGenerator/NameGenerator.gml
@@ -39,37 +39,37 @@ function NameGenerator() constructor {
 	};
 
 	// vars // TODO put these into a struct or dict or something
-	static sector_names = LoadSimpleNames("sector", "Sector 1");
-	static sector_used_names = [];
+	sector_names = LoadSimpleNames("sector", "Sector 1");
+	sector_used_names = [];
 
-	static star_names = LoadSimpleNames("star", "Star 1");
-	static star_used_names = [];
-	static star_names_generic_counter = 0; // TODO once we migrate Star data to proper structs and jsons, this can probably be removed
+	star_names = LoadSimpleNames("star", "Star 1");
+	star_used_names = [];
+	star_names_generic_counter = 0; // TODO once we migrate Star data to proper structs and jsons, this can probably be removed
 
-	static space_marines_names = LoadSimpleNames("space_marine", "Space Marine 1");
-	static space_marines_used_names = [];
+	space_marines_names = LoadSimpleNames("space_marine", "Space Marine 1");
+	space_marines_used_names = [];
 
-	static imperial_names = LoadSimpleNames("imperial", "Imperial 1");
-	static imperial_used_names = [];
+	imperial_names = LoadSimpleNames("imperial", "Imperial 1");
+	imperial_used_names = [];
 
-	static chaos_names = LoadSimpleNames("chaos", "Chaos 1");
-	static chaos_used_names = [];
+	chaos_names = LoadSimpleNames("chaos", "Chaos 1");
+	chaos_used_names = [];
 
-	static eldar_syllables = LoadCompositeNames("eldar", ["first_syllables", "second_syllables", "third_syllables"]);
+	eldar_syllables = LoadCompositeNames("eldar", ["first_syllables", "second_syllables", "third_syllables"]);
 
-	static ork_name_composites = LoadCompositeNames("ork", ["prefixes", "suffixes", "special"]);
+	ork_name_composites = LoadCompositeNames("ork", ["prefixes", "suffixes", "special"]);
 
-	static imperial_ship_names = LoadSimpleNames("imperial_ship", "Imperial Ship 1");
-	static imperial_ship_used_names = [];
+	imperial_ship_names = LoadSimpleNames("imperial_ship", "Imperial Ship 1");
+	imperial_ship_used_names = [];
 
-	static ork_ship_names = LoadSimpleNames("ork_ship", "Ork Ship 1");
-	static ork_ship_used_names = [];
+	ork_ship_names = LoadSimpleNames("ork_ship", "Ork Ship 1");
+	ork_ship_used_names = [];
 
-	static hulk_name_composites = LoadCompositeNames("hulk", ["prefixes", "suffixes"]);
+	hulk_name_composites = LoadCompositeNames("hulk", ["prefixes", "suffixes"]);
 
-	static tau_name_composites = LoadCompositeNames("tau", ["prefixes", "suffixes"]);
+	tau_name_composites = LoadCompositeNames("tau", ["prefixes", "suffixes"]);
 
-	static genestealer_cult_names = LoadCompositeNames("genestealercult", ["main", "embelishment", "title"]);
+	genestealer_cult_names = LoadCompositeNames("genestealercult", ["main", "embelishment", "title"]);
 
 	// init
 
@@ -84,7 +84,8 @@ function NameGenerator() constructor {
 					array_delete(used_names, 0, used_names_length);
 				} else {
 					log_error($"Used up all {entity_name} names. Generating a generic name. used_names_length = {used_names_length}; star_names_generic_counter = {star_names_generic_counter}.");
-					return $"{entity_name} {used_names_length + (star_names_generic_counter++)}";
+					star_names_generic_counter++;
+					return $"{entity_name} {used_names_length + star_names_generic_counter}";
 				}
 			}
 
@@ -225,6 +226,3 @@ function NameGenerator() constructor {
 		return CompositeNameGeneration(tau_name_composites, true);
 	};
 }
-
-// Init
-global.name_generator = new NameGenerator();


### PR DESCRIPTION
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
### Purpose
<!-- With a few sentences, describe why you decided to make these changes/additions. -->
- Fix NameGenerator throwing an error and generating generic names after x amount of new games.

### Describe your changes/additions
<!-- What your changes do and how. No need to get too technical. Some stuff from this list will also be used for the player release notes. -->
- All static vars are now instance vars. I see no reason to have them as static. They shouldn't be static and should reset each instance creation.
- Recreate the NameGenerator on obj_creation create event, to ensure that instance vars are nulled if the player goes back and forth.
- Don't create NameGenerator in the script file. Creation object should be enough.

### What can/needs to be improved/changed
<!-- Is there anything that you think can/needs to be improved, or perhaps done using a different approach. -->
- Nothing.

### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- 6 new games back to back - no generic names observed and no errors.

### Related things and/or additional context
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, screenshots etc. -->
- Bug report: https://discord.com/channels/714022226810372107/1366704470091894844
- Bug report 2: https://discord.com/channels/714022226810372107/1365501015628972152

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->

<!--- "Inspired" by the CDDA PR template -->
