### PR TITLE
fix: NameGenerator not initialized when loading

### DIFF
--- a/objects/obj_creation/CleanUp_0.gml
+++ b/objects/obj_creation/CleanUp_0.gml
@@ -1,1 +1,2 @@
 chapter_icons_container.cleanup();
+global.name_generator = new NameGenerator();

--- a/objects/obj_creation/Create_0.gml
+++ b/objects/obj_creation/Create_0.gml
@@ -9,8 +9,6 @@ try{
     handle_exception(_exception);
 }
 
-global.name_generator = new NameGenerator();
-
 #region Global Settings: volume, fullscreen etc
 ini_open("saves.ini");
 master_volume=ini_read_real("Settings","master_volume",1);

--- a/scripts/__init_global/__init_global.gml
+++ b/scripts/__init_global/__init_global.gml
@@ -11,4 +11,5 @@ function __init_global() {
     global.chapter_name = "None";
     global.game_seed = 0;
     global.ui_click_lock = false;
+    global.name_generator = new NameGenerator();
 }


### PR DESCRIPTION
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
### Purpose
<!-- With a few sentences, describe why you decided to make these changes/additions. -->
- Fix a bug I introduced.

### Describe your changes/additions
<!-- What your changes do and how. No need to get too technical. Some stuff from this list will also be used for the player release notes. -->
- Create NameGenerator through pragma.
- Recreate it in the cleanup of creation, as opposed to entering (no reason as to why, really, just because controller also does the same).

### What can/needs to be improved/changed
<!-- Is there anything that you think can/needs to be improved, or perhaps done using a different approach. -->
- I'm not sure if it's easier to just do this in the main menu create, but I feel really weird putting anything like this into the main menu obj.

### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- New game, save, load, exit the game, load.

### Related things and/or additional context
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, screenshots etc. -->
- Bug report: https://discord.com/channels/714022226810372107/1368062589711421471

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->

<!--- "Inspired" by the CDDA PR template -->
