### PR TITLE
fix: Bandaid fix for purge screen zoom bug

### DIFF
--- a/objects/obj_drop_select/Create_0.gml
+++ b/objects/obj_drop_select/Create_0.gml
@@ -1,6 +1,8 @@
 if !(variable_instance_exists(self, "attack")){
     attack = 0;
 }
+set_zoom_to_default(); //bandaid the purge screen flying off screen if zoomed out 
+
 once_only=0;
 
 raid_tact=1;

--- a/scripts/scr_cheatcode/scr_cheatcode.gml
+++ b/scripts/scr_cheatcode/scr_cheatcode.gml
@@ -343,6 +343,9 @@ function scr_cheatcode(argument0) {
 					var _fleet = get_nearest_player_fleet(0,0);
 					add_ship_to_fleet(new_player_ship("Gloriana"),_fleet);
 					break;
+				case "zoom":
+					set_zoom_to_default();
+					break;
 
 			}
 		}


### PR DESCRIPTION
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
### Purpose
<!-- With a few sentences, describe why you decided to make these changes/additions. -->
- when zoomed out clicking purge would offset the popup offscreen, this forces zoom level to reset so it stays center.

### Describe your changes/additions
<!-- What your changes do and how. No need to get too technical. Some stuff from this list will also be used for the player release notes. -->
- Self-descriptive.

### What can/needs to be improved/changed
<!-- Is there anything that you think can/needs to be improved, or perhaps done using a different approach. -->
- this is a bandaid to the real problem of dynamically positioning the popup in the center of the screen.

### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- None, and I understand the risks.

### Related things and/or additional context
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, screenshots etc. -->
-  https://discord.com/channels/714022226810372107/1343946344091615263.

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->

<!--- "Inspired" by the CDDA PR template -->
