### PR TITLE
fix: Crusade crash (audience variable init)

### DIFF
--- a/objects/obj_crusade/Mouse_50.gml
+++ b/objects/obj_crusade/Mouse_50.gml
@@ -12,7 +12,11 @@ if (placing=true) and (cooldown<=0){
     if (instance_exists(obj_turn_end)){
         if (obj_turn_end.audience>0){
             with(obj_turn_end){
-                cooldown=8;diplomacy=0;alarm[1]=1;audience=0;force_goodbye=0;
+                cooldown=8;
+                diplomacy=0;
+                alarm[1]=1;
+                audience=0;
+                force_goodbye=0;
             }
         }
     }

--- a/objects/obj_turn_end/Create_0.gml
+++ b/objects/obj_turn_end/Create_0.gml
@@ -70,7 +70,8 @@ repeat(91){
     
 }
 
-audiences=0;
+audiences = 0;
+audience = 0;
 audien[0]=0;audien[1]=0;audien[2]=0;audien[3]=0;audien[4]=0;audien[5]=0;
 audien[6]=0;audien[7]=0;audien[8]=0;audien[9]=0;audien[10]=0;audien[11]=0;
 audien_topic[0]="";audien_topic[1]="";audien_topic[2]="";audien_topic[3]="";audien_topic[4]="";audien_topic[5]="";


### PR DESCRIPTION
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
### Purpose
<!-- With a few sentences, describe why you decided to make these changes/additions. -->
- Fix a crash.

### Describe your changes/additions
<!-- What your changes do and how. No need to get too technical. Some stuff from this list will also be used for the player release notes. -->
- Initialize the `audience` variable in the create event of `obj_turn_end`. Hopefully should prevent the crash.

### What can/needs to be improved/changed
<!-- Is there anything that you think can/needs to be improved, or perhaps done using a different approach. -->
- Nothing.

### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- None, and I understand the risks.

### Related things and/or additional context
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, screenshots etc. -->
- Bug report: https://discord.com/channels/714022226810372107/1377098248195670056
```
Error Details:
ERROR in action number 1
of Mouse Event for Glob Left Button for object obj_crusade:
Variable Get 91 (102053, -2147483648)

Stacktrace:
gml_Object_obj_crusade_Mouse_50 (line 13)
```

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->

<!--- "Inspired" by the CDDA PR template -->
