### PR TITLE
feat: EXP reward cap per unit

### DIFF
--- a/scripts/scr_after_combat/scr_after_combat.gml
+++ b/scripts/scr_after_combat/scr_after_combat.gml
@@ -109,14 +109,14 @@ function distribute_experience(_units, _total_exp) {
     var _unit_count = array_length(_units);
     var _exp_reward = 0;
     var _exp_reward_max = 5;
-    var _unit_exp_celling = 200;
+    var _unit_exp_ceiling = 200;
     var _exp_mod_min = 0.1;
 
     if (_unit_count > 0 && _total_exp > 0) {
         _exp_reward = min(_total_exp / _unit_count, _exp_reward_max);
         for (var i = 0; i < _unit_count; i++) {
             var _unit = _units[i];
-            var _exp_mod = max(1 - (_unit.experience / _unit_exp_celling), _exp_mod_min);
+            var _exp_mod = max(1 - (_unit.experience / _unit_exp_ceiling), _exp_mod_min);
             var _exp_update_data = _unit.add_exp(_exp_reward * _exp_mod);
 
             var _powers_learned = _exp_update_data[1];


### PR DESCRIPTION
### Purpose of changes
<!-- With a few sentences, describe your reasons for making these changes. -->
- Prevent excessive EXP rewards.
- Stop EXP farming with powerful units.
- Attempt to bring EXP values in line with the starting EXP allocation logic of exp ~= age.

### Describe the solution
<!-- How does the feature work, or how does this fix a bug? -->
- Cap unit EXP reward per battle at 5.
- Refactor the related code a little bit.

### Describe alternatives you've considered
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
None

### Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
None

### Related links
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
None

### Custom player notes entry
<!-- This will be added to the PR description in the release notes. List changes that players may be interested in, in simple words. -->
Use the PR title.

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->
<!--- "Inspired" by the CDDA PR template -->
