### PR TITLE
fix: Misaligned artifact data in librarium

### DIFF
--- a/scripts/DebugView/DebugView.gml
+++ b/scripts/DebugView/DebugView.gml
@@ -7,47 +7,75 @@
 /// @param {Id.Instance|Struct} obj The object being debugged. Can be a regular struct, an instance or a full object
 function DebugView(view_name, obj) constructor {
 
-    view_ptr = dbg_view(view_name, false); // calling dbg_view opens the overlay automatically 
-    obj_ref = obj;
-    name = view_name;
 
+    
+    
+
+    obj_ref = obj;
+    /// should stop adding duplicate controls if the view already exists
+    update = false;
+
+    if(struct_exists(obj_ref, view_name)){
+        if(dbg_view_exists(obj_ref[$view_name])){
+            view_ptr = obj_ref[$view_name];
+            update = true;
+        }
+    } else {
+        view_ptr = dbg_view(view_name, false); // calling dbg_view opens the overlay automatically 
+        variable_struct_set(obj_ref, view_name, view_ptr);
+    }
+
+    
+
+    name = view_name;
+    
     static add_watch = function (_name, _label = _name){
+        if(update) return self;
         dbg_watch(ref_create(self.obj_ref, _name), _label);
         return self;
     }
 
     static add_slider_int = function(_name, min, max, label = _name, step = 1){
+        if(update) return self;
         dbg_slider_int(ref_create(self.obj_ref, _name), min, max, label, step);
         return self;
     }
 
     static add_slider = function(_name, min, max, label = _name, step = 0.01){
+        if(update) return self;
         dbg_slider(ref_create(self.obj_ref, _name), min, max, label = name, step);
         return self;
     }
 
     static add_checkbox = function(_name, _label = _name){
+        if(update) return self;
         dbg_checkbox(ref_create(self.obj_ref, _name), _label);
         return self;
     }
 
     static add_button = function(_label, fn){
+        if(update) return self;
         dbg_button(_label, fn);
         return self;
     }
 
     static add_section = function(_name, _open = true) {
+        if(update) return self;
         dbg_section(_name, true);
         return self;
     }
 
     static show = function(){
+        if(update) return self;
         show_debug_overlay(true);
-        dbg_set_view(self.view_ptr)
+        if(struct_exists(self, "view_ptr")){
+            dbg_set_view(self.view_ptr)
+        }
         return self;
     }
 
     static hide = function(){
+        if(update) return self;
         show_debug_overlay(false);
         return self;
     }
@@ -57,8 +85,15 @@ function DebugView(view_name, obj) constructor {
         return self;
     }
 
+    static add_text = function(input, label){
+        
+        dbg_text($"{label}: {input}");
+        return self;
+    }
+
     /// quick and dirty way to display all variables of the given obj in a dbg section
     static dump_props = function(){
+        if(update) return self;
         dbg_section("Dump Props");
         var names = struct_get_names(self.obj_ref);
         for(var i = 0; i < array_length(names); i++){

--- a/scripts/scr_librarium/scr_librarium.gml
+++ b/scripts/scr_librarium/scr_librarium.gml
@@ -220,17 +220,17 @@ function scr_librarium(){
                         }                         
                     }
                 }
-                else if (obj_ini.artifact_identified[menu_artifact] < 1) {
+                else if (cur_arti.identified() < 1) {
                     draw_set_color(881503);
                     artif_descr = "";
                     try{
-                        artif_descr = obj_ini.artifact_struct[menu_artifact].description();
+                        artif_descr = cur_arti.description();
                     }   catch( _exception){
                         handle_exception(_exception);
                     }
                     tooltip = "";
                     tooltip_other = "";
-                    var arti_data = gear_weapon_data("any",obj_ini.artifact[menu_artifact], "all", false, obj_ini.artifact_quality[menu_artifact]);
+                    var arti_data = gear_weapon_data("any",cur_arti.type(), "all", false, cur_arti.quality());
 
                     var _can_equip = cur_arti.can_equip();
                     if (_can_equip){
@@ -347,13 +347,13 @@ function scr_librarium(){
                 if (obj_controller.artifacts>0){
                     for (var i = 1; i <= 20; i++) {
                         if (i <= 9 && i<array_length(capital_num)) {
-                            if (capital_num[i] = obj_ini.artifact_sid[obj_controller.menu_artifact] - 500) then good = 1;
+                            if (capital_num[i] = cur_arti.ship_id()) then good = 1;
                         }
                         if (i<array_length(frigate_num)){
-                            if (frigate_num[i] = obj_ini.artifact_sid[obj_controller.menu_artifact] - 500) then good = 1;
+                            if (frigate_num[i] = cur_arti.ship_id()) then good = 1;
                         }
                         if (i<array_length(escort_num)){
-                            if (escort_num[i] = obj_ini.artifact_sid[obj_controller.menu_artifact] - 500) then good = 1;
+                            if (escort_num[i] = cur_arti.ship_id()) then good = 1;
                         }
                     }
                 }
@@ -361,4 +361,7 @@ function scr_librarium(){
                 if (good = 2) then obj_controller.identifiable = 1;
             }
         }
+
+    
+
 }


### PR DESCRIPTION
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
## Purpose and Description
<!-- Explain why and what your changes do in simple terms. -->
- Fixes inconsistent references to 2d array aritfacts and the artifact struct in the librarium, causing stuff to get out of sync.
- This actually fixes save files, rather than breaking them for once

## Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- Used the save files referenced in the discord issue to reproduce and confirm fix

## Related things and/or additional context
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, screenshots etc. -->
- https://discord.com/channels/714022226810372107/1385736067012890624

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->

<!--- "Inspired" by the CDDA PR template -->
