### PR TITLE
fix: Add stockpiled Servo-arms for Sieged chapters

### DIFF
--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -3165,6 +3165,7 @@ function scr_initialize_custom() {
 		scr_add_item(wep2[defaults_slot,  eROLE.Apothecary], 4);
 		scr_add_item("Psychic Hood", 4);
 		scr_add_item("Crozius Arcanum", 4);
+		scr_add_item("Servo-arm", 4);
 		scr_add_item("Force Staff", 4);
 		scr_add_item("Plasma Pistol", 4);
 		scr_add_item("Company Standard", 4);


### PR DESCRIPTION
## Purpose and Description
Similarly to the #884 , the 4 servo arms, needed for techmarine duties, when `sieged` disadvantage is selected, are missing.
This pull request adds them.

## Testing done
- No testing was performed for such a simple fix.

## Related things and/or additional context
https://discord.com/channels/714022226810372107/1386621454682165349