### PR TITLE
feat: Don't destroy equipment with perils

### DIFF
--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -43,6 +43,15 @@ enum location_types {
 #macro ARR_psy_levels ["Rho", "Pi", "Omicron", "Xi", "Nu", "Mu", "Lambda", "Kappa", "Iota", "Theta", "Eta", "Zeta", "Epsilon", "Delta", "Gamma", "Beta", "Alpha", "Alpha Plus", "Beta", "Gamma Plus"]
 #macro ARR_negative_psy_levels ["Rho", "Sigma", "Tau", "Upsilon", "Phi", "Chi", "Psi", "Omega"]
 
+enum EquipmentArea {
+    ARMOUR,
+    WEAPON_ONE,
+    WEAPON_TWO,
+    GEAR,
+    MOBILITY,
+    ALL,
+}
+
 global.base_stats = {
     //tempory stats subject to change by anyone that wishes to try their luck
     "chapter_master": {
@@ -2327,6 +2336,72 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
         for (var i = 0; i < array_length(artifact_list); i++) {
             arti = obj_ini.artifact_struct[artifact_list[i]];
             arti.bearer = [end_company, end_slot];
+        }
+    };
+
+    /// @param {Enum.EquipmentArea} _slot
+    add_equipment_repairs = function(_slot = EquipmentArea.ALL) {
+        var _slots = array_create(0);
+
+        switch (_slot) {
+            case EquipmentArea.ARMOUR:
+                _slots = [EquipmentArea.ARMOUR];
+                break;
+            case EquipmentArea.WEAPON_ONE:
+                _slots = [EquipmentArea.WEAPON_ONE];
+                break;
+            case EquipmentArea.WEAPON_TWO:
+                _slots = [EquipmentArea.WEAPON_TWO];
+                break;
+            case EquipmentArea.GEAR:
+                _slots = [EquipmentArea.GEAR];
+                break;
+            case EquipmentArea.MOBILITY:
+                _slots = [EquipmentArea.MOBILITY];
+                break;
+            case EquipmentArea.ALL:
+                _slots = [EquipmentArea.ARMOUR, EquipmentArea.WEAPON_ONE, EquipmentArea.WEAPON_TWO, EquipmentArea.GEAR, EquipmentArea.MOBILITY];
+                break;
+        }
+
+        for (var i = 0; i < array_length(_slots); i++) {
+            var _cur_slot = _slots[i];
+            switch (_cur_slot) {
+                case EquipmentArea.ARMOUR:
+                    obj_controller.specialist_point_handler.add_to_armoury_repair(armour());
+                    if (instance_exists(obj_ncombat)) {
+                        obj_ncombat.slime += get_armour_data("maintenance");
+                    }
+                    break;
+
+                case EquipmentArea.WEAPON_ONE:
+                    obj_controller.specialist_point_handler.add_to_armoury_repair(weapon_one());
+                    if (instance_exists(obj_ncombat)) {
+                        obj_ncombat.slime += get_weapon_one_data("maintenance");
+                    }
+                    break;
+
+                case EquipmentArea.WEAPON_TWO:
+                    obj_controller.specialist_point_handler.add_to_armoury_repair(weapon_two());
+                    if (instance_exists(obj_ncombat)) {
+                        obj_ncombat.slime += get_weapon_two_data("maintenance");
+                    }
+                    break;
+
+                case EquipmentArea.GEAR:
+                    obj_controller.specialist_point_handler.add_to_armoury_repair(gear());
+                    if (instance_exists(obj_ncombat)) {
+                        obj_ncombat.slime += get_gear_data("maintenance");
+                    }
+                    break;
+
+                case EquipmentArea.MOBILITY:
+                    obj_controller.specialist_point_handler.add_to_armoury_repair(mobility_item());
+                    if (instance_exists(obj_ncombat)) {
+                        obj_ncombat.slime += get_mobility_data("maintenance");
+                    }
+                    break;
+            }
         }
     };
 }

--- a/scripts/scr_perils_table/scr_perils_table.gml
+++ b/scripts/scr_perils_table/scr_perils_table.gml
@@ -170,8 +170,8 @@ function scr_perils_table(perils_strength, unit, psy_discipline, power_name, uni
 						}
 					}
 				}
-				unit.alter_equipment({wep1: "", wep2: "", armour: "", gear: "", mobi: ""}, false, false);
-				var flavour_text2 = "A massive shockwave eminates from the marine, who is knocked out cold!  All of his equipment is destroyed!";
+				unit.add_equipment_repairs(EquipmentArea.ALL);
+				var flavour_text2 = "A massive shockwave eminates from the marine, who is knocked out cold!  All of his equipment is damaged!";
 				return flavour_text2;
 			}
 		],


### PR DESCRIPTION
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
## Purpose and Description
<!-- Explain why and what your changes do in simple terms. -->
- Equipment destruction on some perils is pain, both economically and in terms of micro. Now it'll require repairs instead, just like slime.

## Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- Forced these perils to spawn and ensured that they at least don't crash the game.

## Related things and/or additional context
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, screenshots etc. -->
- https://discord.com/channels/714022226810372107/1272865272159535114/1396226833569022085

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->

<!--- "Inspired" by the CDDA PR template -->
