### PR TITLE
fix: Combat Log

### DIFF
--- a/scripts/scr_flavor2/scr_flavor2.gml
+++ b/scripts/scr_flavor2/scr_flavor2.gml
@@ -260,13 +260,13 @@ function scr_flavor2(lost_units_count, target_type, hostile_range, hostile_weapo
 		flavor = true;
 		if (_hostile_shots == 1) {
 			if (lost_units_count == 0) {
-				m1 += $"{_hostile_weapon} strikes at {target_type}, but fails to inflict any damage.";
+				m1 += $"{_hostile_weapon} strikes at {target_type}, no casualties.";
 			} else {
 				m1 += $"{_hostile_weapon} strikes at {target_type}. ";
 			}
 		} else {
 			if (lost_units_count == 0) {
-				m1 += $"{_hostile_shots} {_hostile_weapon}s strike at {target_type}, but fail to inflict any damage.";
+				m1 += $"{_hostile_shots} {_hostile_weapon}s strike at {target_type}, no casualties.";
 			} else {
 				m1 += $"{_hostile_shots} {_hostile_weapon}s strike at {target_type}. ";
 			}


### PR DESCRIPTION
## Purpose and Description
Fixes misleading statements about no damage - damage is dealt, and marine/hireling/vehicle(?) will lose hit points. It now should state if marine/hireling/vehicle(?) is downed (no longer an active combatant) or not.

## Testing done
- None, as it is a small and contained flavor text tweak.

## Related things and/or additional context
https://discord.com/channels/714022226810372107/1398987282463068270 - bug report.