### PR TITLE
fix: Bolter Burden values

### DIFF
--- a/scripts/scr_weapon/scr_weapon.gml
+++ b/scripts/scr_weapon/scr_weapon.gml
@@ -1032,8 +1032,8 @@ global.weapons = {
 			"artifact": 60
 		},
 		"description": "A standard Bolter, a two-handed firearm that launches rocket propelled projectiles that detonate after penetrating the target. It is a versatile and iconic weapon of Adeptus Astartes, their resounding detonations carry the Emperor's Wrath.",
-		"melee_hands": 0.6,
-		"ranged_hands": 1.6,
+        "melee_hands": 0.6,
+        "ranged_hands": 1.7,
 		"ammo": 16,
 		"range": 12,
 		"spli": 3,


### PR DESCRIPTION
## Purpose and Description
Odd burden values have been a source of frustration and confusion. The mainstay bolter was suffering from this issue.
Reduction of burden values from 2 to 1.6 and 1 to 0.6 should ensure that bolter is the mainstay weapon, that at least has some merit, instead of "to be replaced by heavy bolter".

## Testing done
- Considering the size of the change, no testing should be required.

## Related things and/or additional context
- Recent discussion in Chapter Master discord should be the clue to it.


Slightly reduces the burden of the regular bolters.