### PR TITLE
ci: Hopefuly repair the auto-build commit exclude pattern

### DIFF
--- a/.github/workflows/release_dev.yml
+++ b/.github/workflows/release_dev.yml
@@ -68,7 +68,7 @@ jobs:
           echo "New commits found in range '$RANGE'. Checking their messages."
 
           # collect all commit messages in range
-          ALL_MSGS=$(git log $RANGE --pretty=%B)
+          ALL_MSGS=$(git log $RANGE --pretty=%s)
           echo "Messages in range:"
           # Use sed to indent messages for clarity in logs
           echo "$ALL_MSGS" | sed 's/^/  /'


### PR DESCRIPTION
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
## Purpose and Description
<!-- Explain why and what your changes do in simple terms. -->
- Currently the exclude check uses %B to retrieve commit text for exclude pattern, this causes the check to pass if the commit has any body, aside from the title. (because body never has any tags, hence always passes the 'no exluded tags check')
- Now I replace it with %s.
- %B outputs the full commit message (title + body + metadata).
- %s outputs just the commit title (the subject line).

## Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- None, and I understand the risks.

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->

<!--- "Inspired" by the CDDA PR template -->
