### PR TITLE
fixed left and right pauldrons in bulk paint

### DIFF
--- a/scripts/scr_creation/scr_creation.gml
+++ b/scripts/scr_creation/scr_creation.gml
@@ -100,13 +100,13 @@ function bulk_selection_buttons_setup(){
             cords : [500, 322],
         },
         {
-            text : $"Pauldron 1: {col[right_pauldron]}",
+            text : $"Pauldron 1: {col[left_pauldron]}",
             tooltip:"First Pauldron",
             tooltip2:"The color of your Astartes' left Pauldron.  Normally this Pauldron displays their rank and designation.",
             cords : [500, 357],
         },
         {
-            text : $"Pauldron 2: {col[left_pauldron]}",
+            text : $"Pauldron 2: {col[right_pauldron]}",
             tooltip:"Second Pauldron",
             tooltip2:"The color of your Astartes' right Pauldron.  Normally this Pauldron contains the Chapter Insignia.",
             cords : [500, 392],


### PR DESCRIPTION
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
## Purpose and Description
<!-- Explain why and what your changes do in simple terms. -->
- left and right pauldrons were swapped.  clicking on left pauldron switched the right. and vice versa.  Fixed.

## Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- None, and I understand the risks.

## Related things and/or additional context
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, screenshots etc. -->
-

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->

<!--- "Inspired" by the CDDA PR template -->
