### PR TITLE
feat: waaagh trigger rework.

### DIFF
--- a/scripts/scr_ork_fleet_functions/scr_ork_fleet_functions.gml
+++ b/scripts/scr_ork_fleet_functions/scr_ork_fleet_functions.gml
@@ -168,37 +168,30 @@ function merge_ork_fleets(){
     }
 }
 
-function init_ork_waagh(override=false) {
-var waaagh = irandom(300);
-var waaagh_1 = irandom(3);
-var _ork_stars = scr_get_stars(false, [eFACTION.Ork]);
-var _ork_stars_count = array_length(_ork_stars);
-//
-if ((_ork_stars_count > 45) &&  (waaagh_1 == 3 || overide ) && obj_controller.known[eFACTION.Ork]==0)
-{
-scr_popup("WAAAAGH!","The greenskins have gone unchallenged for far too long. A towering Warboss has rallied the ork hordes and halted their infighting. Now unified, the greenskins pose a dire threat to the entire sector!","waaagh","");
-        scr_event_log("red","Ork WAAAAGH! begins");
-        obj_controller.known[eFACTION.Ork]=0.5;	
-}
-else if ((_ork_stars_count = 5) && (waaagh_1 == 3 || overide) && obj_controller.known[eFACTION.Ork]==0)
-{
-scr_popup("WAAAAGH!","The orks are nearly defeated, but in a final desperate push, a new Warboss has mustered a fresh WAAAGH! and begun reclaiming their lost worlds.","waaagh","");
-        scr_event_log("red","Ork WAAAAGH! begins.");
-        obj_controller.known[eFACTION.Ork]=0.5;	
-}
-else if ((_ork_stars_count >= 5 && _ork_stars_count <= 45) && (waaagh==33 || overide) && obj_controller.known[eFACTION.Ork]==0)
-{
+function init_ork_waagh(override = false) {
+    var waaagh = irandom(300);
+    var waaagh_1 = irandom(3);
+    var _ork_stars = scr_get_stars(false, [eFACTION.Ork]);
+    var _ork_stars_count = array_length(_ork_stars);
 
-	scr_popup("WAAAAGH!","The greenskins have swelled in activity, their numbers increasing seemingly without relent.  A massive Warboss has risen to take control, leading most of the sector's Orks on a massive WAAAGH!","waaagh","");
-        scr_event_log("red","Ork WAAAAGH! begins.");
-        obj_controller.known[eFACTION.Ork]=0.5;	
-}
-else
-{
-	//if no waaagh is triggered
-	return;
-}
-var ork_waagh_activity = [];
+    if ((_ork_stars_count > 45) &&  (waaagh_1 == 3 || override ) && obj_controller.known[eFACTION.Ork] == 0) {
+        scr_popup("WAAAAGH!", "The greenskins have gone unchallenged for far too long. A towering Warboss has rallied the ork hordes and halted their infighting. Now unified, the greenskins pose a dire threat to the entire sector!", "waaagh", "");
+        scr_event_log("red", "Ork WAAAAGH! begins");
+        obj_controller.known[eFACTION.Ork] = 0.5;
+    } else if ((_ork_stars_count > 0 && _ork_stars_count <= 5) && (waaagh_1 == 3 || override) && obj_controller.known[eFACTION.Ork] == 0) {
+        scr_popup("WAAAAGH!", "The orks are nearly defeated, but in a final desperate push, a new Warboss has mustered a fresh WAAAGH! and begun reclaiming their lost worlds.", "waaagh", "");
+        scr_event_log("red", "Ork WAAAAGH! begins.");
+        obj_controller.known[eFACTION.Ork] = 0.5;
+    } else if ((_ork_stars_count >= 5 && _ork_stars_count <= 45) && (waaagh == 33 || override) && obj_controller.known[eFACTION.Ork] == 0) {
+        scr_popup("WAAAAGH!", "The greenskins have swelled in activity, their numbers increasing seemingly without relent.  A massive Warboss has risen to take control, leading most of the sector's Orks on a massive WAAAGH!", "waaagh", "");
+        scr_event_log("red", "Ork WAAAAGH! begins.");
+        obj_controller.known[eFACTION.Ork] = 0.5;
+    } else {
+        //if no waaagh is triggered
+        return;
+    }
+
+    var ork_waagh_activity = [];
         var _any_ork_star = [];
         for (var p=0;p<array_length(_ork_stars);p++){
             with(_ork_stars[p]){
@@ -228,27 +221,27 @@ var ork_waagh_activity = [];
             _waaagh_star_found = true;
         }
 
-        if (_waaagh_star_found){
-            var _pdata = new PlanetData(_waaagh_star[1], _waaagh_star[0]);
- 
-            var _boss = _pdata.add_feature(P_features.OrkWarboss);
-            if (overide){
-                _boss.player_hidden = false;
-                scr_event_log("red",$"boss on {_pdata.name()}", _pdata.system.name);
-            }
+    if (_waaagh_star_found){
+        var _pdata = new PlanetData(_waaagh_star[1], _waaagh_star[0]);
 
-            if (_pdata.planet_forces[eFACTION.Ork] < 4) {
-                _pdata.add_forces(eFACTION.Ork, 2);
-            }
-        } else {
-            out_of_system_warboss(true);
+        var _boss = _pdata.add_feature(P_features.OrkWarboss);
+        if (override) {
+            _boss.player_hidden = false;
+            scr_event_log("red", $"boss on {_pdata.name()}", _pdata.system.name);
         }
-		if (_waaagh_star_found){
-		scr_popup("WAAAAGH!","My lord, our Auspex scans indicate that the Ork Warboss is currently within the "+string(_pdata.system.name)+" system.We must strike swiftly before he relocates. ","waaagh","");
-    	 scr_event_log("red",$"boss on {_pdata.name()}", _pdata.system.name);
-		}
-	
+
+        if (_pdata.planet_forces[eFACTION.Ork] < 4) {
+            _pdata.add_forces(eFACTION.Ork, 2);
+        }
+    } else {
+        out_of_system_warboss(true);
     }
+
+    if (_waaagh_star_found) {
+        scr_popup("WAAAAGH!","My lord, our Auspex scans indicate that the Ork Warboss is currently within the "+string(_pdata.system.name)+" system.We must strike swiftly before he relocates. ","waaagh","");
+        scr_event_log("red",$"boss on {_pdata.name()}", _pdata.system.name);
+    }
+}
 
 
 function out_of_system_warboss(overide = false){


### PR DESCRIPTION
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
## Purpose and Description
<!-- Explain why and what your changes do in simple terms. -->
- Changing condition that trigger Waaagh!:
- If okrs have more than 45 or  less than 5 worlds chance for waaagh to trigger is 25% every turn.
- If none above is true, there is slim random chance that waaagh will triger 0,33% every turn.
- If waaagh is triggered there player would be notifed where warboss spawned to avoid having to hover over any system to see which one has two question marks.
-
## Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- None, and I understand the risks.

## Related things and/or additional context
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, screenshots etc. -->
-

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->

<!--- "Inspired" by the CDDA PR template -->
