### PR TITLE
Merge development branch into main

### DIFF
--- a/scripts/scr_dialogue/scr_dialogue.gml
+++ b/scripts/scr_dialogue/scr_dialogue.gml
@@ -33,15 +33,6 @@ function interpret_diag_string(string_data, data) {
                 return interpret_diag_string(_string, data);
             }
         }
-
-        // Override dialogue (new!)
-        if (struct_exists(string_data, "override")) {
-            // check if a matching override key exists in `data`
-            var override_key = data.override_condition;
-            if (string_exists(string_data.override, override_key)) {
-                return string_interpolate_from_struct(string_data.override[$ override_key], data);
-            }
-        }
     }
 
     return _string;

--- a/scripts/scr_dialogue/scr_dialogue.gml
+++ b/scripts/scr_dialogue/scr_dialogue.gml
@@ -55,16 +55,7 @@ function scr_dialogue(diplo_keyphrase, data = {}) {
         // diplo_keyphrase = keyphrase
 
         clear_diplo_choices();
-        if (diplomacy == -1) {
-            if (is_struct(character_diplomacy)) {
-                if (_unit.role == "Forge Master") {
-                    if (diplo_keyphrase == "intro") {
-                        diplo_text = "Chapter Master. What may ";
-                        iplomacy_option({option_text: "The Imperium and Inquisition's ignorance and hypocrisy will be the death of my Chapter.", goto: _goto});
-                    }
-                }
-            }
-        }
+
         var event_log = "";
         var rando = 0, tempd = "", sorc = false;
         var rela, trade_msg;

--- a/scripts/scr_event_code/scr_event_code.gml
+++ b/scripts/scr_event_code/scr_event_code.gml
@@ -439,7 +439,8 @@ function make_faction_enemy_event() {
 
 function event_dispose_of_mutated_gene() {
     if (pop_data.percent_remove > 0) {
-        obj_controller.gene_seed -= round(obj_controller.gene_seed * (pop_data.percent_remove / 100));
+        var _removal_amount = ceil(obj_controller.gene_seed * (pop_data.percent_remove / 100));
+        obj_controller.gene_seed -= _removal_amount;
     }
     popup_default_close();
 }

--- a/scripts/scr_event_code/scr_event_code.gml
+++ b/scripts/scr_event_code/scr_event_code.gml
@@ -439,7 +439,7 @@ function make_faction_enemy_event() {
 
 function event_dispose_of_mutated_gene() {
     if (pop_data.percent_remove > 0) {
-        obj_controller.gene_seed -= obj_controller.gene_seed * (pop_data.percent_remove / 100);
+        obj_controller.gene_seed -= round(obj_controller.gene_seed * (pop_data.percent_remove / 100));
     }
     popup_default_close();
 }


### PR DESCRIPTION
## Developer Notes

- Removed override dialogue handling from `interpret_diag_string` function (never worked)
- Removed diplomacy special-case logic that triggered custom dialogue and options when `diplomacy == -1`, player role was `"Forge Master"`, and `diplo_keyphrase == "intro"` (was overwritten; did nothing)
- Modified `event_dispose_of_mutated_gene` to apply rounding to gene seed delta calculations, ensuring integer adjustments rather than floating-point values

## Player Notes

- Gene seed mutations are now adjusted using rounded values, potentially changing the granularity of mutation removal calculations