### PR TITLE
fix: missing scope for dropping variable

### DIFF
--- a/scripts/scr_after_combat/scr_after_combat.gml
+++ b/scripts/scr_after_combat/scr_after_combat.gml
@@ -154,7 +154,7 @@ function check_for_plasma_bomb_and_tomb(unit) {
     var _necron_strength = _star.p_necrons[_planet];
     if (unit.gear() == "Plasma Bomb" && !string_count("mech_tomb2", obj_ncombat.battle_special)) {
         if (obj_ncombat.enemy == eFACTION.NECRONS && awake_tomb_world(_star.p_feature[_planet])) {
-            if (((_necron_strength - 2) < 3 && dropping) || (_necron_strength - 1) < 3) {
+            if (((_necron_strength - 2) < 3 && obj_ncombat.dropping) || (_necron_strength - 1) < 3) {
                 obj_ncombat.plasma_bomb += 1;
                 unit.update_gear("", false, false);
             }


### PR DESCRIPTION
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
## Purpose and Description
- missing scope for booleon dropping causing crash with necroon tomb shite

## Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- None, and I understand the risks.

## Related things and/or additional context
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, screenshots etc. -->
-

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->

<!--- "Inspired" by the CDDA PR template -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Developer Notes
- Fixed variable scope in the `check_for_plasma_bomb_and_tomb()` function within `scripts/scr_after_combat/scr_after_combat.gml`
- Replaced unscoped `dropping` identifier with the properly scoped `obj_ncombat.dropping` in the Plasma Bomb eligibility conditional

## Player Notes
- Fixed crash occurring in Necron Tomb scenarios when units with Plasma Bombs are involved
- Plasma Bomb drop eligibility check now correctly evaluates the battle's dropping status rather than an undefined variable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->