### PR TITLE
fix: planet_numeral_name typo

### DIFF
--- a/scripts/scr_event_code/scr_event_code.gml
+++ b/scripts/scr_event_code/scr_event_code.gml
@@ -53,7 +53,7 @@ function event_end_turn_action() {
                 var _planet = _event.planet;
                 if (_event_star != "none") {
                     _event_star.dispo[_planet] = -10; // Resets
-                    var twix = $"Inquisition executes Chapter Serf in control of {pllanet_numera_name(planet, _event_star)} and installs a new Planetary Governor.";
+                    var twix = $"Inquisition executes Chapter Serf in control of {planet_numeral_name(_planet, _event_star)} and installs a new Planetary Governor.";
                     if (_event_star.p_owner[_planet] == eFACTION.PLAYER) {
                         _event_star.p_owner[_planet] = _event_star.p_first[_planet];
                     }


### PR DESCRIPTION
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
## Purpose and Description
- planet_numeral_name typo causing serf swap crash

## Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- None, and I understand the risks.

## Related things and/or additional context
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, screenshots etc. -->
-

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->

<!--- "Inspired" by the CDDA PR template -->
