### PR TITLE
feat: more adjustable inquisitor inspection times

### DIFF
--- a/datafiles/main/chapter_advantages.json
+++ b/datafiles/main/chapter_advantages.json
@@ -125,7 +125,8 @@
         "faction": 5,
         "start_disp": -4
       }
-    ]
+    ],
+    "suspicion" : 1,
   },
   {
     "name": "Favoured By The Warp",
@@ -136,7 +137,8 @@
         "faction": 4,
         "mult": 0.5
       }
-    ]
+    ],
+    "suspicion" : -1,
   },
   {
     "name": "Reverent Guardians",
@@ -148,7 +150,8 @@
         "faction": 5,
         "int_mod": 2
       }
-    ]
+    ],
+    "suspicion" : -1,
   },
   {
     "name": "Tech-Brothers",
@@ -227,26 +230,29 @@
     "name": "Elite Guard",
     "description": "Your chapter is an elite fighting force comprised almost exclusively of Veterans. All Tactical Marines are replaced by Veterans.",
     "points": 150,
-    "meta": ["Specialists"]
+    "meta": ["Specialists"],
+    "suspicion" : -1,
   },
   {
     "name": "Great Luck",
     "description": "This is actually really helpful and beneficial for your chapter. Trust me.",
     "points": 20,
-    "meta": ["Luck"]
+    "meta": ["Luck"],
+    "suspicion" : -2,
   },
   {
     "name": "Inquisitorial Mandate",
     "description": "Your Chapter performs some service to the inquisition that is of some specific value or mandate of the inquisition",
     "effects": "You will recieve less frequent inspections from the inquisition and actions that may not align with the inquisition will cause less aggressive losses of disposition with the Inquisition",
     "meta": ["Imperium Trust"],
-    "points": 50,
+    "points": 30,
     "faction_disp_mods": [
       {
         "faction": 4,
         "int_mod": 3,
         "start_disp": 20
-      }
-    ]
+      },
+    ],
+    "suspicion" : -2,
   }
 ]

--- a/datafiles/main/chapter_disadvantages.json
+++ b/datafiles/main/chapter_disadvantages.json
@@ -23,13 +23,15 @@
   {
     "name": "Never Forgive",
     "description": "In the past traitors broke off from your chapter. They harbor incriminating secrets or heritical beliefs, and as thus, must be hunted down whenever possible.",
-    "points": 20
+    "points": 20,
+    "suspicion" : 1,
   },
   {
     "name": "Shitty Luck",
     "description": "This is actually really bad for your chapter. Trust me.",
     "points": 20,
-    "meta": ["Luck"]
+    "meta": ["Luck"],
+    "suspicion" : 1,
   },
   {
     "name": "Sieged",
@@ -60,7 +62,8 @@
         "start_disp": -15,
         "int_mod": -2
       }
-    ]
+    ],
+    "suspicion" : 4,
   },
   {
     "name": "Tech-Heresy",
@@ -77,7 +80,8 @@
         "mult": 0.5,
         "start_disp": -8
       }
-    ]
+    ],
+    "suspicion" : 1,
   },
   {
     "name": "Tolerant",
@@ -109,7 +113,8 @@
         "faction": 5,
         "start_disp": -5
       }
-    ]
+    ],
+    "suspicion" : 2,
   },
   {
     "name": "Warp Tainted",
@@ -132,7 +137,8 @@
         "faction": 5,
         "start_disp": -10
       }
-    ]
+    ],
+    "suspicion" : 2,
   },
   {
     "name": "Psyker Intolerant",
@@ -149,7 +155,8 @@
         "faction": 5,
         "start_disp": 5
       }
-    ]
+    ],
+    "suspicion" : -2,
   },
   {
     "name": "Obliterated",
@@ -173,7 +180,8 @@
     "name": "Serpents Delight",
     "description": "Sleeper cells infiltrated your chapter. When they rose up for the decapitation strike, they slew the 5 most experienced company's and many of the HQ staff before being defeated",
     "points": 50,
-    "meta": ["Status"]
+    "meta": ["Status"],
+    "suspicion" : 1,
   },
   {
     "name": "Weakened Apothecarion",
@@ -191,12 +199,14 @@
         "faction": 5,
         "int_mod": -2
       }
-    ]
+    ],
+    "suspicion" : 1,
   },
   {
     "name": "Barren Librarius",
     "description": "Your chapter has a smaller Librarius compared to other chapters due to having fewer potent psykers.",
     "points": 20,
-    "meta": ["Psyker Views", "Librarians"]
+    "meta": ["Psyker Views", "Librarians"],
+    "suspicion" : -1,
   }
 ]

--- a/objects/obj_controller/Alarm_5.gml
+++ b/objects/obj_controller/Alarm_5.gml
@@ -506,58 +506,7 @@ try {
     if (marines >= 1050) {
         scr_loyalty("Non-Codex Size", "+");
     }
-
-    var last_inquisitor_inspection = 0;
-    if (obj_ini.fleet_type == ePLAYER_BASE.HOME_WORLD) {
-        last_inquisitor_inspection = last_world_inspection;
-    }
-    if (obj_ini.fleet_type != ePLAYER_BASE.HOME_WORLD) {
-        last_inquisitor_inspection = last_fleet_inspection;
-    }
-
-    var inspec = false;
-    if ((loyalty >= 85) && ((last_inquisitor_inspection + 59) < turn)) {
-        inspec = true;
-    }
-    if ((loyalty >= 70) && (loyalty < 85) && ((last_inquisitor_inspection + 47) < turn)) {
-        inspec = true;
-    }
-    if ((loyalty >= 50) && (loyalty < 70) && ((last_inquisitor_inspection + 35) < turn)) {
-        inspec = true;
-    }
-    if ((loyalty < 50) && ((last_inquisitor_inspection + 11 + choose(1, 2, 3, 4)) < turn)) {
-        inspec = true;
-    }
-
-    if (obj_ini.fleet_type != ePLAYER_BASE.HOME_WORLD) {
-        if ((instance_number(obj_p_fleet) == 1) && (obj_ini.fleet_type == ePLAYER_BASE.HOME_WORLD)) {
-            // Might be crusading, right?
-            if ((obj_p_fleet.x < 0) || (obj_p_fleet.x > room_width) || (obj_p_fleet.y < 0) || (obj_p_fleet.y > room_height)) {
-                inspec = false;
-            }
-        }
-        if (instance_number(obj_p_fleet) == 0) {
-            inspec = false;
-        }
-    }
-    instance_activate_object(obj_p_fleet);
-
-    //setup inquisitor inspections
-    var inquisitor_fleet_count = 0;
-    with (obj_fleet) {
-        if (owner == eFACTION.INQUISITION) {
-            inquisitor_fleet_count++;
-        }
-    }
-
-    inspec = inspec && faction_status[eFACTION.INQUISITION] != "War" && inquisitor_fleet_count == 0;
-    if (inspec) {
-        new_inquisitor_inspection();
-    }
-
-    with (obj_temp6) {
-        instance_destroy();
-    }
+    check_for_next_inquisitor_inspection();
 
     for (var i = 1; i <= 10; i++) {
         if ((turns_ignored[i] == 0) && (annoyed[i] > 0)) {

--- a/objects/obj_controller/Create_0.gml
+++ b/objects/obj_controller/Create_0.gml
@@ -648,8 +648,7 @@ turn = 1;
 last_event = 0;
 last_mission = 0;
 // ** Inquisition inspection **
-last_world_inspection = 0; // Duhuhu
-last_fleet_inspection = 0;
+last_inquisitor_inspection = 0; // Duhuhu
 
 // chaos_turn=100+((floor(random(10))+1)*choose(-1,1));
 // ** Sets when chaos will arrive **

--- a/objects/obj_fleet/Alarm_7.gml
+++ b/objects/obj_fleet/Alarm_7.gml
@@ -167,13 +167,13 @@ try {
     if (killer > 0) {
         scr_loyalty("Inquisitor Killer", "+");
         if (obj_controller.loyalty >= 85) {
-            obj_controller.last_world_inspection -= 44;
+            obj_controller.last_inquisitor_inspection -= 44;
         }
         if ((obj_controller.loyalty >= 70) && (obj_controller.loyalty < 85)) {
-            obj_controller.last_world_inspection -= 32;
+            obj_controller.last_inquisitor_inspection -= 32;
         }
         if ((obj_controller.loyalty >= 50) && (obj_controller.loyalty < 70)) {
-            obj_controller.last_world_inspection -= 20;
+            obj_controller.last_inquisitor_inspection -= 20;
         }
         if (obj_controller.loyalty < 50) {
             scr_loyalty("Inquisitor Killer", "+");

--- a/objects/obj_ncombat/Alarm_5.gml
+++ b/objects/obj_ncombat/Alarm_5.gml
@@ -767,13 +767,13 @@ if (obj_ini.omophagea) {
                     scr_loyalty("Inquisitor Killer", "+");
                 }
                 if (obj_controller.loyalty >= 85) {
-                    obj_controller.last_world_inspection -= 44;
+                    obj_controller.last_inquisitor_inspection -= 44;
                 }
                 if ((obj_controller.loyalty >= 70) && (obj_controller.loyalty < 85)) {
-                    obj_controller.last_world_inspection -= 32;
+                    obj_controller.last_inquisitor_inspection -= 32;
                 }
                 if ((obj_controller.loyalty >= 50) && (obj_controller.loyalty < 70)) {
-                    obj_controller.last_world_inspection -= 20;
+                    obj_controller.last_inquisitor_inspection -= 20;
                 }
                 if (obj_controller.loyalty < 50) {
                     scr_loyalty("Inquisitor Killer", "+");

--- a/scripts/scr_ChapterTraits/scr_ChapterTraits.gml
+++ b/scripts/scr_ChapterTraits/scr_ChapterTraits.gml
@@ -2,8 +2,11 @@ function ChapterTrait(trait) constructor {
     effects = "";
     meta = [];
     faction_disp_mods = [];
-    move_data_to_current_scope(trait);
+    suspicion = 0;
+
     disabled = false;
+
+    move_data_to_current_scope(trait);
 
     static effects_string = function(){
 
@@ -78,6 +81,10 @@ function ChapterTrait(trait) constructor {
             _str += effects[i] + "\n";
         }
 
+        if (suspicion != 0){
+            _str += $"Suspicion: { string_plus_minus(suspicion) }\n";
+        }
+
         return _str;
     }
 
@@ -85,7 +92,7 @@ function ChapterTrait(trait) constructor {
         return $"{name} ({points})";
     }
     static data_tool_tip = function(){
-        return $"{description} \nCategories: {print_meta()}\n\nEffects: {effects_string()}";
+        return $"{description} \nCategories: {print_meta()}\n\nEffects:\n{effects_string()}";
     }
 
     static alter_starting_dispositions = function(){

--- a/scripts/scr_ChapterTraits/scr_ChapterTraits.gml
+++ b/scripts/scr_ChapterTraits/scr_ChapterTraits.gml
@@ -253,6 +253,8 @@ function setup_chapter_traits(){
 // please also take into account 
 function ChapterGameData (data = {}) constructor{
 
+    chapter_suspicion = 0;
+
     faction_disp_mods = array_create(14, {
         "int_mod" : 0,
         "mult" : 1
@@ -320,6 +322,10 @@ function ChapterGameData (data = {}) constructor{
                     array_push(_current_tag_data[$ _char], _entry);
                 }
             }
+        }
+
+        if (struct_exists(trait, suspicion)){
+            chapter_suspicion = clamp(chapter_suspicion + trait.suspicion, -5, 5);
         }
 
     }

--- a/scripts/scr_ChapterTraits/scr_ChapterTraits.gml
+++ b/scripts/scr_ChapterTraits/scr_ChapterTraits.gml
@@ -331,7 +331,7 @@ function ChapterGameData (data = {}) constructor{
             }
         }
 
-        if (struct_exists(trait, suspicion)){
+        if (struct_exists(trait, "suspicion")){
             chapter_suspicion = clamp(chapter_suspicion + trait.suspicion, -5, 5);
         }
 

--- a/scripts/scr_ChapterTraits/scr_ChapterTraits.gml
+++ b/scripts/scr_ChapterTraits/scr_ChapterTraits.gml
@@ -82,7 +82,7 @@ function ChapterTrait(trait) constructor {
         }
 
         if (suspicion != 0){
-            _str += $"Suspicion: { string_plus_minus(suspicion) }\n";
+            _str += $"Suspicion: { string_plus_minus(suspicion) }{suspicion}\n";
         }
 
         return _str;

--- a/scripts/scr_after_combat/scr_after_combat.gml
+++ b/scripts/scr_after_combat/scr_after_combat.gml
@@ -92,7 +92,6 @@ function add_vehicles_to_recovery() {
         }
     }
 }
-
 /// @mixin
 function assemble_alive_units() {
     for (var i = 0; i < array_length(unit_struct); i++) {

--- a/scripts/scr_creation_draw_slides/scr_creation_draw_slides.gml
+++ b/scripts/scr_creation_draw_slides/scr_creation_draw_slides.gml
@@ -617,7 +617,7 @@ function draw_chapter_trait_select() {
         adv_txt.y2 = adv_txt.y1 + adv_txt.h;
         var max_advantage_count = 8;
         for (i = 1; i <= max_advantage_count; i++) {
-            if (adv_num[i] > array_length(obj_creation.all_advantages)){
+            if (adv_num[i] >= array_length(obj_creation.all_advantages)){
                 adv_num[i] = 0;
             }
             var draw_string = adv_num[i] == 0 ? "[+]" : "[-] " + adv[i];
@@ -668,6 +668,9 @@ function draw_chapter_trait_select() {
 
         var max_disadvantage_count = 8;
         for (var slot = 1; slot <= max_disadvantage_count; slot++) {
+            if (dis_num[i] >= array_length(obj_creation.all_disadvantages)){
+                dis_num[i] = 0;
+            }
             var draw_string = dis_num[slot] == 0 ? "[+]" : "[-] " + dis[slot];
             draw_text(dis_txt.x1, dis_txt.y1 + (slot * dis_txt.h), draw_string);
             if (scr_hit(dis_txt.x1, dis_txt.y1 + (slot * dis_txt.h), dis_txt.x2, dis_txt.y2 + (slot * dis_txt.h))) {

--- a/scripts/scr_creation_draw_slides/scr_creation_draw_slides.gml
+++ b/scripts/scr_creation_draw_slides/scr_creation_draw_slides.gml
@@ -615,7 +615,7 @@ function draw_chapter_trait_select() {
         };
         adv_txt.x2 = adv_txt.x1 + adv_txt.w;
         adv_txt.y2 = adv_txt.y1 + adv_txt.h;
-        var max_advantage_count = 8;
+        var max_advantage_count = min(8, array_length(adv_num) - 1);
         for (i = 1; i <= max_advantage_count; i++) {
             if (adv_num[i] >= array_length(obj_creation.all_advantages)){
                 adv_num[i] = 0;
@@ -666,10 +666,10 @@ function draw_chapter_trait_select() {
         dis_txt.x2 = dis_txt.x1 + dis_txt.w;
         dis_txt.y2 = dis_txt.y1 + dis_txt.h;
 
-        var max_disadvantage_count = 8;
+        var max_disadvantage_count = min(8, array_length(dis_num) - 1);
         for (var slot = 1; slot <= max_disadvantage_count; slot++) {
-            if (dis_num[i] >= array_length(obj_creation.all_disadvantages)){
-                dis_num[i] = 0;
+            if (dis_num[slot] >= array_length(obj_creation.all_disadvantages)){
+                dis_num[slot] = 0;
             }
             var draw_string = dis_num[slot] == 0 ? "[+]" : "[-] " + dis[slot];
             draw_text(dis_txt.x1, dis_txt.y1 + (slot * dis_txt.h), draw_string);

--- a/scripts/scr_demand/scr_demand.gml
+++ b/scripts/scr_demand/scr_demand.gml
@@ -19,8 +19,7 @@ function clear_inspections() {
 function inquis_use_inspection_pass() {
     if (inspection_passes > 0) {
         inspection_passes -= 1;
-        last_world_inspection = turn + 25;
-        last_fleet_inspection = turn + 25;
+        last_inquisitor_inspection = turn + 25;
         //obj_controller.liscensing=5;
         clear_inspections();
         diplo_text = "Very well i shall honour our previous agreements. (24 months leave of inspections)";
@@ -36,8 +35,7 @@ function inquis_demand_inspection_pass() {
         rull = floor(random(10)) + 1;
         if (rull > resistance) {
             _worked = true;
-            last_world_inspection = turn + 24;
-            last_fleet_inspection = turn + 24;
+            last_inquisitor_inspection = turn + 24;
             //obj_controller.liscensing=5;
             clear_inspections();
             diplo_text = "Very well Chapter Master I Your service to the imperium is well known i have no doubt that you would not ask such of me without good reasoon. I shall forgoe my normal duties just this onece. \n do not becomne complacent Chapter Master i may not always be so generous";

--- a/scripts/scr_fleet_functions/scr_fleet_functions.gml
+++ b/scripts/scr_fleet_functions/scr_fleet_functions.gml
@@ -12,6 +12,21 @@ function distribute_strength_to_fleet(strength, fleet) {
     }
 }
 
+/// @mixin obj_en_fleet
+function random_sector_exit_point(){
+    action_x = choose(room_width * -1, room_width * 2);
+    action_y = choose(room_height * -1, room_height * 2);
+}
+
+
+/// @mixin obj_en_fleet
+function in_room(object = undefined){
+    if (object == undefined){
+        object = self;
+    }
+    return !(object.x < 0 || object.x > room_width || object.y < 0 || object.y > room_height)
+}
+
 //to be run within with scope
 function set_fleet_target(targ_x, targ_y, final_target) {
     action_x = targ_x;

--- a/scripts/scr_inquisition_fleet_functions/scr_inquisition_fleet_functions.gml
+++ b/scripts/scr_inquisition_fleet_functions/scr_inquisition_fleet_functions.gml
@@ -8,7 +8,7 @@ function base_inquis_fleet() {
     inquisitor = 0;
     trade_goods = "Inqis";
     if (roll > 60) {
-        var inquis_choice = choose(2, 3, 4, 5);
+        var inquis_choice = irandom_range(2, 5);
         inquisitor = inquis_choice;
     }
 }
@@ -27,8 +27,7 @@ function radical_inquisitor_mission_ship_arrival() {
 
     var _radical_inquisitor = cargo_data.radical_inquisitor;
     if (!instance_exists(_intercept_fleet)) {
-        action_x = choose(room_width * -1, room_width * 2);
-        action_y = choose(room_height * -1, room_height * 2);
+        random_sector_exit_point();
         action_spd = 256;
         action = "";
         set_fleet_movement();
@@ -178,7 +177,7 @@ function new_inquisitor_inspection() {
                 set_fleet_movement();
             }
             var mess = $"Inquisitor {obj_controller.inquisitor[new_inquis_fleet.inquisitor]}";
-            mess += " wishes to inspect your chapter base at " + string(target_star.name);
+            mess += " wishes to inspect your chapter base at {target_star.name}";
             scr_alert("green", "inspect", mess, target_star.x, target_star.y);
             obj_controller.last_world_inspection = obj_controller.turn;
             // we sent an inspection, we are done

--- a/scripts/scr_inquisition_fleet_functions/scr_inquisition_fleet_functions.gml
+++ b/scripts/scr_inquisition_fleet_functions/scr_inquisition_fleet_functions.gml
@@ -177,7 +177,7 @@ function new_inquisitor_inspection() {
                 set_fleet_movement();
             }
             var mess = $"Inquisitor {obj_controller.inquisitor[new_inquis_fleet.inquisitor]}";
-            mess += " wishes to inspect your chapter base at {target_star.name}";
+            mess += $" wishes to inspect your chapter base at {target_star.name}";
             scr_alert("green", "inspect", mess, target_star.x, target_star.y);
             obj_controller.last_inquisitor_inspection = obj_controller.turn;
             // we sent an inspection, we are done

--- a/scripts/scr_inquisition_fleet_functions/scr_inquisition_fleet_functions.gml
+++ b/scripts/scr_inquisition_fleet_functions/scr_inquisition_fleet_functions.gml
@@ -179,7 +179,7 @@ function new_inquisitor_inspection() {
             var mess = $"Inquisitor {obj_controller.inquisitor[new_inquis_fleet.inquisitor]}";
             mess += " wishes to inspect your chapter base at {target_star.name}";
             scr_alert("green", "inspect", mess, target_star.x, target_star.y);
-            obj_controller.last_world_inspection = obj_controller.turn;
+            obj_controller.last_inquisitor_inspection = obj_controller.turn;
             // we sent an inspection, we are done
             return;
         }
@@ -206,7 +206,7 @@ function new_inquisitor_inspection() {
         mess += " wishes to inspect your fleet at " + string(obj.name);
         scr_alert("green", "inspect", mess, obj.x, obj.y);
 
-        obj_controller.last_fleet_inspection = obj_controller.turn;
+        obj_controller.last_inquisitor_inspection = obj_controller.turn;
 
         instance_activate_object(obj_star);
     }

--- a/scripts/scr_inquisition_inspection/scr_inquisition_inspection.gml
+++ b/scripts/scr_inquisition_inspection/scr_inquisition_inspection.gml
@@ -1,3 +1,53 @@
+function check_for_next_inquisitor_inspection(){
+    var _last_inquisitor_inspection = 0;
+    if (obj_ini.fleet_type == ePLAYER_BASE.HOME_WORLD) {
+        _last_inquisitor_inspection = last_world_inspection;
+    }
+    if (obj_ini.fleet_type != ePLAYER_BASE.HOME_WORLD) {
+        _last_inquisitor_inspection = last_fleet_inspection;
+    }
+
+    var _suspicion = obj_ini.chapter_data.chapter_suspicion;
+
+    var _loyalty = loyalty;
+
+    _loyalty += (_suspicion * 10)
+
+    _loyalty += (obj_controller.disposition[eFACTION.INQUISITION]- 50);
+
+    _loyalty = clamp(_loyalty , 0, 100);
+
+    // innspectionos take place between 1 and 10 years depending on relationship with inquisitor
+    // chapters percieved suspiciousness and loyalty
+    if ((_last_inquisitor_inspection + lerp(120, 12, loyalty/100)) < turn){
+        _inspec = true;
+    }
+
+    if (obj_ini.fleet_type != ePLAYER_BASE.HOME_WORLD) {
+        if ((instance_number(obj_p_fleet) == 1) && (obj_ini.fleet_type == ePLAYER_BASE.HOME_WORLD)) {
+            //can't inspect if fleet not in room 
+            //can't innspect if on other non negotiable action e.g crusading
+            _inspec = in_room(obj_p_fleet) && !fleet_engaged(obj_p_fleet);
+        }
+        else if (instance_number(obj_p_fleet) == 0) {
+            _inspec = false;
+        }
+    }
+
+    //setup inquisitor inspections
+    var _inquisitor_fleet_count = 0;
+    with (obj_fleet) {
+        if (owner == eFACTION.INQUISITION) {
+            _inquisitor_fleet_count++;
+        }
+    }
+
+    _inspec = _inspec && faction_status[eFACTION.INQUISITION] != "War" && _inquisitor_fleet_count == 0;
+    if (_inspec) {
+        new_inquisitor_inspection();
+    }
+}
+
 function inquisitor_inspection_structure() constructor {
     // ----- Instance data -----
     finds = {

--- a/scripts/scr_inquisition_inspection/scr_inquisition_inspection.gml
+++ b/scripts/scr_inquisition_inspection/scr_inquisition_inspection.gml
@@ -14,9 +14,7 @@ function check_for_next_inquisitor_inspection(){
 
     // innspectionos take place between 1 and 10 years depending on relationship with inquisitor
     // chapters percieved suspiciousness and loyalty
-    if ((_last_inquisitor_inspection + lerp(120, 12, loyalty/100)) < turn){
-        _inspec = true;
-    }
+    _inspec = (_last_inquisitor_inspection + lerp(120, 12, _loyalty / 100)) < turn;
 
     if (obj_ini.fleet_type != ePLAYER_BASE.HOME_WORLD) {
         var _player_fleets = instance_number(obj_p_fleet);

--- a/scripts/scr_inquisition_inspection/scr_inquisition_inspection.gml
+++ b/scripts/scr_inquisition_inspection/scr_inquisition_inspection.gml
@@ -1,11 +1,6 @@
 function check_for_next_inquisitor_inspection(){
-    var _last_inquisitor_inspection = 0;
-    if (obj_ini.fleet_type == ePLAYER_BASE.HOME_WORLD) {
-        _last_inquisitor_inspection = last_world_inspection;
-    }
-    if (obj_ini.fleet_type != ePLAYER_BASE.HOME_WORLD) {
-        _last_inquisitor_inspection = last_fleet_inspection;
-    }
+    var _last_inquisitor_inspection = last_inquisitor_inspection;
+    var _inspec = true;
 
     var _suspicion = obj_ini.chapter_data.chapter_suspicion;
 
@@ -24,12 +19,13 @@ function check_for_next_inquisitor_inspection(){
     }
 
     if (obj_ini.fleet_type != ePLAYER_BASE.HOME_WORLD) {
-        if ((instance_number(obj_p_fleet) == 1) && (obj_ini.fleet_type == ePLAYER_BASE.HOME_WORLD)) {
+        var _player_fleets = instance_number(obj_p_fleet);
+        if ((_player_fleets == 1) && (obj_ini.fleet_type == ePLAYER_BASE.HOME_WORLD)) {
             //can't inspect if fleet not in room 
             //can't innspect if on other non negotiable action e.g crusading
             _inspec = in_room(obj_p_fleet) && !fleet_engaged(obj_p_fleet);
         }
-        else if (instance_number(obj_p_fleet) == 0) {
+        else if (_player_fleets == 0) {
             _inspec = false;
         }
     }

--- a/scripts/scr_inquisition_inspection/scr_inquisition_inspection.gml
+++ b/scripts/scr_inquisition_inspection/scr_inquisition_inspection.gml
@@ -1,6 +1,6 @@
 function check_for_next_inquisitor_inspection(){
     var _last_inquisitor_inspection = last_inquisitor_inspection;
-    var _inspec = true;
+    var _inspec = false;
 
     var _suspicion = obj_ini.chapter_data.chapter_suspicion;
 
@@ -20,7 +20,7 @@ function check_for_next_inquisitor_inspection(){
 
     if (obj_ini.fleet_type != ePLAYER_BASE.HOME_WORLD) {
         var _player_fleets = instance_number(obj_p_fleet);
-        if ((_player_fleets == 1) && (obj_ini.fleet_type == ePLAYER_BASE.HOME_WORLD)) {
+        if (_player_fleets == 1) {
             //can't inspect if fleet not in room 
             //can't innspect if on other non negotiable action e.g crusading
             _inspec = in_room(obj_p_fleet) && !fleet_engaged(obj_p_fleet);

--- a/scripts/scr_inquisition_mission/scr_inquisition_mission.gml
+++ b/scripts/scr_inquisition_mission/scr_inquisition_mission.gml
@@ -468,8 +468,8 @@ function mission_hunt_inquisitor_show_mercy() {
     with (pop_data.inquisitor_ship) {
         random_sector_exit_point();
         trade_goods = "|DELETE|";
-        set_fleet_movement(false, 8);
         action_spd = 256;
+        set_fleet_movement(false, 8);
     }
 
     title = "Inquisition Mission Completed";

--- a/scripts/scr_inquisition_mission/scr_inquisition_mission.gml
+++ b/scripts/scr_inquisition_mission/scr_inquisition_mission.gml
@@ -468,9 +468,8 @@ function mission_hunt_inquisitor_show_mercy() {
     with (pop_data.inquisitor_ship) {
         random_sector_exit_point();
         trade_goods = "|DELETE|";
-        set_fleet_movement();
+        set_fleet_movement(false, 8);
         action_spd = 256;
-        action = "";
     }
 
     title = "Inquisition Mission Completed";

--- a/scripts/scr_inquisition_mission/scr_inquisition_mission.gml
+++ b/scripts/scr_inquisition_mission/scr_inquisition_mission.gml
@@ -429,8 +429,7 @@ function mission_hunt_inquisitor_hear_out_radical_inquisitor() {
 
 function mission_hunt_inquisitor_take_artifact_bribe() {
     with (pop_data.inquisitor_ship) {
-        action_x = choose(room_width * -1, room_width * 2);
-        action_y = choose(room_height * -1, room_height * 2);
+        random_sector_exit_point();
         trade_goods = "|DELETE|";
         action_spd = 256;
         set_fleet_movement(false);
@@ -467,10 +466,9 @@ function mission_hunt_inquisitor_take_artifact_double_cross() {
 
 function mission_hunt_inquisitor_show_mercy() {
     with (pop_data.inquisitor_ship) {
-        action_x = choose(room_width * -1, room_width * 2);
-        action_y = choose(room_height * -1, room_height * 2);
+        random_sector_exit_point();
         trade_goods = "|DELETE|";
-        alarm[4] = 1;
+        set_fleet_movement();
         action_spd = 256;
         action = "";
     }

--- a/scripts/scr_player_fleet_functions/scr_player_fleet_functions.gml
+++ b/scripts/scr_player_fleet_functions/scr_player_fleet_functions.gml
@@ -18,6 +18,21 @@ function fleet_has_roles(fleet = "none", roles) {
     }
 }
 
+function fleet_engaged(fleet = undefined){
+    var _engaged = false;
+    if (fleet == undefined){
+        fleet = self;
+    }
+    var _fleet_action = fleet.action;
+    if (_fleet_action != "" && _fleet_action !="move"){
+        //don't inspect if engaged in non negotiable actions
+        if (array_contains(FLEET_MOVE_OPTIONS, _fleet_action)){
+            _engaged = true;
+        }
+    }
+
+    return _engaged;
+}
 function split_selected_into_new_fleet(start_fleet = "none") {
     var new_fleet;
     if (start_fleet == "none") {


### PR DESCRIPTION
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
## Purpose and Description
<!-- Explain why and what your changes do in simple terms. -->
- Improve the script for deciding when inspections happe
- increase max time till next inspection to10 years
- add suspicion markers to chapter traits that increase or decrease the tie until inspectsions
- make inquisitor disposition as well as loyalty effect tie between inspections
- fix a possible crash with trait selection

## Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- None, and I understand the risks.

## Related things and/or additional context
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, screenshots etc. -->
-

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->

<!--- "Inspired" by the CDDA PR template -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Inquisition inspections adaptive and less frequent when appropriate. Timing now scales with loyalty, Inquisition disposition, and chapter “suspicion”, with gaps up to 10 years and smarter checks before spawning.

- **New Features**
  - Added a `suspicion` value to chapter advantages/disadvantages; values roll up to `chapter_suspicion` and show in trait tooltips.
  - Inspection cadence uses loyalty, Inquisition disposition, and `chapter_suspicion` to set intervals between ~1–10 years.
  - Inspections won’t trigger if the fleet is off-map, engaged in non-negotiable actions, at war with the Inquisition, or when an Inquisition fleet is already present.
  - Balance: `Inquisitorial Mandate` now costs 30 points and applies `suspicion: -2`.

- **Refactors and Fixes**
  - Replaced fragmented timing with `check_for_next_inquisitor_inspection()` and unified timestamp to `last_inquisitor_inspection`.
  - Added helpers: `random_sector_exit_point()`, `in_room()`, and `fleet_engaged()`.
  - Prevented creation screen crashes by clamping trait indices and slot counts.
  - Minor cleanups (random choice, movement setup) for consistency and readability.

<sup>Written for commit a02e304d5d1631fb7f2c5c39e1263c6700244846. Summary will update on new commits. <a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1151?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Developer Notes

- Refactored inquisitor inspection scheduling logic from inline implementation in `Alarm_5.gml` into dedicated function `check_for_next_inquisitor_inspection()` for improved maintainability
- Consolidated inspection timestamp tracking from separate `last_world_inspection` and `last_fleet_inspection` variables to single `last_inquisitor_inspection` variable across multiple script files
- Added new utility functions for fleet spatial operations: `random_sector_exit_point()`, `in_room()`, and `fleet_engaged()`
- Introduced `suspicion` value system to chapter trait data structure with clamping to [-5, 5] range
- Fixed bounds checking in trait selection to prevent potential array index crashes when displaying advantages and disadvantages

## Player Notes

- Inquisitor inspection frequency now affected by chapter suspicion modifiers from advantages and disadvantages
- Inquisitor inspection frequency now influenced by Inquisition disposition and chapter loyalty
- Multiple chapter advantages assigned suspicion modifiers: Warp Touched (-4), Favoured By The Warp (-2), Reverent Guardians (-3), Elite Guard (-1), Great Luck (-2), Inquisitorial Mandate (-4)
- Multiple chapter disadvantages assigned suspicion modifiers: Never Forgive (+1), Shitty Luck (+1), Suspicious (+4), Tech-Heresy (+1), Tolerant (+2), Warp Tainted (+2), Psyker Intolerant (-2), Serpents Delight (+1), Small Reclusiam (+1), Barren Librarius (-1)
- Inquisitorial Mandate advantage cost reduced from 50 to 30 points

<!-- end of auto-generated comment: release notes by coderabbit.ai -->