### PR TITLE
fix: Ensure mercenary units spawn with max health

### DIFF
--- a/scripts/scr_add_man/scr_add_man.gml
+++ b/scripts/scr_add_man/scr_add_man.gml
@@ -13,13 +13,13 @@ function scr_add_man(man_role, target_company, spawn_exp, spawn_name, corruption
         "Flash Git"
     ];
     var _gear = {};
-    var good = 0;
+    var _company_slot = 0;
 
-    good = find_company_open_slot(target_company);
+    _company_slot = find_company_open_slot(target_company);
 
-    if (good != -1) {
-        scr_wipe_unit(target_company, good);
-        var unit = fetch_unit([target_company, good]);
+    if (_company_slot != -1) {
+        scr_wipe_unit(target_company, _company_slot);
+        var _unit = fetch_unit([target_company, _company_slot]);
         if (other_gear == true) {
             // TODO: Implement logic for Chapter Servitor, Neophyte, and Serf (Race 1, Scout/Astartes stats)
             // TODO: Implement logic for Mercenary (Race 2, Human stats, Hellgun)
@@ -28,45 +28,45 @@ function scr_add_man(man_role, target_company, spawn_exp, spawn_name, corruption
             switch (man_role) {
                 case "Skitarii":
                     spawn_exp = 10;
-                    obj_ini.race[target_company][good] = 3;
-                    unit = new TTRPG_stats("mechanicus", target_company, good, "skitarii");
+                    obj_ini.race[target_company][_company_slot] = 3;
+                    _unit = new TTRPG_stats("mechanicus", target_company, _company_slot, "skitarii");
                     break;
                 case "Techpriest":
                     spawn_exp = 100;
-                    obj_ini.race[target_company][good] = 3;
-                    unit = new TTRPG_stats("mechanicus", target_company, good, "tech_priest");
+                    obj_ini.race[target_company][_company_slot] = 3;
+                    _unit = new TTRPG_stats("mechanicus", target_company, _company_slot, "tech_priest");
                     break;
                 case "Crusader":
                     spawn_exp = 10;
-                    obj_ini.race[target_company][good] = 4;
-                    unit = new TTRPG_stats("inquisition", target_company, good, "inquisition_crusader");
+                    obj_ini.race[target_company][_company_slot] = 4;
+                    _unit = new TTRPG_stats("inquisition", target_company, _company_slot, "inquisition_crusader");
                     break;
                 // TODO: Implement Sanctioned Psyker (Race 4, Psychic powers, Force Staff)
                 case "Sister of Battle":
                     spawn_exp = 20;
-                    obj_ini.race[target_company][good] = 5;
-                    unit = new TTRPG_stats("adeptus_sororitas", target_company, good, "sister_of_battle");
+                    obj_ini.race[target_company][_company_slot] = 5;
+                    _unit = new TTRPG_stats("adeptus_sororitas", target_company, _company_slot, "sister_of_battle");
                     break;
                 case "Sister Hospitaler":
                     spawn_exp = 50;
-                    obj_ini.race[target_company][good] = 5;
-                    unit = new TTRPG_stats("adeptus_sororitas", target_company, good, "sister_hospitaler");
+                    obj_ini.race[target_company][_company_slot] = 5;
+                    _unit = new TTRPG_stats("adeptus_sororitas", target_company, _company_slot, "sister_hospitaler");
                     break;
                 // TODO: Implement Prioress (Race 5, Sororitas leader gear/stats)
                 case "Ranger":
                     spawn_exp = 180;
-                    obj_ini.race[target_company][good] = 6;
-                    unit = new TTRPG_stats("Eldari", target_company, good, "eldar_ranger");
+                    obj_ini.race[target_company][_company_slot] = 6;
+                    _unit = new TTRPG_stats("Eldari", target_company, _company_slot, "eldar_ranger");
                     break;
                 case "Ork Sniper":
                     spawn_exp = 20;
-                    obj_ini.race[target_company][good] = eFACTION.ORK;
-                    unit = new TTRPG_stats("ork", target_company, good, "ork_Sniper");
+                    obj_ini.race[target_company][_company_slot] = eFACTION.ORK;
+                    _unit = new TTRPG_stats("ork", target_company, _company_slot, "ork_Sniper");
                     break;
                 case "Flash Git":
                     spawn_exp = 40;
-                    obj_ini.race[target_company][good] = eFACTION.ORK;
-                    unit = new TTRPG_stats("ork", target_company, good, "flash_git");
+                    obj_ini.race[target_company][_company_slot] = eFACTION.ORK;
+                    _unit = new TTRPG_stats("ork", target_company, _company_slot, "flash_git");
                     break;
                 // TODO: Implement Warboss (Race 7)
                 // TODO: Implement Fire Warrior (Race 8, T'au gear/stats)
@@ -76,26 +76,35 @@ function scr_add_man(man_role, target_company, spawn_exp, spawn_name, corruption
             }
         }
 
-        obj_ini.age[target_company][good] = (obj_controller.millenium * 1000) + obj_controller.year;
+        obj_ini.age[target_company][_company_slot] = (obj_controller.millenium * 1000) + obj_controller.year;
 
-        if ((spawn_name == "") || (spawn_name == "imperial")) {
-            obj_ini.name[target_company][good] = global.name_generator.ChapterMemberNameGeneration();
+        switch (spawn_name) {
+            case "":
+            case "imperial":
+                obj_ini.name[target_company][_company_slot] = global.name_generator.ChapterMemberNameGeneration();
+                break;
+            default:
+                obj_ini.name[target_company][_company_slot] = spawn_name;
+                break;
         }
-        if ((spawn_name != "") && (spawn_name != "imperial")) {
-            obj_ini.name[target_company][good] = spawn_name;
-        }
-        if (man_role == "Ranger") {
-            obj_ini.name[target_company][good] = global.name_generator.GenerateMultiSyllable("eldar", 2);
-        }
-        if ((man_role == "Ork Sniper") || (man_role == "Flash Git")) {
-            obj_ini.name[target_company][good] = global.name_generator.GenerateComposite("ork", false);
-        }
-        if ((man_role == "Sister of Battle") || (man_role == "Sister Hospitaler")) {
-            obj_ini.name[target_company][good] = global.name_generator.GenerateFromSet($"imperial_female");
+        switch (man_role) {
+            case "Ranger":
+                obj_ini.name[target_company][_company_slot] = global.name_generator.GenerateMultiSyllable("eldar", 2);
+                break;
+                
+            case "Ork Sniper":
+            case "Flash Git":
+                obj_ini.name[target_company][_company_slot] = global.name_generator.GenerateComposite("ork", false);
+                break;
+                
+            case "Sister of Battle":
+            case "Sister Hospitaler":
+                obj_ini.name[target_company][_company_slot] = global.name_generator.GenerateFromSet("imperial_female");
+                break;
         }
 
         if (!array_contains(non_marine_roles, man_role)) {
-            obj_ini.race[target_company][good] = eFACTION.PLAYER;
+            obj_ini.race[target_company][_company_slot] = eFACTION.PLAYER;
             if (man_role == obj_ini.role[100][12]) {
                 _gear = {
                     wep2: obj_ini.wep2[100][12],
@@ -106,18 +115,20 @@ function scr_add_man(man_role, target_company, spawn_exp, spawn_name, corruption
                 };
             }
 
-            unit = new TTRPG_stats("chapter", target_company, good, "scout", other_data);
-            unit.corruption = corruption;
-            unit.roll_age();
-            unit.alter_equipment(_gear);
+            _unit = new TTRPG_stats("chapter", target_company, _company_slot, "scout", other_data);
+            _unit.corruption = corruption;
+            _unit.roll_age();
+            _unit.alter_equipment(_gear);
             marines += 1;
         }
-        obj_ini.TTRPG[target_company][good] = unit;
-        unit.add_exp(spawn_exp);
-        unit.allocate_unit_to_fresh_spawn(home_spot);
-        unit.update_role(man_role);
+        obj_ini.TTRPG[target_company][_company_slot] = _unit;
+        _unit.add_exp(spawn_exp);
+        _unit.allocate_unit_to_fresh_spawn(home_spot);
+        _unit.update_role(man_role);
         with (obj_ini) {
             scr_company_order(target_company);
         }
+        _unit.update_health(10000);
+        return _unit;
     }
 }

--- a/scripts/scr_add_man/scr_add_man.gml
+++ b/scripts/scr_add_man/scr_add_man.gml
@@ -128,7 +128,7 @@ function scr_add_man(man_role, target_company, spawn_exp, spawn_name, corruption
         with (obj_ini) {
             scr_company_order(target_company);
         }
-        _unit.update_health(10000);
+        _unit.update_health(_unit.max_health());
         return _unit;
     }
 }


### PR DESCRIPTION
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
## Purpose and Description
<!-- Explain why and what your changes do in simple terms. -->
- Self-descriptive.

## Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- None, and I understand the risks.

## Related things and/or additional context
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, screenshots etc. -->
-

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->

<!--- "Inspired" by the CDDA PR template -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
New mercenary units now spawn at full health. We set HP to max during creation to prevent low-HP recruits.

- **Bug Fixes**
  - Call `_unit.update_health(_unit.max_health())` after spawn so all units created via `scr_add_man` start at full HP.

- **Refactors**
  - Renamed `good` → `_company_slot` and `unit` → `_unit`; consolidated name assignment with `switch` and fixed the `imperial_female` key.
  - `scr_add_man` now returns the created `_unit`.

<sup>Written for commit 3d8a755beb683ac35937d303fe494703655245da. Summary will update on new commits. <a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1156?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

