### PR TITLE
fix: crash viewing garrison panel

### DIFF
--- a/objects/obj_star_select/Draw_64.gml
+++ b/objects/obj_star_select/Draw_64.gml
@@ -1,16 +1,13 @@
-if (instances_exist_any([obj_bomb_select, obj_drop_select, obj_popup])) {
+
+
+
+if (instances_exist_any([obj_bomb_select, obj_drop_select, obj_popup])){
     exit;
 }
 
-if (obj_controller.zoomed == 1) {
-    exit;
-}
-if (!instance_exists(target)) {
-    exit;
-}
-if (obj_controller.menu == 60) {
-    exit;
-}
+if (obj_controller.zoomed=1) then exit;
+if (!instance_exists(target)) then exit;
+if (obj_controller.menu=60) then exit;
 
 add_draw_return_values();
 draw_set_font(fnt_40k_14b);
@@ -18,131 +15,136 @@ draw_set_halign(fa_center);
 draw_set_valign(fa_top);
 draw_set_color(0);
 
-var temp1 = 0;
-var xx = __view_get(e__VW.XView, 0) + 0;
-var yy = __view_get(e__VW.YView, 0) + 0;
-if (loading == 1) {
-    xx = xx;
-    yy = yy;
-} else if (loading == 1) {
-    var temp1, dist;
-    dist = 999;
 
-    obj_controller.selecting_planet = 0;
-    button1 = "";
-    button2 = "";
-    button3 = "";
-    button4 = "";
+try{
+var temp1=0;
+var xx = 0;
+var yy = 0;
+if (loading=1){
+    xx=xx;
+    yy=yy;
+} else if (loading==1){
+    var  temp1, dist;
+    dist=999;
+    
+    obj_controller.selecting_planet=0;
+    button1="";
+    button2="";
+    button3="";
+    button4="";
 
-    if (instance_exists(target)) {
-        if (target.space_hulk == 1) {
+    if (instance_exists(target)){
+        if (target.space_hulk==1){
             pop_draw_return_values();
             exit;
         }
     }
 }
-if (obj_controller.selecting_planet > target.planets) {
+if (obj_controller.selecting_planet>target.planets){
     obj_controller.selecting_planet = 0;
 }
-var click_accepted = (!obj_controller.menu) && (!obj_controller.zoomed) && (!instance_exists(obj_bomb_select)) && (!instance_exists(obj_drop_select));
+var click_accepted = (!obj_controller.menu) and (!obj_controller.zoomed) and (!instance_exists(obj_bomb_select)) and (!instance_exists(obj_drop_select));
 if (click_accepted && (!debug || !debug_slate.entered())) {
-    if (mouse_button_clicked(, 0)) {
-        var closes = 0, sta1 = 0, sta2 = 0;
+    if (mouse_button_clicked(, 0)){
+        var closes=0,sta1=0,sta2=0;
         var mouse_consts = return_mouse_consts();
-        sta1 = instance_nearest(mouse_consts[0], mouse_consts[1], obj_star);
-        sta2 = point_distance(mouse_consts[0], mouse_consts[1], sta1.x, sta1.y);
-        closes = true;
-        if (sta2 > 15) {
-            if (scr_hit(27, 165, 300, 165 + 294)) {
-                closes = false;
-            } else if (obj_controller.selecting_planet > 0) {
+        sta1=instance_nearest(mouse_consts[0],mouse_consts[1],obj_star);
+        sta2=point_distance(mouse_consts[0],mouse_consts[1],sta1.x,sta1.y);
+        closes=true;
+        if (sta2>15){
+            if (scr_hit(
+                27,
+                165,
+                300,
+                165+294)
+            ){
+                closes=false
+            } else if (obj_controller.selecting_planet>0){
                 closes = !main_data_slate.entered();
-                if (closes) {
-                    if (is_struct(garrison) || population) {
-                        closes = !garrison_data_slate.entered();
+                if (closes){
+                    if (is_struct(garrison) || population){
+                        closes =  !garrison_data_slate.entered();
                     }
                 }
-
-                if (!is_string(feature)) {
-                    if (feature.main_slate.entered()) {
-                        closes = false;
+               
+                if (!is_string(feature)){
+                    if (feature.main_slate.entered()){
+                        closes=false;
                     }
                 }
             }
             var shutter_button;
-            var shutters = [
-                shutter_1,
-                shutter_2,
-                shutter_3,
-                shutter_4
-            ];
-            for (var i = 0; i < 4; i++) {
+            var shutters = [shutter_1, shutter_2, shutter_3, shutter_4];
+            for (var i=0; i<4;i++){
                 shutter_button = shutters[i];
-                if (shutter_button.hit()) {
-                    closes = false;
+                if (shutter_button.hit()){
+                    closes=false;
                     break;
                 }
             }
-            if (closes) {
-                cooldown = 0;
-                obj_controller.sel_system_x = 0;
-                obj_controller.sel_system_y = 0;
-                obj_controller.selecting_planet = 0;
-                obj_controller.popup = 0;
+            if (closes){
+                cooldown=0;
+                obj_controller.sel_system_x=0;
+                obj_controller.sel_system_y=0;
+                obj_controller.selecting_planet=0;
+                obj_controller.popup=0;
                 instance_destroy();
             }
         }
     }
 }
 
-if ((target.craftworld == 0) && (target.space_hulk == 0)) {
-    draw_sprite(spr_star_screen, target.planets, 27, 165);
-}
-if (target.craftworld == 1) {
-    draw_sprite(spr_star_screen, 5, 27, 165);
-}
-if (target.space_hulk == 1) {
-    draw_sprite(spr_star_screen, 6, 27, 165);
-}
-if ((target.craftworld == 0) && (target.space_hulk == 0)) {
-    draw_sprite_ext(target.sprite_index, target.image_index, 77, 287, 1.25, 1.25, 0, c_white, 1);
+var _standard_star = !target.craftworld && !target.space_hulk;
+
+if (_standard_star){
+    draw_sprite(spr_star_screen,target.planets,27,165);
+    draw_sprite_ext(target.sprite_index,target.image_index,77,287,1.25,1.25,0,c_white,1);
+}else if (target.craftworld){
+    draw_sprite(spr_star_screen,5,27,165);
+} else if(target.space_hulk){
+    draw_sprite_ext(target.sprite_index,target.image_index,77,287,1.25,1.25,0,c_white,1);
 }
 
 var _screen_height = sprite_get_height(spr_star_screen);
 var _screen_width = sprite_get_width(spr_star_screen);
 
-draw_sprite_ext(spr_servo_left_arm, 0, 27 + _screen_width, 165 + _screen_height / 3, 2, 2, 0, c_white, 1);
-draw_sprite_ext(spr_servo_right_arm, 0, 27, 165 + _screen_height / 3, 2, 2, 0, c_white, 1);
-draw_sprite_ext(spr_servo_skull_head, 0, 27 + _screen_width / 2, 165, 2, 2, 0, c_white, 1);
+//TODO bottle these into a constructor for re-use
+draw_sprite_ext(spr_servo_left_arm, 0,27+_screen_width,165+_screen_height/3, 2, 2, 0, c_white, 1);
+draw_sprite_ext(spr_servo_right_arm, 0,27,165+_screen_height/3, 2, 2, 0, c_white, 1);
+draw_sprite_ext(spr_servo_skull_head, 0,27+_screen_width/2,165, 2, 2, 0, c_white, 1);
 
-var system_string = target.name + " System";
-if (target.owner != 1) {
-    draw_set_color(0);
-}
-if (target.owner == eFACTION.PLAYER) {
-    draw_set_color(c_blue);
-}
-if ((target.craftworld == 0) && (target.space_hulk == 0)) {
-    draw_text_transformed(184, 180, system_string, 1, 1, 0);
-}
+var system_string = $"{target.name} System";
 
-if ((target.craftworld == 0) && (target.space_hulk == 0)) {
+draw_set_color(target.owner == eFACTION.PLAYER ? c_blue : 0);
+
+if (_standard_star){
+    draw_text_transformed(184,180,system_string,1,1,0);
     draw_set_color(global.star_name_colors[target.owner]);
-    draw_text_transformed(184, 180, system_string, 1, 1, 0);
+    draw_text_transformed(184,180,system_string,1,1,0);
 }
 
-if (global.cheat_debug && obj_controller.selecting_planet && !loading) {
+
+if (global.cheat_debug && obj_controller.selecting_planet && !loading){
     draw_planet_debug_options();
 }
 
-if (obj_controller.menu == 0 && !debug) {
-    if (manage_units_button.draw(has_player_forces)) {
-        var _viewer = obj_controller.location_viewer;
+
+if (obj_controller.menu == 0 && !debug){
+    if (manage_units_button.draw(has_player_forces)){
+        var _viewer = obj_controller.location_viewer
         _viewer.update_garrison_log();
         var _unit_dispersement = _viewer.garrison_log;
         var _sys_name = target.name;
-        if (struct_exists(_unit_dispersement, target.name)) {
-            group_selection(_unit_dispersement[$ _sys_name].units, {purpose: $"{target.name} Management", purpose_code: "manage", number: 0, system: target.id, feature: "none", planet: 0, selections: []});
+        if (struct_exists(_unit_dispersement, target.name)){
+            group_selection(_unit_dispersement[$ _sys_name].units,{
+                purpose:$"{target.name} Management",
+                purpose_code : "manage",
+                number:0,
+                system:target.id,
+                feature:"none",
+                planet : 0,
+                selections : []
+            });
             instance_destroy();
             pop_draw_return_values();
             exit;
@@ -150,275 +152,249 @@ if (obj_controller.menu == 0 && !debug) {
     }
 }
 
-if (loading != 0) {
+
+if (loading!=0){
     draw_set_font(fnt_40k_14);
     draw_set_color(CM_GREEN_COLOR);
-    draw_text(184, 202, string_hash_to_newline("Select Destination"));
+    draw_text(184,202,
+    "Select Destination");
 }
 
+
 //the draw and click on planets logic
-if (!debug) {
+if (!debug){
     planet_selection_action();
 }
 
 draw_set_font(fnt_40k_14b);
 
-if (obj_controller.selecting_planet != 0) {
-    if (p_data.planet != obj_controller.selecting_planet) {
-        delete p_data;
+if (obj_controller.selecting_planet!=0){
+    if (p_data.planet != obj_controller.selecting_planet){
         p_data = new PlanetData(obj_controller.selecting_planet, target);
+        target.system_datas[obj_controller.selecting_planet] = p_data;
     }
-    // Buttons that are available
-    if (!buttons_selected) {
-        if ((obj_controller.faction_status[eFACTION.IMPERIUM] != "War" && p_data.current_owner > 5) || (obj_controller.faction_status[eFACTION.IMPERIUM] == "War" && p_data.at_war(0, 1, 1) && p_data.player_disposition <= 50)) {
-            var is_enemy = true;
+// Buttons that are available
+    if (!buttons_selected){
+        if (obj_controller.faction_status[eFACTION.IMPERIUM] != "War" && p_data.current_owner > 5) || (obj_controller.faction_status[eFACTION.IMPERIUM] == "War" && p_data.at_war(0, 1, 1) && p_data.player_disposition <= 50) {
+            var is_enemy=true;
         } else {
-            var is_enemy = false;
+            var is_enemy=false;
         }
 
-        if (p_data.planet > 0) {
-            if (target.present_fleet[1] == 0) /* and (target.p_type[obj_controller.selecting_planet]!="Dead")*/ {
-                if (p_data.player_forces > 0) {
-                    if (is_enemy) {
-                        button1 = "Attack";
-                        button2 = "Purge";
-                    }
-                }
-            }
-            if (target.present_fleet[1] > 0) /* and (target.p_type[obj_controller.selecting_planet]!="Dead")*/ {
-                if (is_enemy) {
-                    button1 = "Attack";
-                    button2 = "Raid";
-                    button3 = "Bombard";
-                } else {
-                    button1 = "Attack";
-                    button2 = "Raid";
-                    button3 = "Purge";
-                }
-
-                if (torpedo > 0) {
-                    var pfleet = instance_nearest(x, y, obj_p_fleet);
-                    if (instance_exists(pfleet) && (point_distance(pfleet.x, pfleet.y, target.x, target.y) <= 40) && (pfleet.action == "")) {
-                        if ((pfleet.capital_number + pfleet.frigate_number > 0) && (button4 == "")) {
-                            button4 = "Cyclonic Torpedo";
+        if (p_data.planet>0){
+            if (target.present_fleet[1]=0)/* and (target.p_type[obj_controller.selecting_planet]!="Dead")*/{
+                if (p_data.player_forces>0){
+                    if (is_enemy){
+                        button1="Attack";
+                        if (p_data.population){
+                            button2="Purge";
                         }
                     }
                 }
             }
+            if (target.present_fleet[1]>0)/* and (target.p_type[obj_controller.selecting_planet]!="Dead")*/{
+                if (is_enemy) {
+                    button1="Attack";
+                    button2="Raid";
+                    button3="Bombard";
+                }
+                else {
+                    button1="Attack";
+                    button2="Raid";
+                    if (p_data.population){
+                        button2="Purge";
+                    }
+                }
+                
+                if (torpedo>0){
+                    var pfleet=instance_nearest(x,y,obj_p_fleet);
+                    if (instance_exists(pfleet)) and (point_distance(pfleet.x,pfleet.y,target.x,target.y)<=40) and (pfleet.action=""){
+                        if (pfleet.capital_number+pfleet.frigate_number>0) and (button4="") then button4="Cyclonic Torpedo";
+                    }
+                }
+                
+            }
         }
         var planet_upgrades = target.p_upgrades[obj_controller.selecting_planet];
-        if (((p_data.planet_type == "Dead") || (array_length(p_data.upgrades) > 0)) && ((target.present_fleet[1] > 0) || (target.p_player[obj_controller.selecting_planet] > 0))) {
-            if ((array_length(p_data.features) == 0) || (array_length(planet_upgrades) > 0)) {
+        if (((p_data.planet_type=="Dead") or (array_length(p_data.upgrades)>0)) and ((target.present_fleet[1]>0) or (target.p_player[obj_controller.selecting_planet]>0))){
+            if (array_length(p_data.features)==0) or (array_length(planet_upgrades)>0){
+
                 chock = !p_data.xenos_and_heretics();
-                if (chock == 1) {
-                    if (p_data.has_upgrade(eP_FEATURES.SECRET_BASE)) {
-                        button1 = "Base";
-                    } else if (p_data.has_upgrade(eP_FEATURES.ARSENAL)) {
-                        button1 = "Arsenal";
-                    } else if (p_data.has_upgrade(eP_FEATURES.GENE_VAULT)) {
-                        button1 = "Gene-Vault";
-                    } else if (array_length(p_data.upgrades) == 0) {
-                        button1 = "Build";
+                if (chock==1){
+                    if (p_data.has_upgrade(eP_FEATURES.SECRET_BASE)){
+                        button1="Base";
+                    }else if (p_data.has_upgrade(eP_FEATURES.ARSENAL)){
+                        button1="Arsenal"; 
+                    }else if (p_data.has_upgrade(eP_FEATURES.GENE_VAULT)){
+                        button1="Gene-Vault";
+                    }else if (array_length(p_data.upgrades)==0){
+                        button1="Build";
                     }
-                    if (array_contains(["Build", "Gene-Vault", "Arsenal", "Base"], button1)) {
-                        button2 = "";
-                        button3 = "";
-                        button4 = "";
-                        button5 = "";
+                    if (array_contains(["Build","Gene-Vault","Arsenal","Base"],button1)){
+                        button2="";
+                        button3="";
+                        button4="";
+                        button5="";
                     }
                 }
             }
         }
-
-        if (obj_controller.recruiting_worlds_bought > 0 && !p_data.at_war()) {
-            if (!p_data.has_feature(eP_FEATURES.RECRUITING_WORLD) && p_data.planet_type != "Dead" && !target.space_hulk) {
-                button4 = "+Recruiting";
+        
+        if (obj_controller.recruiting_worlds_bought>0 && !p_data.at_war()){
+            if (!p_data.has_feature(eP_FEATURES.RECRUITING_WORLD) && p_data.planet_type != "Dead" && !target.space_hulk){
+                button4="+Recruiting";
             }
         }
-        if (target.space_hulk) {
-            if (target.present_fleet[1] > 0) {
-                button1 = "Raid";
-                button2 = "Bombard";
-                button3 = "";
-                button4 = "";
+        if (target.space_hulk){
+            if (target.present_fleet[1]>0){
+                button1="Raid";
+                button2="Bombard";
+                button3="";
+                button4="";
             }
         }
-        buttons_selected = true;
+        buttons_selected=true;  
     }
 
-    main_data_slate.inside_method = function() {
+    main_data_slate.inside_method = function(){
         p_data.planet_info_screen();
-    };
-    var slate_draw_scale = 420 / 850;
-    if (feature != "") {
-        if (is_struct(feature)) {
-            feature.draw_planet_features(344 + main_data_slate.width - 4, 165);
-            if (feature.remove) {
-                feature = "";
-            } else if (feature.destroy) {
+    }
+    var slate_draw_scale = 420/850;
+    if (feature!=""){
+        if (is_struct(feature)){
+            feature.draw_planet_features(344+main_data_slate.width-4,165)
+            if (feature.remove){
+                feature="";
+            }else if (feature.destroy){
                 feature = "";
                 instance_destroy();
                 pop_draw_return_values();
                 exit;
             }
         }
-    } else if (garrison != "" && !population) {
-        if (garrison.garrison_force) {
+    }else if (garrison!="" && !population){
+        if (garrison.garrison_force){
             draw_set_font(fnt_40k_14);
-            if (!garrison.garrison_leader) {
-                garrison.find_leader();
+            if (!garrison.garrison_leader){
+                garrison.find_leader()
                 garrison.garrison_disposition_change(target, obj_controller.selecting_planet, true);
-                garrison_data_slate.sub_title = $"Garrison Leader {garrison.garrison_leader.name_role()}";
+                garrison_data_slate.sub_title = $"Garrison Leader {garrison.garrison_leader.name_role()}"
                 garrison_data_slate.body_text = garrison.garrison_report();
             }
-            garrison_data_slate.inside_method = function() {
-                garrison_data_slate.title = "Garrison Report";
+            garrison_data_slate.inside_method=function(){
+                garrison_data_slate.title = "Garrison Report"
                 draw_set_color(c_gray);
                 var xx = garrison_data_slate.XX;
                 var yy = garrison_data_slate.YY;
                 var cur_planet = obj_controller.selecting_planet;
-                var half_way = yy + garrison_data_slate.height / 2;
+                var half_way =  yy+garrison_data_slate.height/2;
                 draw_set_halign(fa_left);
-                draw_line(xx + 10, half_way, garrison_data_slate.width - 10, half_way);
-                var defence_data = determine_pdf_defence(target.p_pdf[cur_planet], garrison, target.p_fortified[cur_planet]);
+                draw_line(xx+10, half_way, garrison_data_slate.width-10, half_way);
+                var defence_data  = determine_pdf_defence(target.p_pdf[cur_planet], garrison,target.p_fortified[cur_planet]);
                 var defence_string = $"Planetary Defence : {defence_data[0]}";
-                draw_text(xx + 20, half_way, defence_string);
-                if (scr_hit(xx + 20, half_way + 10, xx + 20 + string_width(defence_string), half_way + 10 + 20)) {
+                draw_text(xx+20, half_way, defence_string);
+                if (scr_hit(xx+20, half_way+10, xx+20+string_width(defence_string), half_way+10+20)){
                     tooltip_draw(defence_data[1], 400);
                 }
-                if (garrison.dispo_change != "none") {
-                    if (garrison.dispo_change > 55) {
-                        draw_text(xx + 20, half_way + 30, $"Garrison Disposition Effect : Positive");
-                    } else if (garrison.dispo_change > 44) {
-                        draw_text(xx + 20, half_way + 30, $"Garrison Disposition Effect : Neutral");
-                    } else {
-                        draw_text(xx + 20, half_way + 30, $"Garrison Disposition Effect : Negative");
+                if (garrison.dispo_change!="none"){
+                    if (garrison.dispo_change>55){
+                        draw_text(xx+20, half_way+30, $"Garrison Disposition Effect : Positive");
+                    } else if (garrison.dispo_change>44){
+                        draw_text(xx+20, half_way+30, $"Garrison Disposition Effect : Neutral");
+                    } else{ 
+                        draw_text(xx+20, half_way+30, $"Garrison Disposition Effect : Negative");
                     }
                 }
-            };
-            garrison_data_slate.draw(340 + main_data_slate.width, 160, 0.6, 0.6);
-        }
-    } else if (population) {
+            }
+            garrison_data_slate.draw(340+main_data_slate.width, 160, 0.6, 0.6);
+
+        } 
+    } else if (population){
         garrison_data_slate.title = "Population Report";
-        garrison_data_slate.inside_method = function() {
-            draw_set_color(c_gray);
-            var xx = garrison_data_slate.XX;
-            var yy = garrison_data_slate.YY;
-            var cur_planet = obj_controller.selecting_planet;
-            var half_way = garrison_data_slate.height / 2;
-            var spacing_x = 100;
-            var spacing_y = 65;
-            draw_set_halign(fa_left);
-            if (!target.space_hulk) {
-                if ((obj_controller.faction_status[eFACTION.IMPERIUM] != "War" && p_data.current_owner <= 5) || (obj_controller.faction_status[eFACTION.IMPERIUM] == "War")) {
-                    colonist_button.update({x1: xx + 35, y1: half_way});
-                    colonist_button.draw(array_length(potential_donors));
-
-                    recruiting_button.update({x1: xx + (spacing_x * 2) + 15, y1: half_way});
-                    recruiting_button.draw(true);
-                    if (p_data.has_feature(eP_FEATURES.RECRUITING_WORLD)) {
-                        var _recruit_world = p_data.get_features(eP_FEATURES.RECRUITING_WORLD)[0];
-                        if ((_recruit_world.recruit_type == 0) && (obj_controller.faction_status[p_data.current_owner] != "War" && obj_controller.faction_status[p_data.current_owner] != "Antagonism" || p_data.player_disposition >= 50)) {
-                            draw_text(xx + (spacing_x * 3) + 35, half_way - 20, "Open: Voluntery");
-                        } else if (_recruit_world.recruit_type == 0 && p_data.player_disposition <= 50) {
-                            draw_text(xx + (spacing_x * 3) + 35, half_way - 20, "Covert: Voluntery");
-                        } else {
-                            draw_text(xx + (spacing_x * 3) + 35, half_way - 20, "Abduct");
-                        }
-                        recruitment_type_button.update({x1: xx + (spacing_x * 3) + 35, y1: half_way});
-                        recruitment_type_button.draw(true);
-
-                        draw_text(xx + (spacing_x * 3) - 15, half_way + spacing_y - 20, $"Req:{_recruit_world.recruit_cost * 2}");
-                        if (_recruit_world.recruit_cost > 0) {
-                            recruitment_costdown_button.update({x1: xx + (spacing_x * 2) + 35, y1: half_way + spacing_y});
-                            recruitment_costdown_button.draw(true);
-                        }
-                        if (_recruit_world.recruit_cost < 5) {
-                            recruitment_costup_button.update({x1: xx + (spacing_x * 3) + 35, y1: half_way + spacing_y});
-                            recruitment_costup_button.draw(true);
-                        }
-                    }
-                }
-            }
-        };
-        garrison_data_slate.draw(344 + main_data_slate.width - 4, 160, 0.6, 0.6);
+        garrison_data_slate.inside_method = function(){
+            p_data.draw_planet_population_controls();
+        }
+        garrison_data_slate.draw(344+main_data_slate.width-4, 160, 0.6, 0.6);          
+    }   
+    if (obj_controller.selecting_planet>0){
+        main_data_slate.draw(344,160, slate_draw_scale, slate_draw_scale+0.1);
     }
-    if (obj_controller.selecting_planet > 0) {
-        main_data_slate.draw(344, 160, slate_draw_scale, slate_draw_scale + 0.1);
+    var current_button="";
+    var shutter_x = main_data_slate.XX-165;
+    var shutter_y = 296+165;
+    if (!debug){
+        if (shutter_1.draw_shutter(shutter_x, shutter_y, button1, 0.5, true)) then current_button=button1;
+        if (shutter_2.draw_shutter(shutter_x, shutter_y+47, button2,0.5, true))then current_button=button2;
+        if (shutter_3.draw_shutter(shutter_x, shutter_y+(47*2), button3,0.5, true))then current_button=button3;
+        if (shutter_4.draw_shutter(shutter_x, shutter_y+(47*3), button4,0.5, true))then current_button=button4;
     }
-    var current_button = "";
-    var shutter_x = main_data_slate.XX - 165;
-    var shutter_y = 296 + 165;
-    if (!debug) {
-        if (shutter_1.draw_shutter(shutter_x, shutter_y, button1, 0.5, true)) {
-            current_button = button1;
-        }
-        if (shutter_2.draw_shutter(shutter_x, shutter_y + 47, button2, 0.5, true)) {
-            current_button = button2;
-        }
-        if (shutter_3.draw_shutter(shutter_x, shutter_y + (47 * 2), button3, 0.5, true)) {
-            current_button = button3;
-        }
-        if (shutter_4.draw_shutter(shutter_x, shutter_y + (47 * 3), button4, 0.5, true)) {
-            current_button = button4;
-        }
-    }
-    if (current_button != "") {
-        if (array_contains(["Build", "Base", "Arsenal", "Gene-Vault"], current_button)) {
-            var building = instance_create(x, y, obj_temp_build);
-            building.target = target;
-            building.planet = obj_controller.selecting_planet;
-            if (p_data.has_upgrade(eP_FEATURES.SECRET_BASE)) {
-                building.lair = 1;
-            }
-            if (p_data.has_upgrade(eP_FEATURES.ARSENAL)) {
-                building.arsenal = 1;
-            }
-            if (p_data.has_upgrade(eP_FEATURES.GENE_VAULT)) {
-                building.gene_vault = 1;
-            }
-            obj_controller.temp[104] = string(scr_master_loc());
-            obj_controller.menu = 60;
-            with (obj_star_select) {
+    if (current_button!=""){
+        if (array_contains(["Build","Base","Arsenal","Gene-Vault"],current_button)){
+            var building=instance_create(x,y,obj_temp_build);
+            building.target=target;
+            building.planet=obj_controller.selecting_planet;
+            building.lair = p_data.has_upgrade(eP_FEATURES.SECRET_BASE);
+            if (p_data.has_upgrade(eP_FEATURES.ARSENAL)) then building.arsenal=1;
+            if (p_data.has_upgrade(eP_FEATURES.GENE_VAULT)) then building.gene_vault=1;
+            obj_controller.temp[104]=string(scr_master_loc());
+            obj_controller.menu=60;
+            with(obj_star_select){
                 instance_destroy();
             }
-        } else if (current_button == "Raid" && instance_nearest(x, y, obj_p_fleet).acted <= 1) {
-            instance_create_layer(x, y, layer_get_all()[0], obj_drop_select, {p_target: target, planet_number: obj_controller.selecting_planet, sh_target: instance_nearest(x, y, obj_p_fleet), purge: 0});
-        } else if (current_button == "Attack") {
+        }else if (current_button=="Raid" && instance_nearest(x,y,obj_p_fleet).acted<=1){
+            instance_create_layer(x, y, layer_get_all()[0], obj_drop_select,{
+                p_target:target,
+                planet_number : obj_controller.selecting_planet,
+                sh_target:instance_nearest(x,y,obj_p_fleet),
+                purge:0,
+            });
+
+        }else if (current_button=="Attack"){
             var _allow_attack = true;
-            var _targ = !target.present_fleet[1] ? -50 : instance_nearest(x, y, obj_p_fleet);
-            if (instance_exists(_targ)) {
-                if (_targ.acted >= 2) {
+            var _targ = !target.present_fleet[1] ? -50 : instance_nearest(x,y,obj_p_fleet);
+            if (instance_exists(_targ)){
+                if (_targ.acted>=2){
                     _allow_attack = false;
                 }
             }
-            if (_allow_attack) {
-                instance_create_layer(x, y, layer_get_all()[0], obj_drop_select, {p_target: target, planet_number: obj_controller.selecting_planet, attack: true, sh_target: _targ, purge: 0});
-            }
-        } else if (current_button == "Purge") {
+            if (_allow_attack){
+                instance_create_layer(x, y, layer_get_all()[0], obj_drop_select,{
+                    p_target:target,
+                    planet_number : obj_controller.selecting_planet,
+                    attack :true,
+                    sh_target : _targ,
+                    purge:0,
+                }); 
+            }           
+
+        }else if (current_button=="Purge"){
             var _allow_attack = true;
-            var _targ = !target.present_fleet[1] ? -50 : instance_nearest(x, y, obj_p_fleet);
-            if (instance_exists(_targ)) {
-                if (_targ.acted >= 2) {
+            var _targ = !target.present_fleet[1] ? -50 : instance_nearest(x,y,obj_p_fleet);
+            if (instance_exists(_targ)){
+                if (_targ.acted>=2){
                     _allow_attack = false;
                 }
             }
-            if (_allow_attack) {
-                instance_create_layer(x, y, layer_get_all()[0], obj_drop_select, {p_target: target, purge: 1, planet_number: obj_controller.selecting_planet, sh_target: _targ});
+            if (_allow_attack){           
+                instance_create_layer(x, y, layer_get_all()[0], obj_drop_select,{
+                    p_target:target,
+                    purge:1,
+                    planet_number : obj_controller.selecting_planet,
+                    sh_target : _targ,
+                });
             }
-        } else if (current_button == "Bombard") {
-            instance_create(x, y, obj_bomb_select);
-            if (instance_exists(obj_bomb_select)) {
-                obj_bomb_select.p_target = target;
-                obj_bomb_select.sh_target = instance_nearest(x, y, obj_p_fleet);
+
+        }else if (current_button=="Bombard"){
+            instance_create(x,y,obj_bomb_select);
+            if (instance_exists(obj_bomb_select)){
+                obj_bomb_select.p_target=target;
+                obj_bomb_select.sh_target=instance_nearest(x,y,obj_p_fleet);
                 obj_bomb_select.p_data = p_data;
-                if (instance_nearest(x, y, obj_p_fleet).acted > 0) {
-                    with (obj_bomb_select) {
-                        instance_destroy();
-                    }
+                if (instance_nearest(x,y,obj_p_fleet).acted>0) then with(obj_bomb_select){
+                    instance_destroy();
                 }
             }
-        } else if (current_button == "+Recruiting") {
+        }else if (current_button=="+Recruiting"){
             if (obj_controller.recruiting_worlds_bought > 0 && p_data.current_owner <= 5 && !p_data.at_war()) {
                 if (!p_data.has_feature(eP_FEATURES.RECRUITING_WORLD)) {
                     if (obj_controller.faction_status[eFACTION.IMPERIUM] == "War") {
@@ -446,50 +422,54 @@ if (obj_controller.selecting_planet != 0) {
                     // 135 ; popup?
                 }
             }
-        } else if (current_button == "Cyclonic Torpedo") {
+        }else if (current_button=="Cyclonic Torpedo"){
             scr_destroy_planet(2);
         }
-    }
+    } 
 }
 
-if (target != 0) {
-    if ((player_fleet > 0) && (imperial_fleet + mechanicus_fleet + inquisitor_fleet + eldar_fleet + ork_fleet + tau_fleet + heretic_fleet > 0)) {
+
+if (target!=0){
+    if (player_fleet>0) and (imperial_fleet+mechanicus_fleet+inquisitor_fleet+eldar_fleet+ork_fleet+tau_fleet+heretic_fleet>0){
         draw_set_color(0);
         draw_set_alpha(0.75);
-        draw_rectangle(37, 413, 270, 452, 0);
+        draw_rectangle(37,413,270,452,0);
         draw_set_alpha(1);
-
+        
         /*draw_set_color(CM_GREEN_COLOR);draw_rectangle(40,247,253,273,1);*/
-
+        
+        
         draw_set_halign(fa_left);
-
+        
+        
         draw_set_color(0);
         draw_set_font(fnt_40k_14b);
-        draw_text(37, 413, "Select Fleet Combat");
-
+        draw_text(37,413,"Select Fleet Combat");
+        
         draw_set_color(CM_GREEN_COLOR);
         draw_set_font(fnt_40k_14b);
-        draw_text(37.5, 413.5, "Select Fleet Combat");
-
-        var i, x3, y3;
-        i = 0;
+        draw_text(37.5,413.5,"Select Fleet Combat");
+        
         // x3=46;y3=252;
-        x3 = 49;
-        y3 = 441;
-
-        repeat (7) {
-            i += 1;
-            if (en_fleet[i] > 0) {
+        var x3=49,y3=441;
+        
+        for (var i=1;i<=7;i++){
+            if (en_fleet[i]>0){
                 // draw_sprite_ext(spr_force_icon,en_fleet[i],x3,y3,0.5,0.5,0,c_white,1);
-                scr_image("ui/force", en_fleet[i], x3 - 16, y3 - 16, 32, 32);
-                x3 += 64;
+                scr_image("ui/force",en_fleet[i],x3-16,y3-16,32,32);
+                x3+=64;
             }
         }
     }
 }
 
 pop_draw_return_values();
+}catch(_exception){
+    handle_exception(_exception);
+    instance_destroy();
+}
 
 /* */
+
 
 /*  */

--- a/scripts/scr_PlanetData/scr_PlanetData.gml
+++ b/scripts/scr_PlanetData/scr_PlanetData.gml
@@ -1307,9 +1307,9 @@ function PlanetData(planet, system) constructor {
 
     static create_planet_garrison = function() {
         var company_data = obj_controller.company_data;
-        var _squad_id = company_data.company_squads[company_data.cur_squad];
-        var current_squad = fetch_squad(_squad_id);
+        var current_squad = company_data.grab_current_squad();
         current_squad.set_location(system.name, 0, planet);
+        
         var _mission = obj_star_select.mission;
         current_squad.assignment = {
             type: _mission,
@@ -1318,7 +1318,7 @@ function PlanetData(planet, system) constructor {
         };
         var operation_data = {
             type: "squad",
-            reference: _squad_id,
+            reference: current_squad.uid,
             job: _mission,
             task_time: 0,
         };
@@ -1344,53 +1344,56 @@ function PlanetData(planet, system) constructor {
             planet_draw = c_red;
             tooltip_draw("Can't garrison on non-friendly planet or planet with no friendly PDF", 150);
         }
-        if (mouse_check_button_pressed(mb_left)) {
-            if (garrison_assignment) {
-                if (!(garrison_issue && _mission == "garrison")) {
-                    create_planet_garrison();
-                    exit;
-                }
-            } else if (!_loading) {
-                garrison = new GarrisonForce(operatives);
-                system.garrison = garrison.garrison_force;
-                feature = "";
-                buttons_selected = false;
-            } else if (_loading && planet > 0) {
-                obj_controller.unload = planet;
-                obj_controller.return_object = system;
-                obj_controller.return_size = obj_controller.man_size;
-                edit_player_forces(obj_controller.man_size);
+        if (!mouse_check_button_pressed(mb_left)) {
+            return;
+        }
 
-                // 135 ; SPECIAL PLANET CRAP HERE
-
-                // Recon Stuff
-
-                if (has_problem("recon")) {
-                    var arti = instance_create(system.x, system.y, obj_temp7); // Unloading / artifact crap
-
-                    arti.num = planet;
-                    arti.alarm[0] = 1;
-                    arti.loc = obj_controller.selecting_location;
-                    arti.managing = obj_controller.managing;
-                    arti.type = "recon";
-
-                    with (arti) {
-                        setup_planet_mission_group();
-                    }
-                }
-                if (!instance_exists(obj_ground_mission)) {
-                    check_for_artifact_grab_mission();
-                }
-                if (!instance_exists(obj_ground_mission)) {
-                    check_for_stc_grab_mission();
-                }
-                // Ancient Ruins
-                if (!instance_exists(obj_ground_mission)) {
-                    scr_check_for_ruins_exploration();
-                }
-                instance_destroy(obj_star_select);
+        if (garrison_assignment) {
+            if (!(garrison_issue && _mission == "garrison")) {
+                create_planet_garrison();
                 exit;
             }
+        } else if (!_loading) {
+            garrison = new GarrisonForce(operatives);
+            LOGGER.info($"{garrison.garrison_force}");
+            system.garrison = garrison.garrison_force;
+            feature = "";
+            buttons_selected = false;
+        } else if (_loading && planet > 0) {
+            obj_controller.unload = planet;
+            obj_controller.return_object = system;
+            obj_controller.return_size = obj_controller.man_size;
+            edit_player_forces(obj_controller.man_size);
+
+            // 135 ; SPECIAL PLANET CRAP HERE
+
+            // Recon Stuff
+
+            if (has_problem("recon")) {
+                var arti = instance_create(system.x, system.y, obj_temp7); // Unloading / artifact crap
+
+                arti.num = planet;
+                arti.alarm[0] = 1;
+                arti.loc = obj_controller.selecting_location;
+                arti.managing = obj_controller.managing;
+                arti.type = "recon";
+
+                with (arti) {
+                    setup_planet_mission_group();
+                }
+            }
+            if (!instance_exists(obj_ground_mission)) {
+                check_for_artifact_grab_mission();
+            }
+            if (!instance_exists(obj_ground_mission)) {
+                check_for_stc_grab_mission();
+            }
+            // Ancient Ruins
+            if (!instance_exists(obj_ground_mission)) {
+                scr_check_for_ruins_exploration();
+            }
+            instance_destroy(obj_star_select);
+            exit;
         }
-    };
+    }
 }

--- a/scripts/scr_PlanetData/scr_PlanetData.gml
+++ b/scripts/scr_PlanetData/scr_PlanetData.gml
@@ -1396,8 +1396,6 @@ function PlanetData(planet, system) constructor {
             exit;
         }
     }
-}
-
 
     static planet_selection_logic = function(){
         var planet_is_allies = scr_is_planet_owned_by_allies(system, planet);
@@ -1517,4 +1515,6 @@ static draw_planet_population_controls = function(){
             }
         }
     }
+
+}
 

--- a/scripts/scr_PlanetData/scr_PlanetData.gml
+++ b/scripts/scr_PlanetData/scr_PlanetData.gml
@@ -1399,6 +1399,9 @@ function PlanetData(planet, system) constructor {
     static draw_planet_population_controls = function(){
         draw_set_color(c_gray);
         var _gar_slate = obj_star_select.garrison_data_slate;
+        _gar_slate.sub_title = "";
+        _gar_slate.body_text = "";
+        _gar_slate.title = "";
         var xx = _gar_slate.XX;
         var yy = _gar_slate.YY;                
         var _half_way =  _gar_slate.height/2;

--- a/scripts/scr_PlanetData/scr_PlanetData.gml
+++ b/scripts/scr_PlanetData/scr_PlanetData.gml
@@ -947,7 +947,7 @@ function PlanetData(planet, system) constructor {
             draw_text(xx + 480, yy + 196, $"{system.name} {nm}  ({planet_type})");
         }
         if (is_craftworld) {
-            draw_text(xx + 480, yy + 196, string(system.name) + " (Craftworld)");
+            draw_text(xx + 480, yy + 196,  + $"{system.name} (Craftworld)");
         }
         // if (is_craftworld=0) and (is_hulk=0) then draw_text(xx+534,yy+214,string(planet_type)+" World");
         // if (is_craftworld=1) then draw_text(xx+594,yy+214,"Craftworld");
@@ -1416,7 +1416,7 @@ function PlanetData(planet, system) constructor {
                     y1:_half_way,
                 });
 
-                _col_button.draw(array_length(potential_donors));
+                _col_button.draw(array_length(obj_star_select.potential_donors));
 
                 var _recruit_button = obj_star_select.recruiting_button;
 
@@ -1448,7 +1448,7 @@ function PlanetData(planet, system) constructor {
                     y1:_half_way,
                     allow_click : true,
                 });
-                
+
                 _type_button.draw(true);
 
                 draw_text(xx+(spacing_x*3)-15, _half_way+(spacing_y)-20, $"Req:{_recruit_world.recruit_cost * 2}");

--- a/scripts/scr_PlanetData/scr_PlanetData.gml
+++ b/scripts/scr_PlanetData/scr_PlanetData.gml
@@ -1456,3 +1456,65 @@ function PlanetData(planet, system) constructor {
             
         }        
     }
+
+static draw_planet_population_controls = function(){
+        draw_set_color(c_gray);
+        var _gar_slate = obj_star_select.garrison_data_slate;
+        var xx = _gar_slate.XX;
+        var yy = _gar_slate.YY;                
+        var _half_way =  _gar_slate.height/2;
+        var spacing_x = 100
+        var spacing_y = 65
+        draw_set_halign(fa_left);
+        if (!target.space_hulk) {
+            if (obj_controller.faction_status[eFACTION.IMPERIUM] != "War" && current_owner <= 5) || (obj_controller.faction_status[eFACTION.IMPERIUM] == "War") {
+                colonist_button.update({
+                    x1:xx+35,
+                    y1:_half_way,
+                });
+                colonist_button.draw(array_length(potential_donors));
+
+                recruiting_button.update({
+                    x1:xx+(spacing_x*2)+15,
+                    y1:_half_way,
+                    allow_click : true,
+                });
+                recruiting_button.draw();
+                if (has_feature(eP_FEATURES.RECRUITING_WORLD)) {
+                    var _recruit_world = get_features(eP_FEATURES.RECRUITING_WORLD)[0];
+                    if (_recruit_world.recruit_type == 0) && (obj_controller.faction_status[current_owner] != "War" && obj_controller.faction_status[p_data.current_owner] != "Antagonism" || p_data.player_disposition >= 50) {
+                        draw_text(xx+(spacing_x*3)+35, _half_way-20, "Open: Voluntery");
+                    } else if (_recruit_world.recruit_type == 0 && player_disposition <= 50) {
+                        draw_text(xx+(spacing_x*3)+35, _half_way-20, "Covert: Voluntery");
+                    } else {
+                        draw_text(xx+(spacing_x*3)+35, _half_way-20, "Abduct");
+                    }
+                    recruitment_type_button.update({
+                        x1:xx+(spacing_x*3)+35,
+                        y1:_half_way,
+                        allow_click : true,
+                    });
+                    recruitment_type_button.draw(true);
+
+                    draw_text(xx+(spacing_x*3)-15, _half_way+(spacing_y)-20, $"Req:{_recruit_world.recruit_cost * 2}");
+                    if (_recruit_world.recruit_cost > 0) {
+                        recruitment_costdown_button.update({
+                            x1:xx+(spacing_x*2)+35,
+                            y1:_half_way+(spacing_y),
+                            allow_click : true,
+                        });
+                        recruitment_costdown_button.draw(true);
+                    }
+                    if (_recruit_world.recruit_cost < 5) {
+                        recruitment_costup_button.update({
+                            x1:xx+(spacing_x*3)+35,
+                            y1:_half_way+(spacing_y),
+                            allow_click : true,
+                        });
+                        recruitment_costup_button.draw(true);
+                    }
+                }
+            }
+        }
+    }
+

--- a/scripts/scr_PlanetData/scr_PlanetData.gml
+++ b/scripts/scr_PlanetData/scr_PlanetData.gml
@@ -1354,10 +1354,9 @@ function PlanetData(planet, system) constructor {
                 exit;
             }
         } else if (!_loading) {
-            garrison = new GarrisonForce(operatives);
-            LOGGER.info($"{garrison.garrison_force}");
-            system.garrison = garrison.garrison_force;
-            feature = "";
+            obj_star_select.garrison = new GarrisonForce(operatives);
+            system.garrison = obj_star_select.garrison.garrison_force;
+            obj_star_select.feature = "";
             buttons_selected = false;
         } else if (_loading && planet > 0) {
             obj_controller.unload = planet;
@@ -1397,65 +1396,7 @@ function PlanetData(planet, system) constructor {
         }
     }
 
-    static planet_selection_logic = function(){
-        var planet_is_allies = scr_is_planet_owned_by_allies(system, planet);
-        var garrison_issue = (!planet_is_allies || pdf<=0);
-        var _mission = variable_instance_exists(obj_star_select,"mission") ? obj_star_select.mission : "";
-
-        var _loading =  obj_star_select.loading;
-        var garrison_assignment = obj_controller.view_squad && _loading;
-        if (garrison_assignment && (garrison_issue && _mission=="garrisons")){
-            planet_draw = c_red;
-            tooltip_draw("Can't garrisons on non-friendly planet or planet with no friendly PDF", 150);                  
-        }
-        if (mouse_check_button_pressed(mb_left)){
-            if (garrison_assignment){
-                if (!(garrison_issue && _mission=="garrisons")){
-                    create_planet_garrison();
-                    exit;
-                }
-            } else if (!_loading){
-                garrisons.update(operatives);
-                system.garrisons = garrisons.garrison_force;
-                feature="";
-                buttons_selected=false;                 
-            } else if (_loading && planet >0){ 
-
-                obj_controller.unload=planet;
-                obj_controller.return_object=system;
-                obj_controller.return_size=obj_controller.man_size;
-                edit_player_forces(obj_controller.man_size)
-                
-                // 135 ; SPECIAL PLANET CRAP HERE
-                
-                // Recon Stuff
-
-                if (has_problem("recon")){
-                    var arti=instance_create(system.x,system.y,obj_temp7);// Unloading / artifact crap
-
-                    arti.num=planet;
-                    arti.alarm[0]=1;
-                    arti.loc=obj_controller.selecting_location;
-                    arti.managing=obj_controller.managing;
-                    arti.type="recon";
-
-                    with (arti){
-                        setup_planet_mission_group()
-                    }
-                }
-                if (!instance_exists(obj_ground_mission)){
-                    check_for_artifact_grab_mission();
-                    check_for_stc_grab_mission();
-                    scr_check_for_ruins_exploration(); 
-                } 
-                instance_destroy(obj_star_select);
-                exit;
-            }                       
-            
-        }        
-    }
-
-static draw_planet_population_controls = function(){
+    static draw_planet_population_controls = function(){
         draw_set_color(c_gray);
         var _gar_slate = obj_star_select.garrison_data_slate;
         var xx = _gar_slate.XX;
@@ -1464,54 +1405,71 @@ static draw_planet_population_controls = function(){
         var spacing_x = 100
         var spacing_y = 65
         draw_set_halign(fa_left);
-        if (!target.space_hulk) {
-            if (obj_controller.faction_status[eFACTION.IMPERIUM] != "War" && current_owner <= 5) || (obj_controller.faction_status[eFACTION.IMPERIUM] == "War") {
-                colonist_button.update({
+        if (!is_hulk) {
+            var _imperium_status = obj_controller.faction_status[eFACTION.IMPERIUM];
+            if (_imperium_status != "War" && current_owner <= 5) || (_imperium_status == "War") {
+
+                var _col_button = obj_star_select.colonist_button;
+
+                _col_button.update({
                     x1:xx+35,
                     y1:_half_way,
                 });
-                colonist_button.draw(array_length(potential_donors));
 
-                recruiting_button.update({
+                _col_button.draw(array_length(potential_donors));
+
+                var _recruit_button = obj_star_select.recruiting_button;
+
+                _recruit_button.update({
                     x1:xx+(spacing_x*2)+15,
                     y1:_half_way,
                     allow_click : true,
                 });
-                recruiting_button.draw();
-                if (has_feature(eP_FEATURES.RECRUITING_WORLD)) {
-                    var _recruit_world = get_features(eP_FEATURES.RECRUITING_WORLD)[0];
-                    if (_recruit_world.recruit_type == 0) && (obj_controller.faction_status[current_owner] != "War" && obj_controller.faction_status[p_data.current_owner] != "Antagonism" || p_data.player_disposition >= 50) {
-                        draw_text(xx+(spacing_x*3)+35, _half_way-20, "Open: Voluntery");
-                    } else if (_recruit_world.recruit_type == 0 && player_disposition <= 50) {
-                        draw_text(xx+(spacing_x*3)+35, _half_way-20, "Covert: Voluntery");
-                    } else {
-                        draw_text(xx+(spacing_x*3)+35, _half_way-20, "Abduct");
-                    }
-                    recruitment_type_button.update({
-                        x1:xx+(spacing_x*3)+35,
-                        y1:_half_way,
+
+                _recruit_button.draw();
+
+                if (!has_feature(eP_FEATURES.RECRUITING_WORLD)) {
+                    return;
+                }
+
+                var _recruit_world = get_features(eP_FEATURES.RECRUITING_WORLD)[0];
+                var _recruit_string = "Abduct"
+                if (_recruit_world.recruit_type == 0) && (owner_status() != "War" && owner_status() != "Antagonism" || player_disposition >= 50) {
+                    _recruit_string = "Open: Voluntery";
+                } else if (_recruit_world.recruit_type == 0 && player_disposition <= 50) {
+                    _recruit_string = "Covert: Voluntery";
+                }
+
+                draw_text(xx+(spacing_x*3)+35, _half_way-20, _recruit_string);
+
+                var _type_button = obj_star_select.recruitment_type_button;
+                _type_button.update({
+                    x1:xx+(spacing_x*3)+35,
+                    y1:_half_way,
+                    allow_click : true,
+                });
+                
+                _type_button.draw(true);
+
+                draw_text(xx+(spacing_x*3)-15, _half_way+(spacing_y)-20, $"Req:{_recruit_world.recruit_cost * 2}");
+
+                if (_recruit_world.recruit_cost > 0) {
+                    obj_star_select.recruitment_costdown_button.update({
+                        x1:xx+(spacing_x*2)+35,
+                        y1:_half_way+(spacing_y),
                         allow_click : true,
                     });
-                    recruitment_type_button.draw(true);
-
-                    draw_text(xx+(spacing_x*3)-15, _half_way+(spacing_y)-20, $"Req:{_recruit_world.recruit_cost * 2}");
-                    if (_recruit_world.recruit_cost > 0) {
-                        recruitment_costdown_button.update({
-                            x1:xx+(spacing_x*2)+35,
-                            y1:_half_way+(spacing_y),
-                            allow_click : true,
-                        });
-                        recruitment_costdown_button.draw(true);
-                    }
-                    if (_recruit_world.recruit_cost < 5) {
-                        recruitment_costup_button.update({
-                            x1:xx+(spacing_x*3)+35,
-                            y1:_half_way+(spacing_y),
-                            allow_click : true,
-                        });
-                        recruitment_costup_button.draw(true);
-                    }
+                    obj_star_select.recruitment_costdown_button.draw(true);
                 }
+                if (_recruit_world.recruit_cost < 5) {
+                    obj_star_select.recruitment_costup_button.update({
+                        x1:xx+(spacing_x*3)+35,
+                        y1:_half_way+(spacing_y),
+                        allow_click : true,
+                    });
+                    obj_star_select.recruitment_costup_button.draw(true);
+                }
+
             }
         }
     }

--- a/scripts/scr_PlanetData/scr_PlanetData.gml
+++ b/scripts/scr_PlanetData/scr_PlanetData.gml
@@ -947,7 +947,7 @@ function PlanetData(planet, system) constructor {
             draw_text(xx + 480, yy + 196, $"{system.name} {nm}  ({planet_type})");
         }
         if (is_craftworld) {
-            draw_text(xx + 480, yy + 196,  + $"{system.name} (Craftworld)");
+            draw_text(xx + 480, yy + 196, $"{system.name} (Craftworld)");
         }
         // if (is_craftworld=0) and (is_hulk=0) then draw_text(xx+534,yy+214,string(planet_type)+" World");
         // if (is_craftworld=1) then draw_text(xx+594,yy+214,"Craftworld");

--- a/scripts/scr_PlanetData/scr_PlanetData.gml
+++ b/scripts/scr_PlanetData/scr_PlanetData.gml
@@ -1397,3 +1397,62 @@ function PlanetData(planet, system) constructor {
         }
     }
 }
+
+
+    static planet_selection_logic = function(){
+        var planet_is_allies = scr_is_planet_owned_by_allies(system, planet);
+        var garrison_issue = (!planet_is_allies || pdf<=0);
+        var _mission = variable_instance_exists(obj_star_select,"mission") ? obj_star_select.mission : "";
+
+        var _loading =  obj_star_select.loading;
+        var garrison_assignment = obj_controller.view_squad && _loading;
+        if (garrison_assignment && (garrison_issue && _mission=="garrisons")){
+            planet_draw = c_red;
+            tooltip_draw("Can't garrisons on non-friendly planet or planet with no friendly PDF", 150);                  
+        }
+        if (mouse_check_button_pressed(mb_left)){
+            if (garrison_assignment){
+                if (!(garrison_issue && _mission=="garrisons")){
+                    create_planet_garrison();
+                    exit;
+                }
+            } else if (!_loading){
+                garrisons.update(operatives);
+                system.garrisons = garrisons.garrison_force;
+                feature="";
+                buttons_selected=false;                 
+            } else if (_loading && planet >0){ 
+
+                obj_controller.unload=planet;
+                obj_controller.return_object=system;
+                obj_controller.return_size=obj_controller.man_size;
+                edit_player_forces(obj_controller.man_size)
+                
+                // 135 ; SPECIAL PLANET CRAP HERE
+                
+                // Recon Stuff
+
+                if (has_problem("recon")){
+                    var arti=instance_create(system.x,system.y,obj_temp7);// Unloading / artifact crap
+
+                    arti.num=planet;
+                    arti.alarm[0]=1;
+                    arti.loc=obj_controller.selecting_location;
+                    arti.managing=obj_controller.managing;
+                    arti.type="recon";
+
+                    with (arti){
+                        setup_planet_mission_group()
+                    }
+                }
+                if (!instance_exists(obj_ground_mission)){
+                    check_for_artifact_grab_mission();
+                    check_for_stc_grab_mission();
+                    scr_check_for_ruins_exploration(); 
+                } 
+                instance_destroy(obj_star_select);
+                exit;
+            }                       
+            
+        }        
+    }

--- a/scripts/scr_company_struct/scr_company_struct.gml
+++ b/scripts/scr_company_struct/scr_company_struct.gml
@@ -187,7 +187,7 @@ function CompanyStruct(comp) constructor {
         }
         var sprite_draw_delay = "none";
         var unit_sprite_coords = {};
-        var _cur_squad = company_squads[current_squad];
+        var _cur_squad = grab_current_squad();
         var _reset_surface = false;
         var _member = _cur_squad.fetch_member(0);
         if (array_length(squad_draw_surfaces) == 0 || (squad_draw_surfaces[0][0] != _member.uid)) {
@@ -273,7 +273,7 @@ function CompanyStruct(comp) constructor {
 
     static draw_squad_assignment_options = function() {
         var _squad_sys = squad_loc.system;
-        var _cur_squad = company_squads[current_squad];
+        var _cur_squad = grab_current_squad();
         if (_cur_squad.assignment == "none") {
             draw_text_transformed(xx + bound_width[0] + 5, yy + bound_height[0] + 125, $"Squad has no current assignments", 1, 1, 0);
 

--- a/scripts/scr_garrison/scr_garrison.gml
+++ b/scripts/scr_garrison/scr_garrison.gml
@@ -38,41 +38,45 @@ function GarrisonForce(planet_operatives, turn_end = false, type = "garrison") c
     viable_garrison = 0;
     var operative, unit, member;
     for (var ops = 0; ops < array_length(planet_operatives); ops++) {
-        if (planet_operatives[ops].type == "squad") {
-            if (planet_operatives[ops].job == type) {
-                //marine garrison on planet
-                var _squad = fetch_squad(planet_operatives[ops].reference);
-                if (array_length(_squad.members) > 0) {
-                    operative = _squad;
-                    array_push(garrison_squads, operative);
-                    total_garrison += array_length(operative.members);
-                    garrison_force = true;
-                    for (var i = 0; i < array_length(operative.members); i++) {
-                        member = operative.members[i];
-                        unit = fetch_unit([member[0], member[1]]);
-                        if (!is_struct(unit)) {
-                            continue;
-                        }
-                        if (unit.name() == "") {
-                            continue;
-                        }
-                        array_push(members, unit);
-                        if (unit.hp() > 0) {
-                            viable_garrison++;
-                        }
-                    }
-                    if (turn_end) {
-                        planet_operatives[ops].task_time++;
-                    }
-                    if (planet_operatives[ops].task_time > time_on_planet) {
-                        time_on_planet = planet_operatives[ops].task_time;
-                    }
-                } else {
-                    array_delete(planet_operatives, ops, 1);
-                    ops--;
+        var _op = planet_operatives[ops];
+        if (_op.type == "squad") {
+            if (_op.job != type) {
+                continue;
+            }
+            //marine garrison on planet
+            var _squad = fetch_squad(_op.reference);
+            if (array_length(_squad.members) <= 0) {
+                continue;
+            }
+
+            operative = _squad;
+            array_push(garrison_squads, operative);
+            total_garrison += array_length(operative.members);
+            garrison_force = true;
+            for (var i = 0; i < array_length(operative.members); i++) {
+                unit = operative.fetch_member(i);
+                if (!is_struct(unit)) {
+                    continue;
+                }
+                if (unit.name() == "") {
+                    continue;
+                }
+                array_push(members, unit);
+                if (unit.hp() > 0) {
+                    viable_garrison++;
                 }
             }
+            if (turn_end) {
+                _op.task_time++;
+            }
+            if (_op.task_time > time_on_planet) {
+                time_on_planet = _op.task_time;
+            }
+        } else {
+            array_delete(planet_operatives, ops, 1);
+            ops--;
         }
+
     }
 
     static garrison_sustain_damages = function(win_or_loss) {
@@ -120,7 +124,7 @@ function GarrisonForce(planet_operatives, turn_end = false, type = "garrison") c
         var unit;
         for (var _squad = 0; _squad < array_length(garrison_squads); _squad++) {
             var _leader = garrison_squads[_squad].determine_leader();
-            unit = obj_ini.TTRPG[_leader[0]][_leader[1]];
+            unit = fetch_unit(_leader);
             if (garrison_leader == "none") {
                 garrison_leader = unit;
                 for (var r = 0; r < array_length(hierarchy); r++) {

--- a/scripts/scr_garrison/scr_garrison.gml
+++ b/scripts/scr_garrison/scr_garrison.gml
@@ -46,6 +46,8 @@ function GarrisonForce(planet_operatives, turn_end = false, type = "garrison") c
             //marine garrison on planet
             var _squad = fetch_squad(_op.reference);
             if (array_length(_squad.members) <= 0) {
+                array_delete(planet_operatives, ops, 1);
+                ops--;
                 continue;
             }
 
@@ -72,9 +74,6 @@ function GarrisonForce(planet_operatives, turn_end = false, type = "garrison") c
             if (_op.task_time > time_on_planet) {
                 time_on_planet = _op.task_time;
             }
-        } else {
-            array_delete(planet_operatives, ops, 1);
-            ops--;
         }
 
     }


### PR DESCRIPTION
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
## Purpose and Description
<!-- Explain why and what your changes do in simple terms. -->
- Self-descriptive.

## Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- None, and I understand the risks.

## Related things and/or additional context
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, screenshots etc. -->
-

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->

<!--- "Inspired" by the CDDA PR template -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash when opening the garrison panel and stabilizes the planet screen UI (garrison and recruiting). Also hardens the star selection Draw path to avoid null-state and interaction-related crashes.

- **Bug Fixes**
  - Make garrison creation null-safe: process only squad-type operatives with matching job, drop empty squads, fetch members via `squad.fetch_member()`/`fetch_unit()`, and count viable units reliably.
  - Determine garrison leader with `fetch_unit()` to avoid `obj_ini` indexing crashes.
  - Wrap the star-select Draw event in try/catch with `handle_exception()` in the catch and destroy the instance; add early exits and improve close logic to prevent click-through, honoring shutter/menu and slate interactions.
  - Create and cache `p_data` per planet (`target.system_datas`) to keep UI state consistent across selections.
  - Restore population/recruit controls by moving them into `PlanetData.draw_planet_population_controls()` and wiring the garrison slate; enable recruitment button interactions.
  - Use `company_data.grab_current_squad()` and set squad location/assignment (using the squad `uid`) when creating planet garrisons.
  - Fix UI text and drawing (craftworld/system strings, standard star rendering) and reduce overlapping elements.

<sup>Written for commit 7db158ed5def11f1ab2337003794a4dd5b95e5c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

