### PR TITLE
feat: Finished squad modding and tavish dark angels work

### DIFF
--- a/datafiles/main/chapters/1.JSON
+++ b/datafiles/main/chapters/1.JSON
@@ -179,7 +179,7 @@
         },
         {
           "name": "Traitor's Bane", //the most holy name of your long schlong weapon
-          "description": "Weapon taken by Chief Librarian Ezekiel as his personal favourite, it radiates fell power and traps the souls of an Fallen slain in battle. It is said shadows wrap around the blade when Fallen are near", //write fun stuff
+          "description": "Weapon taken by Chief Librarian Ezekiel as his personal favourite, it radiates fell power and traps the souls of a Fallen slain in battle. It is said shadows wrap around the blade when Fallen are near", //write fun stuff
           "base_weapon_type": "Force Sword", //doesn't matter if it's armour, gear, mobi or anything else, you always use base_weapon_type to define it
           "slot": "" //leave empty if you want it to be stored in the Librarium without assignment
         },

--- a/datafiles/main/chapters/1.JSON
+++ b/datafiles/main/chapters/1.JSON
@@ -209,7 +209,7 @@
         },
         {
           "name": "Deathbringer's Aegis", //the most holy name of your long schlong weapon
-          "description": "One of the six sets of battle plate crafted to mark the Lion's re-envisioning of the Hexagrammaton. However, he Aegis was one of the few relics of Hexagramaton to be forged of Terminator plate, and aside from that contained additional neural regulators and medicae infusers that make the armour perfect in resilience for the Masters of the Deathwing in their role", //write fun stuff
+          "description": "One of the six sets of battle plate crafted to mark the Lion's re-envisioning of the Hexagrammaton. However, the Aegis was one of the few relics of the Hexagrammaton to be forged of Terminator plate, and aside from that contained additional neural regulators and medicae infusers that make the armour perfect in resilience for the Masters of the Deathwing in their role", //write fun stuff
           "base_weapon_type": "Tartaros", //doesn't matter if it's armour, gear, mobi or anything else, you always use base_weapon_type to define it
           "slot": "" //leave empty if you want it to be stored in the Librarium without assignment
         },

--- a/datafiles/main/chapters/1.JSON
+++ b/datafiles/main/chapters/1.JSON
@@ -215,7 +215,7 @@
         },
         {
           "name": "Dreadbringer's Plate", //the most holy name of your long schlong weapon
-          "description": "Formed of hardened Ceramite and ferro-crystalline ores native to Caliban, it is another of the Hexagrammaton relics. Because of its composition it could withstand the most potent of corrosives without damaged. It was said that the First Master of the Dreadwing walked through a maelstrom of Phosphex unscathed.", //write fun stuff
+          "description": "Formed of hardened Ceramite and ferro-crystalline ores native to Caliban, it is another of the Hexagrammaton relics. Because of its composition it could withstand the most potent of corrosives without damage. It was said that the First Master of the Dreadwing walked through a maelstrom of Phosphex unscathed.", //write fun stuff
           "base_weapon_type": "Artificer Armour", //doesn't matter if it's armour, gear, mobi or anything else, you always use base_weapon_type to define it
           "slot": "" //leave empty if you want it to be stored in the Librarium without assignment
         },

--- a/datafiles/main/chapters/1.JSON
+++ b/datafiles/main/chapters/1.JSON
@@ -227,7 +227,7 @@
         },
         {
           "name": "Shield of Calloson", //the most holy name of your long schlong weapon
-          "description": "This Storm Shield is a relic of the Dark Angels, reserved for Deathwing use. its resilience is legendary", //write fun stuff
+          "description": "This Storm Shield is a relic of the Dark Angels, reserved for Deathwing use. Its resilience is legendary", //write fun stuff
           "base_weapon_type": "Storm Shield", //doesn't matter if it's armour, gear, mobi or anything else, you always use base_weapon_type to define it
           "slot": "" //leave empty if you want it to be stored in the Librarium without assignment
         }

--- a/datafiles/main/chapters/1.JSON
+++ b/datafiles/main/chapters/1.JSON
@@ -119,7 +119,7 @@
         },
         {
           "name": "The Protector", //the most holy name of your long schlong weapon
-          "description": "A suit of armour which history starts in the late M37 where Master MEthias of the 5th Company survived a close range battle cannon shot wearing this armour. Henceforth this suit of armour has been given to high ranking Dark Angels until eventually it became one of the symbols of office of the Chapter Master", //write fun stuff
+          "description": "A suit of armour which history starts in the late M37 where Master Methias of the 5th Company survived a close range battle cannon shot wearing this armour. Henceforth this suit of armour has been given to high ranking Dark Angels until eventually it became one of the symbols of office of the Chapter Master", //write fun stuff
           "base_weapon_type": "Artificer Armour", //doesn't matter if it's armour, gear, mobi or anything else, you always use base_weapon_type to define it
           "slot": "armour" //leave empty if you want it to be stored in the Librarium without assignment
         },

--- a/datafiles/main/chapters/1.JSON
+++ b/datafiles/main/chapters/1.JSON
@@ -16,7 +16,7 @@
     "purity": 10, //1-10
     "stability": 99, //1-99
     "cooperation": 8, //1-10
-    "homeworld_exists:": 1, //only is there for an obscure bit of code, but to avoid bugs and crashes keep it as is until we fix it
+    "homeworld_exists": 1, //only is there for an obscure bit of code, but to avoid bugs and crashes keep it as is until we fix it
     "recruiting_exists": 1, //same here
     "home_warp": 1, //[0] low/no connections [1] connected [2] warp hub
     "home_planets": 0, //how many planets in home system, [0]=1 [3]=4

--- a/datafiles/main/chapters/1.JSON
+++ b/datafiles/main/chapters/1.JSON
@@ -149,7 +149,7 @@
         },
         {
           "name": "Fellbane", //the most holy name of your long schlong weapon
-          "description": "Personal weapon of Master Balthasar of the 5th Company, one of the few Heavenflall blades in active service", //write fun stuff
+          "description": "Personal weapon of Master Balthasar of the 5th Company, one of the few Heavenfall blades in active service", //write fun stuff
           "base_weapon_type": "Power Sword", //doesn't matter if it's armour, gear, mobi or anything else, you always use base_weapon_type to define it
           "slot": "" //leave empty if you want it to be stored in the Librarium without assignment
         },

--- a/datafiles/main/chapters/1.JSON
+++ b/datafiles/main/chapters/1.JSON
@@ -1,412 +1,1862 @@
 {
-    "chapter": {
-        "id": 1,
-        "name": "Dark Angels",
-        "flavor": "The Dark Angels claim complete allegiance and service to the Emperor of Mankind, though their actions and secret goals seem to run counter to this- above all other things they strive to atone for an ancient crime of betrayal.",
-        "origin": 1, // 1 - Founding, 2 -successor, 3 - Other/non-canon/fanmade, 4 - Custom
-        "points": 150,
-        "founding": 0, // The id of the founding chapter, 0 for unknown or none
-        "splash": 1,
-        "icon_name": "dark_angels", // ? dunno what this is used for yet but the icon breaks if you dont use it 
-        "fleet_type": 1, // 1= Homeworld, 2 = Fleet based, 3 = Penitent
-        "strength": 10, // 1-10
-        "purity": 10, // 1-10
-        "stability": 96, // 1-99
-        "cooperation": 5, // 1-10
-        "homeworld_exists": 1, // 1 = true
-        "recruiting_exists": 1, // 1 = true
-        "homeworld_rule": 1, // 1 = Govenor, 2 = Countries, 3 = Personal Rule
-        "homeworld": "Dead", // "Lava" "Desert" "Forge" "Hive" "Death" "Agri" "Feudal" "Temperate" "Ice" "Dead" "Shrine"
-        "homeworld_name": "The Rock",
-        "recruiting": "Death", //"Lava" "Desert" "Forge" "Hive" "Death" "Agri" "Feudal" "Temperate" "Ice" "Dead" "Shrine"
-        "recruiting_name": "Kimmeria",
-        "discipline": "librarius", // one of 'default' 'biomancy' 'pyromancy' 'telekinesis' 'rune_magic'
-        "aspirant_trial": "SURVIVAL", // ? need to find the best way to do this
-        "advantages": [ //TODO something with these after rework of adv organisation
-            "",
-            "Enemy: Fallen",
-            "Reverent Guardians",
-            "",
-            "",
-            "",
-            "",
-            "",
-            ""
+  "chapter":
+  {
+    "id": 1, //number for your JSON file to be referenced in game files
+    "name": "Dark Angels", //name of the chapter
+    "flavor": "The Dark Angels are the Progenitor Chapter formed from the First Legion of Primarch Lion El'Johnson. Though through their secretive nature their allegiance and actions may be questionable, they are some of the most deadly and well-armed Astartes in the Imperium", //the short description that appears on popup when you hover over a chapter image
+    "battle_cry": "Repent! For tomorrow you die!", //this is where you cry. I mean this is where you say what are you crying about. I mean... fuck it just type shit here to scream at people
+    "origin": 1, //[1] Founding [2] Successor [3] Other [4] Custom
+    "points": 150, //creation points, feel free to cheat here for more wild stuff in custom if you don't like doing it via files
+    "founding": 1, //ID of the progenitor chapter, as per fiels in datafiles/main/chapters
+    "successors": 19, //write how many successors your chapter has. Go bonkers. Show them you got the seed to have 666 successors
+    "splash": 1, //the more artsy image on the left side of selection screen. Highly advised to use the same number as chapter ID
+    "icon_name": "dark_angels", //name for the chapter icon you'll be using. Standing 
+    "fleet_type": 2, //[1] Homeworld [2] Fleetbased [3] Penitent
+    "strength": 5, //1-10
+    "purity": 10, //1-10
+    "stability": 99, //1-99
+    "cooperation": 8, //1-10
+    "homeworld_exists:": 1, //only is there for an obscure bit of code, but to avoid bugs and crashes keep it as is until we fix it
+    "recruiting_exists": 1, //same here
+    "home_warp": 1, //[0] low/no connections [1] connected [2] warp hub
+    "home_planets": 0, //how many planets in home system, [0]=1 [3]=4
+    "homeworld": "Dead", //Homeworld planet type "Lava" "Desert" "Forge" "Hive" "Death" "Agri" "Feudal" "Temperate" "Ice" "Dead" "Shrine"
+    "homeworld_rule": 1, //[1] Governor [2] Semi-independent [3] Direct Rule
+    "home_spawn_loc": 1, //unsure which is it, probably 0=fringe, 1=central
+    "homeworld_name": "Caliban", //name of the homeworld
+    "monastery_name": "", //name of the F-M structure on the homeplanet.
+    "recruiting": "Dead", //Recruiting world planet type "Lava" "Desert" "Forge" "Hive" "Death" "Agri" "Feudal" "Temperate" "Ice" "Dead" "Shrine"
+    "recruiting_name": "Caliban", //recruiting world name
+    "recruit_home_relationship": 0, //[0] same planet [1] same system [2] different system
+    "discipline": "librarius", //one of 'default' 'biomancy' 'pyromancy' 'telekinesis' 'rune_magic'
+    "aspirant_trial": 2, //[0]"BLOODDUEL" [1]"HUNTING" [2]"SURVIVAL" [3]"EXPOSURE" [4]"KNOWLEDGE" [5]"CHALLENGE" [6]"APPRENTICESHIP"
+    "advantages": //Self-Explanatory
+      [
+        "", //first blank cause reasons
+        "Enemy: Fallen",
+        "Ancient Armoury",
+        "Paragon",
+        "Retinue of Renown",
+        "",
+        "",
+        "",
+        ""
+      ],
+    "disadvantages": //S-E
+      [
+        "", //first blank cause reasons
+        "Never Forgive",
+        "Suspicious",
+        "",
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+    "mutations": //defines which mutations are present
+      {
+        "mucranoid":0,
+        "zygote":0,
+        "secretions":0,
+        "doomed":0,
+        "occulobe":0,
+        "membrane":0,
+        "lyman":0,
+        "betchers":0,
+        "ossmodula":0,
+        "omophagea":0,
+        "voice":0,
+        "catalepsean":0,
+        "preomnor":0
+      },
+    "disposition":
+      [
+        0,  //nothing, probably self
+        0,  //Progenitor
+        70,  //Imperium
+        65,  //Admech
+        50,  //=][=
+        60,  //Ecclesiarchy
+        0,  //Astartes
+        0   //Nothing
+      ],
+    "colors": //main or default colours for your chapter. Check a pasted table or scr_colors_initialize.gml for the color array
+      {
+        "special": 0, // 0 - normal, 1 - Breastplate, 2 - Vertical, 3 - Quadrant
+        "main": "Caliban Green",
+        "weapon": "Dark Red",
+        "pauldron_l": "Caliban Green",
+        "pauldron_r": "Caliban Green",
+        "trim": "Silver",
+        "secondary": "Caliban Green",
+        "lens": "Red"
+      },
+    "culture_styles":   //write in the styles you want
+      [
+        "Knightly",
+      ],
+    "chapter_master":
+      {
+        "name": "Azrael", //name for your chapter master, leave blank for random
+        "traits": //currently kinda not working, he's guaranteed to have Lead by Example though
+        [
+          "old_guard"
         ],
-        "disadvantages": [
-            "",
-            "Never Forgive",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            ""
-        ],
-        "colors": {
-            "main": "Caliban Green",
-            "secondary": "Caliban Green",
-            "pauldron_r": "Caliban Green", // todo update refs for new names
-            "pauldron_l": "Caliban Green",
-            "trim": "Grey",
-            "lens": "Red",
-            "weapon": "Dark Red",
-            "special": 0, // 0 - normal, 1 - Breastplate, 2 - Vertical, 3 - Quadrant
-            //"trim_on": 0 // 0 no, 1 yes for special trim colours // todo update ref for new name
+        "specialty": 1, //1 Leader, 2 Champion, 3 Psyker
+        "melee": 1, //[1]twin power fists [2]twin lighting claws [3]Relic blade [4]Thunder Hammer [5]Power Sword [6]Power axe [7]Eviscerator [8]Force staff
+        "ranged": 1, //[1]boltstorm gauntlet [2]Infernus pistol [3]Plasma pistol [4]Plasma gun [5]MC Heavy Bolter [6]Mc Meltagun [7]Storm Shield
+        "armour": "", //default is Artificer, dont' need to put anything unless you want something different
+        "gear": "" //default is Iron Halo, same as above
+      },
+    "artifact": //copy and paste the template below as many times as you like
+      [
+        {
+          "name": "Sword of Secrets", //the most holy name of your long schlong weapon
+          "description": "An ancient power sword, one of the sacred Heavenfall Blades carved from the core of an obsidian meteorite that struck the Rock thousands of years past", //write fun stuff
+          "base_weapon_type": "Power Sword", //doesn't matter if it's armour, gear, mobi or anything else, you always use base_weapon_type to define it
+          "slot": "wep1" //leave empty if you want it to be stored in the Librarium without assignment
         },
-        "culture_styles": [
-            "Knightly",
-        ],
-        "names": {
-            //Chapter Staff
-            "hchaplain": "Sapphon",
-            "clibrarian": "Ezekial",
-            "fmaster": "Sepharon",
-            "hapothecary": "Razaek",
-            //Company Captains 1 - 10
-            "honorcapt": "Belial",
-            "watchmaster": "Sammael",
-            "arsenalmaster": "Astoran",
-            "admiral": "Korahael",
-            "marchmaster": "Balthazar",
-            "ritesmaster": "Araphil",
-            "victualler": "Ezekiah",
-            "lordexec": "Molochi",
-            "relmaster": "Xerophus",
-            "recruiter": "Ranaeus"
+        {
+          "name": "The Protector", //the most holy name of your long schlong weapon
+          "description": "A suit of armour which history starts in the late M37 where Master MEthias of the 5th Company survived a close range battle cannon shot wearing this armour. Henceforth this suit of armour has been given to high ranking Dark Angels until eventually it became one of the symbols of office of the Chapter Master", //write fun stuff
+          "base_weapon_type": "Artificer Armour", //doesn't matter if it's armour, gear, mobi or anything else, you always use base_weapon_type to define it
+          "slot": "armour" //leave empty if you want it to be stored in the Librarium without assignment
         },
-        "battle_cry": "Repent!  For tomorow you may die",
-        "equal_specialists": 0,
-        "load_to_ships": {
-            "escort_load": 2, // 0 no, 2 yes, 1 doesnt do anything :)
-            "split_scouts": 0, // 0 no, 1 yes
-            "split_vets": 0 // 0 no, 1 yes
+        {
+          "name": "Lion's Wrath", //the most holy name of your long schlong weapon
+          "description": "Constructed during the Great Scouring shortly after the destruction of Caliban, this combi-plasma bolter is a badge of office for the Chapter Master of the Dark Angels since time immemorial", //write fun stuff
+          "base_weapon_type": "Combiplasma", //doesn't matter if it's armour, gear, mobi or anything else, you always use base_weapon_type to define it
+          "slot": "wep2" //leave empty if you want it to be stored in the Librarium without assignment
         },
-        "successors": 9, //total number of successor chapters
-        "mutations": {
-            "preomnor": 0,
-            "voice": 0,
-            "doomed": 0,
-            "lyman": 0,
-            "omophagea": 0,
-            "ossmodula": 0,
-            "membrane": 0,
-            "zygote": 0,
-            "betchers": 0,
-            "catalepsean": 0,
-            "secretions": 0,
-            "occulobe": 0,
-            "mucranoid": 0
+        {
+          "name": "Lion Helm", //the most holy name of your long schlong weapon
+          "description": "Said to have been worn by the Primarch Lion El'Johnson and takes form of a winged Mark VII helmet,with a protective field inbuilt into its innards that can be activated even despite not being worn", //write fun stuff
+          "base_weapon_type": "Iron Halo", //doesn't matter if it's armour, gear, mobi or anything else, you always use base_weapon_type to define it
+          "slot": "gear" //leave empty if you want it to be stored in the Librarium without assignment
         },
-        "disposition": [ // todo maybe convert to struct
-            0, // nothing
-            0, // Progenitor faction
-            65, // Imperium
-            60, // Admech
-            60, //Inquisition
-            60, // Ecclesiarchy
-            50, // Astartes
-            0 // nothing
-        ],
-        "chapter_master": {
-            "name": "Azrael",
-            "specialty": 2, //1 Leader, 2 Champion, 3 Psyker,
-            "melee": 5, // 1 twin power fists ... 8 force staff
-            "ranged": 4, // 1 boltstorm gauntlets ... 7 storm shield
-            // All chapter masters have the trait `Lead by Example` by default
-            "traits": [
-                "old_guard",
-                "melee_enthusiast"
-            ],
-            "gear": "",
-            "mobi": ""
+        {
+          "name": "Blade of Burden", //the most holy name of your long schlong weapon
+          "description": "A relic power sword, given to a Master of the Deathwing upon his promotion from the Knights in the times of Great Crusade", //write fun stuff
+          "base_weapon_type": "Power Sword", //doesn't matter if it's armour, gear, mobi or anything else, you always use base_weapon_type to define it
+          "slot": "" //leave empty if you want it to be stored in the Librarium without assignment
         },
-        "artifact": {
-            "name": "Sword of Secrets",
-            "description": "A master-crafted Power Sword of formidable potency created soon after the disappearance of Lion El'Jonson. It is the mightiest of the Heavenfall Blades",
-            "base_weapon_type": "Power Sword"
+        {
+          "name": "Blade of Corswain", //the most holy name of your long schlong weapon
+          "description": "Granted to Corswain by his mentor Alajos in the times of Great Crusade, this masterwork Terrannic Greatsword has been with a Champion of the Dark Angels since time immemorial", //write fun stuff
+          "base_weapon_type": "Relic Blade", //doesn't matter if it's armour, gear, mobi or anything else, you always use base_weapon_type to define it
+          "slot": "" //leave empty if you want it to be stored in the Librarium without assignment
         },
-        "company_titles": [
-            "",
-            "Deathwing",
-            "Ravenwing",
-            "The Unmerciful",
-            "The Feared",
-            "The Unrelenting",
-            "The Resolute",
-            "The Unbowed",
-            "The Wrathful",
-            "The Remorseless",
-            "The Redeemed"
-        ],
-        "flagship_name": "Invincible Reason",
-        /**
-        * * Default fleet composition
-        * * Homeworld 
-        * - 2 Battle Barges, 8 Strike cruisers, 7 Gladius, 3 Hunters
-        * * Fleet based and Penitent 
-        * - 4 Battle Barges, 3 Strike Cruisers, 7 Gladius, 3 Hunters
-        * 
-        * use negative numbers to subtract ships
-        */
-        "extra_ships": {
-            "battle_barges": 1,
-            "gladius": 0,
-            "strike_cruisers": 0,
-            "hunters": 0
+        {
+          "name": "Fellbane", //the most holy name of your long schlong weapon
+          "description": "Personal weapon of Master Balthasar of the 5th Company, one of the few Heavenflall blades in active service", //write fun stuff
+          "base_weapon_type": "Power Sword", //doesn't matter if it's armour, gear, mobi or anything else, you always use base_weapon_type to define it
+          "slot": "" //leave empty if you want it to be stored in the Librarium without assignment
         },
-        /**
-        * * Default HQ Layout (Does not include company specialists)
-        * - 8 Chaplains, 8 Techmarines, 8 Apothecary, 2 Epistolary (librarian), 
-        * - 2 Codiciery, 4 Lexicanum
-        * * Default Company specialists (divided based on `load_to_ships.split_vets` setting)
-        * - 20 Terminators, 85 Veterans, 20 Devastators, 20 Assault
-        * Use negative numbers to subtract
-        * Stacks with advantages/disadvantages
-        */
-        "extra_specialists": {
-            "chaplains": 0,
-            "techmarines": 0,
-            "apothecary": 0,
-            "epistolary": 0,
-            "codiciery": 0,
-            "lexicanum": 0,
-            "terminator": 80,
-            "assault": 0,
-            "veteran": -80,
-            "devastator": 0
+        {
+          "name": "Lost Mace of Corswain", //the most holy name of your long schlong weapon
+          "description": "Once wielded by the legendary Paladin Corswain, long thought lost, it was recovered from the Space Hulk Olethros by the Deathwing", //write fun stuff
+          "base_weapon_type": "Power Mace", //doesn't matter if it's armour, gear, mobi or anything else, you always use base_weapon_type to define it
+          "slot": "" //leave empty if you want it to be stored in the Librarium without assignment
         },
-        /**
-        * * Default Marine strength
-        * - 100 marines per company
-        * use negative numbers to subtract
-        * Stacks with strength for non-founding chapters
-        */
-        // * Not working yet
-        "extra_marines": {
-            "second": 0,
-            "third": 0,
-            "fourth": 0,
-            "fifth": 0,
-            "sixth": 0,
-            "seventh": 0,
-            "eighth": 0,
-            "ninth": 0,
-            "tenth": 0
+        {
+          "name": "Mace of Redemption", //the most holy name of your long schlong weapon
+          "description": "Used in the early M34 by Supreme Grand Master Raphael to slay the Black Lion Daemon Prince upon the world of New Caliban", //write fun stuff
+          "base_weapon_type": "Mace of Absolution", //doesn't matter if it's armour, gear, mobi or anything else, you always use base_weapon_type to define it
+          "slot": "" //leave empty if you want it to be stored in the Librarium without assignment
         },
-        "extra_vehicles": {
-            "rhino": 0,
-            "whirlwind": 0,
-            "predator": 0,
-            "land_raider": 0
+        {
+          "name": "Raven Sword", //the most holy name of your long schlong weapon
+          "description": "An ancient blade of the Dark Angels Legion, the badge of office for the Ravenwing Master since its creation from pure obsidian ten thousand years ago", //write fun stuff
+          "base_weapon_type": "Power Sword", //doesn't matter if it's armour, gear, mobi or anything else, you always use base_weapon_type to define it
+          "slot": "" //leave empty if you want it to be stored in the Librarium without assignment
         },
-        /** Add extra starting items ["Item Name", Number to add] */
-        "extra_equipment": [
-            // [
-            //     "Bolter",
-            //     20
-            // ]
-        ],
-        /** 
-        * Provide a place to change the default name and equipment preferences of roles for this chapter
-        * `custom_roles` should be used for specialist/leadership type roles, 
-        * for combat roles, `custom_squads` should probably? be used instead 
-        */
-        "custom_roles": {
-            "chapter_master": {
-                "name": "Supreme Grand Master"
-            },
-            "honour_guard": {
-                "name": "Deathwing Knight",
-                "wep1": "Mace of Absolution",
-                "armour": "Terminator Armour"
-            },
-            "captain": {
-                "name": "Master",
-                "wep1": "Power Sword"
-            }
+        {
+          "name": "Sword of Silence", //the most holy name of your long schlong weapon
+          "description": "One of the Heavenfall Blades, this one is wielded by Belial, Master of the Deathwing", //write fun stuff
+          "base_weapon_type": "Power Sword", //doesn't matter if it's armour, gear, mobi or anything else, you always use base_weapon_type to define it
+          "slot": "" //leave empty if you want it to be stored in the Librarium without assignment
         },
-        /**
-        * * Custom squad roles, loadouts and formations
-        * When companies are made, squads are formed based on these rules: 
-        * - squad name: one of captain, terminator, terminator_assault, sternguard_veteran,
-                vanguard_veteran, devastator, tactical, assault, scout, scout_sniper
-        * - squad array layout [Role, Role, ...Role, type_data]
-        * - each element of the array is a default Role, and their settings.
-            - if you changed the role using `custom_roles` you need to reference the role with this new name
-            - for non-leader roles it is better to change the name of the role in the squad layout instead
-        * - unit layout [Role Name, Settings Struct]
-        * - settings struct: 
-        *   - max: The most amount of this unit is allowed per squad
-        *   - min: The squad can't be formed unless at least 1 of this unit is in it
-        *   - role: The name of the unit when it is a member of the squad. This is where you rename roles e.g. 
-                "Terminator" > "Deathwing Terminator" 
-        **  - loadout: Struct containing Required and Optional weaponry this unit can equip 
-                a required loadout always follows this syntax <loadout_slot>:[<loadout_item>,<required number>]
-				so "wep1":["Bolter",4], will mean four marines are always equipped with 4 bolters in the wep1 slot
-        *       option loadouts follow the following syntax <loudout_slot>:[[<loadout_item_list>],<allowed_number>]
-				for example [["Flamer", "Meltagun"],1], means the role can have a max of one flamer or meltagun
-					[["Plasma Pistol","Bolt Pistol"], 4] means the role can have a mix of 4 plasma pistols and bolt pistols on top
-						of all required loadout options
-                - wep1: right hand weapon
-                - wep2: left hand weapon
-                - mobi: Mobility item, e.g. Jump Packs. 
-                - armour: required armour 
-                - gear: special equipment needed for certain roles, like a Roasrius or Narthecium
-        *   - type_data: names the squad, allows certain formations ? idk what that does yet
-        */
-        "squad_name": "Squad",
-        "custom_squads": {
-            "terminator_squad": [
-                // Terminator Sergeant
-                [
-                    "Veteran Sergeant",
-                    {
-                        "max": 1,
-                        "min": 1,
-                        "role": "Deathwing Sergeant",
-                        "loadout": {
-                            "required": {
-                                "wep1": [
-                                    "Power Sword",
-                                    1
-                                ]
-                            }
-                        }
-                    }
-                ],
-                // Terminator
-                [
-                    "Terminator",
-                    {
-                        "max": 4,
-                        "min": 2,
-                        "role": "Deathwing Terminator",
-                        "loadout": {
-                            "required": {
-                                "wep1": [
-                                    "",
-                                    0
-                                ],
-                                "wep2": [
-                                    "Storm Bolter",
-                                    3
-                                ]
-                            },
-                            "option": {
-                                "wep1": [
-                                    [
-                                        [
-                                            "Power Fist",
-                                            "Chainfist"
-                                        ],
-                                        4
-                                    ]
-                                ],
-                                "wep2": [
-                                    [
-                                        [
-                                            "Heavy Flamer",
-                                            "Heavy Flamer",
-                                            "Heavy Flamer",
-                                            "Assault Cannon",
-                                            "Assault Cannon",
-                                            "Plasma Cannon"
-                                        ],
-                                        1
-                                    ]
-                                ]
-                            }
-                        }
-                    }
-                ],
-                [
-                    "type_data",
-                    {
-                        "display_data": "Deathwing Terminator Squad",
-                        "formation_options": [
-                            "terminator",
-                            "veteran",
-                            "assault",
-                            "devastator",
-                            "scout",
-                            "tactical"
-                        ]
-                    }
-                ]
-            ],
-            "terminator_assault_squad": [
-                // Assault Terminator Sergeant
-                [
-                    "Veteran Sergeant",
-                    {
-                        "max": 1,
-                        "min": 1,
-                        "role": "Deathwing Sergeant",
-                        "loadout": {
-                            "required": {
-                                "wep1": [
-                                    "Thunder Hammer",
-                                    1
-                                ],
-                                "wep2": [
-                                    "Storm Shield",
-                                    1
-                                ]
-                            }
-                        }
-                    }
-                ],
-                // Assault Terminator
-                [
-                    "Terminator",
-                    {
-                        "max": 4,
-                        "min": 2,
-                        "role": "Deathwing Terminator",
-                        "loadout": {
-                            "required": {
-                                "wep1": [
-                                    "Thunder Hammer",
-                                    1
-                                ],
-                                "wep2": [
-                                    "Storm Shield",
-                                    1
-                                ]
-                            },
-                            "option": {
-                                "wep1": [
-                                    [
-                                        [
-                                            "Lightning Claw"
-                                        ],
-                                        3,
-                                        {
-                                            "wep2": "Lightning Claw"
-                                        }
-                                    ]
-                                ]
-                            }
-                        }
-                    }
-                ],
-                [
-                    "type_data",
-                    {
-                        "display_data": "Deathwing Terminator Squad",
-                        "formation_options": [
-                            "terminator",
-                            "veteran",
-                            "assault",
-                            "devastator",
-                            "scout",
-                            "tactical"
-                        ]
-                    }
-                ]
-            ]
+        {
+          "name": "Traitor's Bane", //the most holy name of your long schlong weapon
+          "description": "Weapon taken by Chief Librarian Ezekiel as his personal favourite, it radiates fell power and traps the souls of an Fallen slain in battle. It is said shadows wrap around the blade when Fallen are near", //write fun stuff
+          "base_weapon_type": "Force Sword", //doesn't matter if it's armour, gear, mobi or anything else, you always use base_weapon_type to define it
+          "slot": "" //leave empty if you want it to be stored in the Librarium without assignment
+        },
+        {
+          "name": "Atonement", //the most holy name of your long schlong weapon
+          "description": "A Plasma Pistol recovered from a slain Fallen Angel, its machine spirit uniquely placid in the hands of a Dark Angel. It becomes enraged when fighting the enemies of the Emperor, making itself more deadly than any other Plasma Pistol", //write fun stuff
+          "base_weapon_type": "Plasma Pistol", //doesn't matter if it's armour, gear, mobi or anything else, you always use base_weapon_type to define it
+          "slot": "" //leave empty if you want it to be stored in the Librarium without assignment
+        },
+        {
+          "name": "Deliverer", //the most holy name of your long schlong weapon
+          "description": "Chief Librarian Ezekiel's personal weapon of choice, said to be exceedingly deadly against the Fallen due to its machine spirit", //write fun stuff
+          "base_weapon_type": "Bolt Pistol", //doesn't matter if it's armour, gear, mobi or anything else, you always use base_weapon_type to define it
+          "slot": "" //leave empty if you want it to be stored in the Librarium without assignment
+        },
+        {
+          "name": "Lion's Spear", //the most holy name of your long schlong weapon
+          "description": "An ancient Storm Bolter used by the Deathwing Company", //write fun stuff
+          "base_weapon_type": "Storm Bolter", //doesn't matter if it's armour, gear, mobi or anything else, you always use base_weapon_type to define it
+          "slot": "" //leave empty if you want it to be stored in the Librarium without assignment
+        },
+        {
+          "name": "Armour of the Forest", //the most holy name of your long schlong weapon
+          "description": "Forged by the Lion, struck from Terran steel it was created in the heart of Caliban's forests and embodied the pragmatism of the Legion in its spartiatic functionality and appearance. Worn by Corswain throughout his life", //write fun stuff
+          "base_weapon_type": "Artificer Armour", //doesn't matter if it's armour, gear, mobi or anything else, you always use base_weapon_type to define it
+          "slot": "" //leave empty if you want it to be stored in the Librarium without assignment
+        },
+        {
+          "name": "Deathbringer's Aegis", //the most holy name of your long schlong weapon
+          "description": "One of the six sets of battle plate crafted to mark the Lion's re-envisioning of the Hexagrammaton. However, he Aegis was one of the few relics of Hexagramaton to be forged of Terminator plate, and aside from that contained additional neural regulators and medicae infusers that make the armour perfect in resilience for the Masters of the Deathwing in their role", //write fun stuff
+          "base_weapon_type": "Tartaros", //doesn't matter if it's armour, gear, mobi or anything else, you always use base_weapon_type to define it
+          "slot": "" //leave empty if you want it to be stored in the Librarium without assignment
+        },
+        {
+          "name": "Dreadbringer's Plate", //the most holy name of your long schlong weapon
+          "description": "Formed of hardened Ceramite and ferro-crystalline ores native to Caliban, it is another of the Hexagrammaton relics. Because of its composition it could withstand the most potent of corrosives without damaged. It was said that the First Master of the Dreadwing walked through a maelstrom of Phosphex unscathed.", //write fun stuff
+          "base_weapon_type": "Artificer Armour", //doesn't matter if it's armour, gear, mobi or anything else, you always use base_weapon_type to define it
+          "slot": "" //leave empty if you want it to be stored in the Librarium without assignment
+        },
+        {
+          "name": "Secret's Shield", //the most holy name of your long schlong weapon
+          "description": "A suit of Artificer Armour that was created for the current Chief Librarian of the Chapter, Ezekiel", //write fun stuff
+          "base_weapon_type": "Artificer Armour", //doesn't matter if it's armour, gear, mobi or anything else, you always use base_weapon_type to define it
+          "slot": "" //leave empty if you want it to be stored in the Librarium without assignment
+        },
+        {
+          "name": "Shield of Calloson", //the most holy name of your long schlong weapon
+          "description": "This Storm Shield is a relic of the Dark Angels, reserved for Deathwing use. its resilience is legendary", //write fun stuff
+          "base_weapon_type": "Storm Shield", //doesn't matter if it's armour, gear, mobi or anything else, you always use base_weapon_type to define it
+          "slot": "" //leave empty if you want it to be stored in the Librarium without assignment
         }
+      ],
+    "names":
+      {
+        //Chapter Staff
+        "hchaplain": "Sapphon", // Head Chaplain
+        "clibrarian": "Ezekiel", // Chief Librarian
+        "fmaster": "Belaphor", // Forge Master
+        "hapothecary": "Razaek", // Head Apothecary
+        //Company Captains 1 - 10
+        "honorcapt": "Belial",
+        "watchmaster": "Sammael",
+        "arsenalmaster": "Orias",
+        "admiral": "Korahael",
+        "marchmaster": "Balthasar",
+        "ritesmaster": "Araphil",
+        "victualler": "Ezekiah",
+        "lordexec": "Calogrant",
+        "relmaster": "Xerophus",
+        "recruiter": "Saphamedes"
+      },
+    "company_titles":
+      [
+        "", //leave blank cause reasons
+        "Deathwing", //1st Company
+        "Ravenwing", //2nd
+        "The Unmerciful", //3rd
+        "The Feared", //4th
+        "The Unrelenting", //5th
+        "The Resolute", //6th
+        "The Unbowed", //7th
+        "The Wrathful", //8th
+        "The Remorseless", //9th
+        "The Redeemed"  //10th
+      ],
+    "equal_specialists": 0,// 0 if no, 1 if yes. If yes, will distribute specialist roles like Assaults and Devastators equally between companies. Otherwise all Assaults go in Company 8 and all Devastators in Company 9
+    "flagship_name":  "Invincible Reason", // leave blank to autogenerate
+    "load_to_ships": 
+      {
+        "escort_load": 2, // 0 no, 2 yes, 1 doesnt do anything :)
+        "split_scouts": 0, // 0 no, 1 yes. If yes, splits scouts between ships equally. Otherwise all scouts are kept on the homeworld.
+        "split_vets": 0 // 0 no, 1 yes. If yes, all veterans are distrubuted equally between ships. Otherwise all veterans are kept in the flagship
+      },
+    "full_liveries":
+      [
+        {//[1] Chapter Master
+          "weapon_primary":11,
+          "metallic_trim":1,
+          "weapon_secondary":1,
+          "is_changed":true,
+          "left_arm":26,
+          "left_backpack":26,
+          "left_chest":26,
+          "right_arm":26,
+          "right_backpack":26,
+          "right_chest":26,
+          "left_hand":26,
+          "left_head":26,
+          "left_leg_knee":26,
+          "right_hand":26,
+          "eye_lense":9,
+          "right_head":26,
+          "left_leg_lower":26,
+          "left_leg_upper":26,
+          "left_muzzle":26,
+          "right_leg_knee":26,
+          "left_pauldron":26,
+          "right_leg_lower":26,
+          "right_leg_upper":26,
+          "right_muzzle":26,
+          "right_pauldron":26,
+          "left_thorax":26,
+          "left_trim":1,
+          "right_thorax":26,
+          "right_trim":1,
+          "company_marks":0,
+          "company_marks_loc":0
+        },
+        {//[2] Brown dude, so far unknown what is this defining
+          "weapon_primary":11,
+          "metallic_trim":20,
+          "weapon_secondary":1,
+          "is_changed":true,
+          "left_arm":14,
+          "left_backpack":14,
+          "left_chest":14,
+          "right_arm":14,
+          "right_backpack":14,
+          "right_chest":14,
+          "left_hand":14,
+          "left_head":14,
+          "left_leg_knee":14,
+          "right_hand":14,
+          "eye_lense":9,
+          "right_head":14,
+          "left_leg_lower":14,
+          "left_leg_upper":14,
+          "left_muzzle":14,
+          "right_leg_knee":14,
+          "left_pauldron":14,
+          "right_leg_lower":14,
+          "right_leg_upper":14,
+          "right_muzzle":14,
+          "right_pauldron":14,
+          "left_thorax":0,
+          "left_trim":20,
+          "right_thorax":0,
+          "right_trim":20,
+          "company_marks":0,
+          "company_marks_loc":0
+        },
+        {//[3] Honour Guard
+          "weapon_primary":11,
+          "metallic_trim":1,
+          "weapon_secondary":1,
+          "is_changed":true,
+          "left_arm":26,
+          "left_backpack":26,
+          "left_chest":26,
+          "right_arm":26,
+          "right_backpack":26,
+          "right_chest":26,
+          "left_hand":26,
+          "left_head":26,
+          "left_leg_knee":26,
+          "right_hand":26,
+          "eye_lense":9,
+          "right_head":26,
+          "left_leg_lower":26,
+          "left_leg_upper":26,
+          "left_muzzle":26,
+          "right_leg_knee":26,
+          "left_pauldron":26,
+          "right_leg_lower":26,
+          "right_leg_upper":26,
+          "right_muzzle":26,
+          "right_pauldron":26,
+          "left_thorax":26,
+          "left_trim":1,
+          "right_thorax":26,
+          "right_trim":1,
+          "company_marks":0,
+          "company_marks_loc":0
+        },
+        {//[4] Veteran
+          "weapon_primary":11,
+          "metallic_trim":1,
+          "weapon_secondary":1,
+          "is_changed":true,
+          "left_arm":26,
+          "left_backpack":26,
+          "left_chest":26,
+          "right_arm":26,
+          "right_backpack":26,
+          "right_chest":26,
+          "left_hand":26,
+          "left_head":26,
+          "left_leg_knee":26,
+          "right_hand":26,
+          "eye_lense":9,
+          "right_head":26,
+          "left_leg_lower":26,
+          "left_leg_upper":26,
+          "left_muzzle":26,
+          "right_leg_knee":26,
+          "left_pauldron":26,
+          "right_leg_lower":26,
+          "right_leg_upper":26,
+          "right_muzzle":26,
+          "right_pauldron":26,
+          "left_thorax":26,
+          "left_trim":26,
+          "right_thorax":26,
+          "right_trim":26,
+          "company_marks":0,
+          "company_marks_loc":0
+        },
+        {//[5] Terminator
+          "weapon_primary":11,
+          "metallic_trim":1,
+          "weapon_secondary":1,
+          "is_changed":true,
+          "left_arm":26,
+          "left_backpack":26,
+          "left_chest":26,
+          "right_arm":26,
+          "right_backpack":26,
+          "right_chest":26,
+          "left_hand":26,
+          "left_head":26,
+          "left_leg_knee":26,
+          "right_hand":26,
+          "eye_lense":9,
+          "right_head":26,
+          "left_leg_lower":26,
+          "left_leg_upper":26,
+          "left_muzzle":26,
+          "right_leg_knee":26,
+          "left_pauldron":26,
+          "right_leg_lower":26,
+          "right_leg_upper":26,
+          "right_muzzle":26,
+          "right_pauldron":26,
+          "left_thorax":26,
+          "left_trim":26,
+          "right_thorax":26,
+          "right_trim":26,
+          "company_marks":0,
+          "company_marks_loc":0
+        },
+        {//[6] Captain
+          "weapon_primary":11,
+          "metallic_trim":1,
+          "weapon_secondary":1,
+          "is_changed":true,
+          "left_arm":26,
+          "left_backpack":26,
+          "left_chest":26,
+          "right_arm":26,
+          "right_backpack":26,
+          "right_chest":26,
+          "left_hand":26,
+          "left_head":26,
+          "left_leg_knee":26,
+          "right_hand":26,
+          "eye_lense":9,
+          "right_head":26,
+          "left_leg_lower":26,
+          "left_leg_upper":26,
+          "left_muzzle":26,
+          "right_leg_knee":26,
+          "left_pauldron":26,
+          "right_leg_lower":26,
+          "right_leg_upper":26,
+          "right_muzzle":26,
+          "right_pauldron":26,
+          "left_thorax":26,
+          "left_trim":12,
+          "right_thorax":26,
+          "right_trim":12,
+          "company_marks":0,
+          "company_marks_loc":0
+        },
+        {//[7] Dreadnought
+          "weapon_primary":11,
+          "metallic_trim":1,
+          "weapon_secondary":1,
+          "is_changed":true,
+          "left_arm":26,
+          "left_backpack":26,
+          "left_chest":26,
+          "right_arm":26,
+          "right_backpack":26,
+          "right_chest":26,
+          "left_hand":26,
+          "left_head":26,
+          "left_leg_knee":26,
+          "right_hand":26,
+          "eye_lense":9,
+          "right_head":26,
+          "left_leg_lower":26,
+          "left_leg_upper":26,
+          "left_muzzle":26,
+          "right_leg_knee":26,
+          "left_pauldron":26,
+          "right_leg_lower":26,
+          "right_leg_upper":26,
+          "right_muzzle":26,
+          "right_pauldron":26,
+          "left_thorax":26,
+          "left_trim":26,
+          "right_thorax":26,
+          "right_trim":26,
+          "company_marks":0,
+          "company_marks_loc":0
+        },
+        {//[8] Champion
+          "weapon_primary":11,
+          "metallic_trim":1,
+          "weapon_secondary":1,
+          "is_changed":true,
+          "left_arm":26,
+          "left_backpack":26,
+          "left_chest":26,
+          "right_arm":26,
+          "right_backpack":26,
+          "right_chest":26,
+          "left_hand":26,
+          "left_head":26,
+          "left_leg_knee":26,
+          "right_hand":26,
+          "eye_lense":9,
+          "right_head":26,
+          "left_leg_lower":26,
+          "left_leg_upper":26,
+          "left_muzzle":26,
+          "right_leg_knee":26,
+          "left_pauldron":26,
+          "right_leg_lower":26,
+          "right_leg_upper":26,
+          "right_muzzle":26,
+          "right_pauldron":26,
+          "left_thorax":26,
+          "left_trim":26,
+          "right_thorax":26,
+          "right_trim":26,
+          "company_marks":0,
+          "company_marks_loc":0
+        },
+        {//[9] Tactical
+          "weapon_primary":11,
+          "metallic_trim":1,
+          "weapon_secondary":1,
+          "is_changed":true,
+          "left_arm":26,
+          "left_backpack":26,
+          "left_chest":26,
+          "right_arm":26,
+          "right_backpack":26,
+          "right_chest":26,
+          "left_hand":26,
+          "left_head":26,
+          "left_leg_knee":26,
+          "right_hand":26,
+          "eye_lense":9,
+          "right_head":26,
+          "left_leg_lower":26,
+          "left_leg_upper":26,
+          "left_muzzle":26,
+          "right_leg_knee":26,
+          "left_pauldron":26,
+          "right_leg_lower":26,
+          "right_leg_upper":26,
+          "right_muzzle":26,
+          "right_pauldron":26,
+          "left_thorax":26,
+          "left_trim":26,
+          "right_thorax":26,
+          "right_trim":26,
+          "company_marks":0,
+          "company_marks_loc":0
+        },
+        {//[10] Devastator
+          "weapon_primary":11,
+          "metallic_trim":1,
+          "weapon_secondary":1,
+          "is_changed":true,
+          "left_arm":26,
+          "left_backpack":26,
+          "left_chest":26,
+          "right_arm":26,
+          "right_backpack":26,
+          "right_chest":26,
+          "left_hand":26,
+          "left_head":26,
+          "left_leg_knee":26,
+          "right_hand":26,
+          "eye_lense":9,
+          "right_head":26,
+          "left_leg_lower":26,
+          "left_leg_upper":26,
+          "left_muzzle":26,
+          "right_leg_knee":26,
+          "left_pauldron":26,
+          "right_leg_lower":26,
+          "right_leg_upper":26,
+          "right_muzzle":26,
+          "right_pauldron":26,
+          "left_thorax":26,
+          "left_trim":26,
+          "right_thorax":26,
+          "right_trim":26,
+          "company_marks":0,
+          "company_marks_loc":0
+        },
+        {//[11] Assault
+          "weapon_primary":11,
+          "metallic_trim":1,
+          "weapon_secondary":1,
+          "is_changed":true,
+          "left_arm":26,
+          "left_backpack":26,
+          "left_chest":26,
+          "right_arm":26,
+          "right_backpack":26,
+          "right_chest":26,
+          "left_hand":26,
+          "left_head":26,
+          "left_leg_knee":26,
+          "right_hand":26,
+          "eye_lense":9,
+          "right_head":26,
+          "left_leg_lower":26,
+          "left_leg_upper":26,
+          "left_muzzle":26,
+          "right_leg_knee":26,
+          "left_pauldron":26,
+          "right_leg_lower":26,
+          "right_leg_upper":26,
+          "right_muzzle":26,
+          "right_pauldron":26,
+          "left_thorax":26,
+          "left_trim":26,
+          "right_thorax":26,
+          "right_trim":26,
+          "company_marks":0,
+          "company_marks_loc":0
+        },
+        {//[12] Ancient
+          "weapon_primary":11,
+          "metallic_trim":1,
+          "weapon_secondary":1,
+          "is_changed":true,
+          "left_arm":26,
+          "left_backpack":26,
+          "left_chest":26,
+          "right_arm":26,
+          "right_backpack":26,
+          "right_chest":26,
+          "left_hand":26,
+          "left_head":26,
+          "left_leg_knee":26,
+          "right_hand":26,
+          "eye_lense":9,
+          "right_head":26,
+          "left_leg_lower":26,
+          "left_leg_upper":26,
+          "left_muzzle":26,
+          "right_leg_knee":26,
+          "left_pauldron":26,
+          "right_leg_lower":26,
+          "right_leg_upper":26,
+          "right_muzzle":26,
+          "right_pauldron":26,
+          "left_thorax":26,
+          "left_trim":26,
+          "right_thorax":26,
+          "right_trim":26,
+          "company_marks":0,
+          "company_marks_loc":0
+        },
+        {//[13] Scout
+          "weapon_primary":11,
+          "metallic_trim":1,
+          "weapon_secondary":1,
+          "is_changed":true,
+          "left_arm":26,
+          "left_backpack":26,
+          "left_chest":26,
+          "right_arm":26,
+          "right_backpack":26,
+          "right_chest":26,
+          "left_hand":26,
+          "left_head":26,
+          "left_leg_knee":26,
+          "right_hand":26,
+          "eye_lense":9,
+          "right_head":26,
+          "left_leg_lower":26,
+          "left_leg_upper":26,
+          "left_muzzle":26,
+          "right_leg_knee":26,
+          "left_pauldron":26,
+          "right_leg_lower":26,
+          "right_leg_upper":26,
+          "right_muzzle":26,
+          "right_pauldron":26,
+          "left_thorax":26,
+          "left_trim":26,
+          "right_thorax":26,
+          "right_trim":26,
+          "company_marks":0,
+          "company_marks_loc":0
+        },
+        {//[14] Green dude
+          "weapon_primary":11,
+          "metallic_trim":20,
+          "weapon_secondary":20,
+          "is_changed":true,
+          "left_arm":23,
+          "left_backpack":23,
+          "left_chest":23,
+          "right_arm":23,
+          "right_backpack":23,
+          "right_chest":23,
+          "left_hand":23,
+          "left_head":23,
+          "left_leg_knee":23,
+          "right_hand":23,
+          "eye_lense":9,
+          "right_head":23,
+          "left_leg_lower":23,
+          "left_leg_upper":23,
+          "left_muzzle":23,
+          "right_leg_knee":23,
+          "left_pauldron":23,
+          "right_leg_lower":23,
+          "right_leg_upper":23,
+          "right_muzzle":23,
+          "right_pauldron":23,
+          "left_thorax":0,
+          "left_trim":20,
+          "right_thorax":0,
+          "right_trim":20,
+          "company_marks":0,
+          "company_marks_loc":0
+        },
+        {//[15] Chaplain
+          "weapon_primary":11,
+          "metallic_trim":1,
+          "weapon_secondary":1,
+          "is_changed":true,
+          "left_arm":8,
+          "left_backpack":8,
+          "left_chest":8,
+          "right_arm":8,
+          "right_backpack":8,
+          "right_chest":8,
+          "left_hand":8,
+          "left_head":8,
+          "left_leg_knee":8,
+          "right_hand":8,
+          "eye_lense":9,
+          "right_head":8,
+          "left_leg_lower":8,
+          "left_leg_upper":8,
+          "left_muzzle":8,
+          "right_leg_knee":8,
+          "left_pauldron":26,
+          "right_leg_lower":8,
+          "right_leg_upper":8,
+          "right_muzzle":8,
+          "right_pauldron":8,
+          "left_thorax":0,
+          "left_trim":1,
+          "right_thorax":0,
+          "right_trim":1,
+          "company_marks":0,
+          "company_marks_loc":0
+        },
+        {//[16] Apothecary
+          "weapon_primary":11,
+          "metallic_trim":1,
+          "weapon_secondary":1,
+          "is_changed":true,
+          "left_arm":0,
+          "left_backpack":0,
+          "left_chest":0,
+          "right_arm":0,
+          "right_backpack":0,
+          "right_chest":0,
+          "left_hand":0,
+          "left_head":0,
+          "left_leg_knee":0,
+          "right_hand":0,
+          "eye_lense":9,
+          "right_head":0,
+          "left_leg_lower":0,
+          "left_leg_upper":0,
+          "left_muzzle":0,
+          "right_leg_knee":0,
+          "left_pauldron":26,
+          "right_leg_lower":0,
+          "right_leg_upper":0,
+          "right_muzzle":0,
+          "right_pauldron":0,
+          "left_thorax":0,
+          "left_trim":1,
+          "right_thorax":0,
+          "right_trim":1,
+          "company_marks":0,
+          "company_marks_loc":0
+        },
+        {//[17] Techmarine
+          "weapon_primary":11,
+          "metallic_trim":1,
+          "weapon_secondary":1,
+          "is_changed":true,
+          "left_arm":9,
+          "left_backpack":9,
+          "left_chest":9,
+          "right_arm":9,
+          "right_backpack":9,
+          "right_chest":9,
+          "left_hand":9,
+          "left_head":9,
+          "left_leg_knee":9,
+          "right_hand":9,
+          "eye_lense":22,
+          "right_head":9,
+          "left_leg_lower":9,
+          "left_leg_upper":9,
+          "left_muzzle":9,
+          "right_leg_knee":9,
+          "left_pauldron":26,
+          "right_leg_lower":9,
+          "right_leg_upper":9,
+          "right_muzzle":9,
+          "right_pauldron":9,
+          "left_thorax":0,
+          "left_trim":1,
+          "right_thorax":0,
+          "right_trim":1,
+          "company_marks":0,
+          "company_marks_loc":0
+        },
+        {//[18] Librarian
+          "weapon_primary":11,
+          "metallic_trim":1,
+          "weapon_secondary":1,
+          "is_changed":true,
+          "left_arm":34,
+          "left_backpack":34,
+          "left_chest":34,
+          "right_arm":34,
+          "right_backpack":34,
+          "right_chest":34,
+          "left_hand":34,
+          "left_head":34,
+          "left_leg_knee":34,
+          "right_hand":34,
+          "eye_lense":22,
+          "right_head":34,
+          "left_leg_lower":34,
+          "left_leg_upper":34,
+          "left_muzzle":34,
+          "right_leg_knee":34,
+          "left_pauldron":26,
+          "right_leg_lower":34,
+          "right_leg_upper":34,
+          "right_muzzle":34,
+          "right_pauldron":34,
+          "left_thorax":0,
+          "left_trim":1,
+          "right_thorax":0,
+          "right_trim":1,
+          "company_marks":0,
+          "company_marks_loc":0
+        },
+        {//[19] Sergeant
+          "weapon_primary":11,
+          "metallic_trim":1,
+          "weapon_secondary":1,
+          "is_changed":true,
+          "left_arm":26,
+          "left_backpack":26,
+          "left_chest":26,
+          "right_arm":26,
+          "right_backpack":26,
+          "right_chest":26,
+          "left_hand":26,
+          "left_head":26,
+          "left_leg_knee":26,
+          "right_hand":26,
+          "eye_lense":9,
+          "right_head":26,
+          "left_leg_lower":26,
+          "left_leg_upper":26,
+          "left_muzzle":26,
+          "right_leg_knee":26,
+          "left_pauldron":26,
+          "right_leg_lower":26,
+          "right_leg_upper":26,
+          "right_muzzle":26,
+          "right_pauldron":26,
+          "left_thorax":26,
+          "left_trim":26,
+          "right_thorax":26,
+          "right_trim":26,
+          "company_marks":0,
+          "company_marks_loc":0
+        },
+        {//[20] Veteran Sergeant
+          "weapon_primary":11,
+          "metallic_trim":1,
+          "weapon_secondary":1,
+          "is_changed":true,
+          "left_arm":26,
+          "left_backpack":26,
+          "left_chest":26,
+          "right_arm":26,
+          "right_backpack":26,
+          "right_chest":26,
+          "left_hand":26,
+          "left_head":26,
+          "left_leg_knee":26,
+          "right_hand":26,
+          "eye_lense":9,
+          "right_head":26,
+          "left_leg_lower":26,
+          "left_leg_upper":26,
+          "left_muzzle":26,
+          "right_leg_knee":26,
+          "left_pauldron":26,
+          "right_leg_lower":26,
+          "right_leg_upper":26,
+          "right_muzzle":26,
+          "right_pauldron":26,
+          "left_thorax":26,
+          "left_trim":26,
+          "right_thorax":26,
+          "right_trim":26,
+          "company_marks":0,
+          "company_marks_loc":0
+        },
+        {//[21] Blue Chest
+          "weapon_primary":11,
+          "metallic_trim":20,
+          "weapon_secondary":20,
+          "is_changed":true,
+          "left_arm":31,
+          "left_backpack":31,
+          "left_chest":31,
+          "right_arm":31,
+          "right_backpack":31,
+          "right_chest":31,
+          "left_hand":31,
+          "left_head":31,
+          "left_leg_knee":31,
+          "right_hand":31,
+          "eye_lense":9,
+          "right_head":31,
+          "left_leg_lower":31,
+          "left_leg_upper":31,
+          "left_muzzle":31,
+          "right_leg_knee":31,
+          "left_pauldron":31,
+          "right_leg_lower":31,
+          "right_leg_upper":31,
+          "right_muzzle":31,
+          "right_pauldron":31,
+          "left_thorax":0,
+          "left_trim":20,
+          "right_thorax":0,
+          "right_trim":20,
+          "company_marks":0,
+          "company_marks_loc":0
+        }
+      ],
+    "complex_livery_data": //helm_pattern - paint setup, [0] Full colour primary [1] Stripe in the middle secondary [2] Upper main lower second [3] same as 1 for some reason
+      {
+        "sgt":
+        {
+          "helm_detail":1,
+          "helm_lens":9,
+          "helm_pattern":0,
+          "helm_primary":26,
+          "helm_secondary":26
+        },
+        "veteran":
+        {
+          "helm_detail":26,
+          "helm_lens":9,
+          "helm_pattern":0,
+          "helm_primary":26,
+          "helm_secondary":26
+        },
+        "captain":
+        {
+          "helm_detail":1,
+          "helm_lens":9,
+          "helm_pattern":0,
+          "helm_primary":26,
+          "helm_secondary":26
+        },
+        "vet_sgt":
+        {
+          "helm_detail":1,
+          "helm_lens":9,
+          "helm_pattern":0,
+          "helm_primary":26,
+          "helm_secondary":26
+        }
+      },
+    "company_liveries"://if you put -1 as value that means there is no change from the base colour scheme. Beware that compnay markings overwrite specialists as well
+      [
+        {// HQ
+          "weapon_primary":-1,
+          "metallic_trim":-1,
+          "weapon_secondary":-1,
+          "is_changed":true,
+          "left_arm":-1,
+          "left_backpack":-1,
+          "left_chest":-1,
+          "right_arm":-1,
+          "right_backpack":-1,
+          "right_chest":-1,
+          "left_hand":-1,
+          "left_head":-1,
+          "left_leg_knee":-1,
+          "right_hand":-1,
+          "eye_lense":-1,
+          "right_head":-1,
+          "left_leg_lower":-1,
+          "left_leg_upper":-1,
+          "left_muzzle":-1,
+          "right_leg_knee":-1,
+          "left_pauldron":-1,
+          "right_leg_lower":-1,
+          "right_leg_upper":-1,
+          "right_muzzle":-1,
+          "right_pauldron":-1,
+          "left_thorax":-1,
+          "left_trim":-1,
+          "right_thorax":-1,
+          "right_trim":-1,
+          "company_marks":-1,
+          "company_marks_loc":-1
+        },
+        {// 1
+          "weapon_primary":-1,
+          "metallic_trim":26,
+          "weapon_secondary":-1,
+          "is_changed":true,
+          "left_arm":17,
+          "left_backpack":17,
+          "left_chest":17,
+          "right_arm":17,
+          "right_backpack":17,
+          "right_chest":17,
+          "left_hand":17,
+          "left_head":17,
+          "left_leg_knee":17,
+          "right_hand":17,
+          "eye_lense":-1,
+          "right_head":17,
+          "left_leg_lower":17,
+          "left_leg_upper":17,
+          "left_muzzle":17,
+          "right_leg_knee":17,
+          "left_pauldron":17,
+          "right_leg_lower":17,
+          "right_leg_upper":17,
+          "right_muzzle":17,
+          "right_pauldron":17,
+          "left_thorax":17,
+          "left_trim":17,
+          "right_thorax":17,
+          "right_trim":17,
+          "company_marks":-1,
+          "company_marks_loc":-1
+        },
+        {// 2
+          "weapon_primary":-1,
+          "metallic_trim":-1,
+          "weapon_secondary":-1,
+          "is_changed":true,
+          "left_arm":8,
+          "left_backpack":8,
+          "left_chest":8,
+          "right_arm":8,
+          "right_backpack":8,
+          "right_chest":8,
+          "left_hand":8,
+          "left_head":8,
+          "left_leg_knee":8,
+          "right_hand":8,
+          "eye_lense":-1,
+          "right_head":8,
+          "left_leg_lower":8,
+          "left_leg_upper":8,
+          "left_muzzle":8,
+          "right_leg_knee":8,
+          "left_pauldron":8,
+          "right_leg_lower":8,
+          "right_leg_upper":8,
+          "right_muzzle":8,
+          "right_pauldron":8,
+          "left_thorax":8,
+          "left_trim":8,
+          "right_thorax":8,
+          "right_trim":8,
+          "company_marks":-1,
+          "company_marks_loc":-1
+        },
+        {// 3
+          "weapon_primary":-1,
+          "metallic_trim":-1,
+          "weapon_secondary":-1,
+          "is_changed":true,
+          "left_arm":-1,
+          "left_backpack":-1,
+          "left_chest":-1,
+          "right_arm":-1,
+          "right_backpack":-1,
+          "right_chest":-1,
+          "left_hand":-1,
+          "left_head":-1,
+          "left_leg_knee":-1,
+          "right_hand":-1,
+          "eye_lense":-1,
+          "right_head":-1,
+          "left_leg_lower":-1,
+          "left_leg_upper":-1,
+          "left_muzzle":-1,
+          "right_leg_knee":-1,
+          "left_pauldron":-1,
+          "right_leg_lower":-1,
+          "right_leg_upper":-1,
+          "right_muzzle":-1,
+          "right_pauldron":-1,
+          "left_thorax":-1,
+          "left_trim":-1,
+          "right_thorax":-1,
+          "right_trim":-1,
+          "company_marks":-1,
+          "company_marks_loc":-1
+        },
+        {// 4
+          "weapon_primary":-1,
+          "metallic_trim":-1,
+          "weapon_secondary":-1,
+          "is_changed":true,
+          "left_arm":-1,
+          "left_backpack":-1,
+          "left_chest":-1,
+          "right_arm":-1,
+          "right_backpack":-1,
+          "right_chest":-1,
+          "left_hand":-1,
+          "left_head":-1,
+          "left_leg_knee":-1,
+          "right_hand":-1,
+          "eye_lense":-1,
+          "right_head":-1,
+          "left_leg_lower":-1,
+          "left_leg_upper":-1,
+          "left_muzzle":-1,
+          "right_leg_knee":-1,
+          "left_pauldron":-1,
+          "right_leg_lower":-1,
+          "right_leg_upper":-1,
+          "right_muzzle":-1,
+          "right_pauldron":-1,
+          "left_thorax":-1,
+          "left_trim":-1,
+          "right_thorax":-1,
+          "right_trim":-1,
+          "company_marks":-1,
+          "company_marks_loc":-1
+        },
+        {// 5
+          "weapon_primary":-1,
+          "metallic_trim":-1,
+          "weapon_secondary":-1,
+          "is_changed":true,
+          "left_arm":-1,
+          "left_backpack":-1,
+          "left_chest":-1,
+          "right_arm":-1,
+          "right_backpack":-1,
+          "right_chest":-1,
+          "left_hand":-1,
+          "left_head":-1,
+          "left_leg_knee":-1,
+          "right_hand":-1,
+          "eye_lense":-1,
+          "right_head":-1,
+          "left_leg_lower":-1,
+          "left_leg_upper":-1,
+          "left_muzzle":-1,
+          "right_leg_knee":-1,
+          "left_pauldron":-1,
+          "right_leg_lower":-1,
+          "right_leg_upper":-1,
+          "right_muzzle":-1,
+          "right_pauldron":-1,
+          "left_thorax":-1,
+          "left_trim":-1,
+          "right_thorax":-1,
+          "right_trim":-1,
+          "company_marks":-1,
+          "company_marks_loc":-1
+        },
+        {// 6
+          "weapon_primary":-1,
+          "metallic_trim":-1,
+          "weapon_secondary":-1,
+          "is_changed":true,
+          "left_arm":-1,
+          "left_backpack":-1,
+          "left_chest":-1,
+          "right_arm":-1,
+          "right_backpack":-1,
+          "right_chest":-1,
+          "left_hand":-1,
+          "left_head":-1,
+          "left_leg_knee":-1,
+          "right_hand":-1,
+          "eye_lense":-1,
+          "right_head":-1,
+          "left_leg_lower":-1,
+          "left_leg_upper":-1,
+          "left_muzzle":-1,
+          "right_leg_knee":-1,
+          "left_pauldron":-1,
+          "right_leg_lower":-1,
+          "right_leg_upper":-1,
+          "right_muzzle":-1,
+          "right_pauldron":-1,
+          "left_thorax":-1,
+          "left_trim":-1,
+          "right_thorax":-1,
+          "right_trim":-1,
+          "company_marks":-1,
+          "company_marks_loc":-1
+        },
+        {// 7
+          "weapon_primary":-1,
+          "metallic_trim":-1,
+          "weapon_secondary":-1,
+          "is_changed":true,
+          "left_arm":-1,
+          "left_backpack":-1,
+          "left_chest":-1,
+          "right_arm":-1,
+          "right_backpack":-1,
+          "right_chest":-1,
+          "left_hand":-1,
+          "left_head":-1,
+          "left_leg_knee":-1,
+          "right_hand":-1,
+          "eye_lense":-1,
+          "right_head":-1,
+          "left_leg_lower":-1,
+          "left_leg_upper":-1,
+          "left_muzzle":-1,
+          "right_leg_knee":-1,
+          "left_pauldron":-1,
+          "right_leg_lower":-1,
+          "right_leg_upper":-1,
+          "right_muzzle":-1,
+          "right_pauldron":-1,
+          "left_thorax":-1,
+          "left_trim":-1,
+          "right_thorax":-1,
+          "right_trim":-1,
+          "company_marks":-1,
+          "company_marks_loc":-1
+        },
+        {// 8
+          "weapon_primary":-1,
+          "metallic_trim":-1,
+          "weapon_secondary":-1,
+          "is_changed":true,
+          "left_arm":-1,
+          "left_backpack":-1,
+          "left_chest":-1,
+          "right_arm":-1,
+          "right_backpack":-1,
+          "right_chest":-1,
+          "left_hand":-1,
+          "left_head":-1,
+          "left_leg_knee":-1,
+          "right_hand":-1,
+          "eye_lense":-1,
+          "right_head":-1,
+          "left_leg_lower":-1,
+          "left_leg_upper":-1,
+          "left_muzzle":-1,
+          "right_leg_knee":-1,
+          "left_pauldron":-1,
+          "right_leg_lower":-1,
+          "right_leg_upper":-1,
+          "right_muzzle":-1,
+          "right_pauldron":-1,
+          "left_thorax":-1,
+          "left_trim":-1,
+          "right_thorax":-1,
+          "right_trim":-1,
+          "company_marks":-1,
+          "company_marks_loc":-1
+        },
+        {// 9
+          "weapon_primary":-1,
+          "metallic_trim":-1,
+          "weapon_secondary":-1,
+          "is_changed":true,
+          "left_arm":-1,
+          "left_backpack":-1,
+          "left_chest":-1,
+          "right_arm":-1,
+          "right_backpack":-1,
+          "right_chest":-1,
+          "left_hand":-1,
+          "left_head":-1,
+          "left_leg_knee":-1,
+          "right_hand":-1,
+          "eye_lense":-1,
+          "right_head":-1,
+          "left_leg_lower":-1,
+          "left_leg_upper":-1,
+          "left_muzzle":-1,
+          "right_leg_knee":-1,
+          "left_pauldron":-1,
+          "right_leg_lower":-1,
+          "right_leg_upper":-1,
+          "right_muzzle":-1,
+          "right_pauldron":-1,
+          "left_thorax":-1,
+          "left_trim":-1,
+          "right_thorax":-1,
+          "right_trim":-1,
+          "company_marks":-1,
+          "company_marks_loc":-1
+        },
+        {// 10
+          "weapon_primary":-1,
+          "metallic_trim":-1,
+          "weapon_secondary":-1,
+          "is_changed":true,
+          "left_arm":-1,
+          "left_backpack":-1,
+          "left_chest":-1,
+          "right_arm":-1,
+          "right_backpack":-1,
+          "right_chest":-1,
+          "left_hand":-1,
+          "left_head":-1,
+          "left_leg_knee":-1,
+          "right_hand":-1,
+          "eye_lense":-1,
+          "right_head":-1,
+          "left_leg_lower":-1,
+          "left_leg_upper":-1,
+          "left_muzzle":-1,
+          "right_leg_knee":-1,
+          "left_pauldron":-1,
+          "right_leg_lower":-1,
+          "right_leg_upper":-1,
+          "right_muzzle":-1,
+          "right_pauldron":-1,
+          "left_thorax":-1,
+          "left_trim":-1,
+          "right_thorax":-1,
+          "right_trim":-1,
+          "company_marks":-1,
+          "company_marks_loc":-1
+        }
+    ],
+    "custom_roles":
+    {
+      "chapter_master"://feel free to add specific equipment, name and whatnot
+      {
+        "name": "Supreme Grand Master"
+      }
+      /*"template":
+      {
+        "wep1":"",
+        "wep2":"",
+        "gear":"",
+        "armour":"",
+        "name":"template",
+        "mobi":""
+      },*/
+    },
+    "extra_equipment": 
+    [
+      // ["Bolter", 10] is an example of how this is called
+    ],
+    "extra_marines": //default is 100 marines per company, the first company works via adding veterans or terminators
+    {//beware, only adds Tacticals
+      "second": 0,
+      "third": 0,
+      "fourth": 0,
+      "fifth": 0,
+      "sixth": 0,
+      "seventh": 0,
+      "eighth": 0,
+      "ninth": 0,
+      "tenth": 0
+    },
+    "extra_ships": 
+    /**
+    * * Default fleet composition
+    * * Homeworld 
+    * - 2 Battle Barges, 8 Strike cruisers, 7 Gladius, 3 Hunters
+    * * Fleet based and Penitent 
+    * - 4 Battle Barges, 3 Strike Cruisers, 7 Gladius, 3 Hunters
+    * 
+    * use negative numbers to subtract ships
+    * * Stacks with advantages/disadvantages
+    */
+    {
+      "gloriana": 1,
+      "battle_barges": 4,
+      "strike_cruisers": 13,
+      "gladius": 8,
+      "hunters": 3
+    },
+    /**
+    * * Default HQ Layout (Does not include company specialists)
+    * - 8 Chaplains, 8 Techmarines, 8 Apothecary, 2 Epistolary (librarian), 
+    * - 2 Codiciery, 4 Lexicanum
+    * * Default Company specialists (divided based on `load_to_ships.split_vets` setting)
+    * - 20 Terminators, 85 Veterans, 20 Devastators, 20 Assault
+    * Use negative numbers to subtract
+    * Stacks with advantages/disadvantages
+    */
+    "extra_specialists": 
+    {
+      "chaplains": 12,//adds them to the Reclusiam
+      "chaplains_per_company": 0,//adds them to company, X per company
+      "techmarines": 12,
+      "techmarines_per_company": 0,
+      "apothecary": 2,
+      "apothecary_per_company": 0,
+      "epistolary": 2,
+      "epistolary_per_company": 0,
+      "codiciery": 6,
+      "lexicanum": 4,
+      "terminator": 85,
+      "assault": 0,
+      "veteran": -85,
+      "devastator": 0,
+      "dreadnought": 0
+    },
+    "extra_vehicles":
+    {
+      "rhino": 0,
+      "predator": 0,
+      "land_speeder": 0,
+      "whirlwind": 0,
+      "land_raider": 0
+    },
+    "companies":
+    {
+        "first":
+        {
+            "veterans": 4,
+            "dreadnoughts": 9,
+            "landraiders": 21
+        },
+        "second":
+        {
+            "dreadnoughts": 0,
+            "landraiders": 0,
+            "rhinos": 0,
+            "predators": 0,
+            "whirlwinds": 0,
+            "landspeeders": 20,
+            "tacticals": 0,
+            "assaults": 0,
+            "devastators": 0,
+            "scouts": 0,
+            "veterans": 100
+        },
+        "third":
+        {
+          "veterans": 5,
+          "dreadnoughts": 3
+        },
+        "fourth":
+        {
+          "veterans": 5,
+          "dreadnoughts": 2
+        },
+        "fifth":
+        {
+          "veterans": 5,
+          "dreadnoughts": 4
+        },
+        "sixth":
+        {
+          "veterans": 5,
+          "dreadnoughts": 1
+        },
+        "seventh":
+        {
+          "veterans": 5,
+          "dreadnoughts": 3
+        },
+        "eighth":
+        {
+          "veterans": 5,
+          "dreadnoughts": 2
+        },
+        "ninth":
+        {
+          "veterans": 5,
+          "dreadnoughts": 4
+        },
+        "tenth":
+        {
+          "veterans": 5
+        }
+    },
+    /*"custom_advisors"://here you define what image [by typing the png name] are your custom advisors using. If you add nothing here, the game uses defaults
+    {
+      "forge_master": ,
+      "apothecary": ,
+      "librarian": , 
+      "chaplain": ,
+      "admiral": ,
+      "recruiter": 
+    },*/
+    "squad_name": "Squad", //how will any squad be referenced
+
+    "squad_builder" : [
+      {
+        "company": 1,
+        "squads": [
+          {
+            "squad": "deathwing_command_squad",
+            "max_count": 1,
+            "min_count": 1,
+            "require": true
+          },
+          {
+            "squad": "deathwing_squad",
+            "proportion": 1
+          },
+        ]
+      },
+      {
+        "company": 2,
+        "squads": [
+          {
+            "squad": "ravenwing_command_squad",
+            "max_count": 1,
+            "min_count": 1,
+          },
+          {
+            "squad": "ravenwing_squad",
+            "proportion": 1
+          },
+        ]
+      },
+    ],
+  "custom_squads" : {
+  "deathwing_command_squad": {
+    "Captain": {
+      "max": 1,
+      "min": 1,
+      "role": "Master of the Deathwing",
+      "loadout": {
+        "required": {
+          "armour": ["Terminator Armour", 1]
+        }
+      }
+    },
+    "Chaplain": {
+      "max": 1,
+      "min": 0,
+      "role": "Chaplain",
+      "loadout": {
+        "required": {
+          "armour": ["Terminator Armour", 1]
+        }
+      }
+    },
+    "Apothecary": {
+      "max": 2,
+      "min": 0,
+      "role": "Apothecary",
+      "loadout": {
+        "required": {
+          "armour": ["Terminator Armour", 1]
+        }
+      }
+    },
+    "Ancient": {
+      "max": 1,
+      "min": 0,
+      "role": "Deathwing Ancient",
+      "loadout": {
+        "required": {
+          "armour": ["Terminator Armour", 1]
+        }
+      }
+    },
+    "Librarian": {
+      "max": 1,
+      "min": 0,
+      "role": "Librarian",
+      "loadout": {
+        "required": {
+          "armour": ["Terminator Armour", 1]
+        }
+      }
+    },
+    "Techmarine": {
+      "max": 2,
+      "min": 0,
+      "role": "Techmarine",
+      "loadout": {
+        "required": {
+          "mobi": ["Servo-harness", 1],
+          "armour": ["Terminator Armour", 1]
+        }
+      }
+    },
+    "Champion": {
+      "max": 1,
+      "min": 0,
+      "role": "Knight Master",
+      "loadout": {
+        "required": {
+          "wep1": ["Relic Blade", 1],
+          "wep2": ["Storm Shield", 1],
+          "gear": ["Iron Halo", 1],
+          "armour": ["Tartaros", 1]
+        }
+      }
+    },
+    "Veteran": {
+      "max": 4,
+      "min": 0,
+      "role": "Deathwing Knight",
+      "loadout": {
+        "required": {
+          "wep1": ["Mace of Absolution", 4],
+          "wep2": ["Storm Shield", 4],
+          "armour": ["Terminator Armour", 4]
+        }
+      }
+    },
+    "type_data": {
+      "display_data": "Deathwing Command Squad",
+      "formation_options": ["champion", "command", "terminator", "veteran", "assault", "devastator", "scout", "tactical"],
+      "base": "command"
     }
+  },
+
+  "deathwing_squad": {
+    "Veteran Sergeant": {
+      "max": 1,
+      "min": 1,
+      "role": "Deathwing Sergeant",
+      "loadout": {
+        "required": {
+          "wep1": ["Power Sword", 1]
+        }
+      }
+    },
+    "Terminator": {
+      "max": 9,
+      "min": 2,
+      "role": "Deathwing Terminator",
+      "loadout": {
+        "required": {
+          "wep1": ["", 0],
+          "wep2": ["Storm Bolter", 7]
+        },
+        "option": {
+          "wep1": [
+            [["Power Fist", "Chainfist"], 9]
+          ],
+          "wep2": [
+            [["Heavy Flamer", "Heavy Flamer", "Heavy Flamer", "Assault Cannon", "Assault Cannon", "Plasma Cannon"], 2]
+          ]
+        }
+      }
+    },
+    "type_data": {
+      "display_data": "Deathwing Terminator Squad",
+      "formation_options": ["terminator", "veteran", "assault", "devastator", "scout", "tactical"],
+      "base": "veteran"
+    }
+  },
+
+  "ravenwing_squad": {
+    "Veteran Sergeant": {
+      "max": 1,
+      "min": 1,
+      "role": "Ravenwing Sergeant",
+      "loadout": {
+        "required": {
+          "wep1": ["Power Sword", 1],
+          "mobi": ["Bike", 4]
+        },
+        "option": {
+          "wep2": [
+            [["Combiplasma", "Plasma Gun", "Meltagun"], 1]
+          ]
+        }
+      }
+    },
+    "Veteran": {
+      "max": 5,
+      "min": 2,
+      "role": "Ravenwing Biker",
+      "loadout": {
+        "required": {
+          "wep1": ["Chainsword", 5],
+          "wep2": ["Bolt Pistol", 3],
+          "mobi": ["Bike", 5]
+        },
+        "option": {
+          "wep2": [
+            [["Flamer", "Grav-Gun", "Meltagun", "Plasma Gun", "Plasma Pistol"], 2]
+          ]
+        }
+      }
+    },
+    "type_data": {
+      "display_data": "Ravenwing Bike Squad",
+      "formation_options": ["tactical", "assault", "devastator", "scout", "terminator", "veteran"],
+      "allowed_companies": [2]
+    }
+  },
+
+  "ravenwing_command_squad": {
+    "Captain": {
+      "max": 1,
+      "min": 1,
+      "role": "Master of the Ravenwing",
+      "loadout": {
+        "required": {
+          "mobi": ["Bike", 1]
+        }
+      }
+    },
+    "Chaplain": {
+      "max": 1,
+      "min": 0,
+      "role": "Chaplain",
+      "loadout": {
+        "required": {
+          "mobi": ["Bike", 1]
+        }
+      }
+    },
+    "Apothecary": {
+      "max": 2,
+      "min": 0,
+      "role": "Apothecary",
+      "loadout": {
+        "required": {
+          "mobi": ["Bike", 1]
+        }
+      }
+    },
+    "Ancient": {
+      "max": 1,
+      "min": 0,
+      "role": "Ravenwing Ancient",
+      "loadout": {
+        "required": {
+          "mobi": ["Bike", 1]
+        }
+      }
+    },
+    "Librarian": {
+      "max": 1,
+      "min": 1,
+      "role": "Librarian",
+      "loadout": {
+        "required": {
+          "mobi": ["Bike", 1]
+        }
+      }
+    },
+    "Techmarine": {
+      "max": 2,
+      "min": 0,
+      "role": "Techmarine",
+      "loadout": {
+        "required": {
+          "mobi": ["Servo-harness", 1]
+        }
+      }
+    },
+    "Champion": {
+      "max": 1,
+      "min": 0,
+      "role": "Huntsmaster",
+      "loadout": {
+        "required": {
+          "wep1": ["Relic Blade", 1],
+          "wep2": ["Plasma Pistol", 1],
+          "gear": ["Iron Halo", 1],
+          "armour": ["Artificer Armour", 1],
+          "mobi": ["Bike", 1]
+        }
+      }
+    },
+    "Veteran": {
+      "max": 4,
+      "min": 0,
+      "role": "Black Knight",
+      "loadout": {
+        "required": {
+          "wep1": ["Chainsword", 4],
+          "wep2": ["Bolt Pistol", 2],
+          "mobi": ["Bike", 4]
+        },
+        "option": {
+          "wep2": [
+            [["Flamer", "Grav-gun", "Meltagun", "Plasma Gun", "Plasma Pistol"], 2]
+          ]
+        }
+      }
+    },
+    "type_data": {
+      "display_data": "Ravenwing Command Squad",
+      "formation_options": ["champion", "command", "terminator", "veteran", "assault", "devastator", "scout", "tactical"],
+      "base": "command",
+    }
+  }
+}
+/*  * Custom squad roles, loadouts and formations
+    * When companies are made, squads are formed based on these rules: 
+    * - squad name: one of captain, terminator, terminator_assault, sternguard_veteran,
+      vanguard_veteran, devastator, tactical, assault, scout, scout_sniper
+    * - squad array layout [Role, Role, ...Role, type_data]
+    * - each element of the array is a default Role, and their settings.
+      - if you changed the role using `custom_roles` you need to reference the role with this new name
+      - for non-leader roles it is better to change the name of the role in the squad layout instead
+    * - unit layout [Role Name, Settings Struct]
+    * - settings struct: 
+    *   - max: The most amount of this unit is allowed per squad
+    *   - min: The squad can't be formed unless at least 1 of this unit is in it
+    *   - role: The name of the unit when it is a member of the squad. This is where you rename roles e.g. 
+      "Terminator" > "Deathwing Terminator" 
+    **  - loadout: Struct containing Required and Optional weaponry this unit can equip 
+      a required loadout always follows this syntax <loadout_slot>:[<loadout_item>,<required number>]
+    so "wep1":["Bolter",4], will mean four marines are always equipped with 4 bolters in the wep1 slot
+    *       option loadouts follow the following syntax <loudout_slot>:[[<loadout_item_list>],<allowed_number>]
+    for example [["Flamer", "Meltagun"],1], means the role can have a max of one flamer or meltagun
+    [["Plasma Pistol","Bolt Pistol"], 4] means the role can have a mix of 4 plasma pistols and bolt pistols on top
+    of all required loadout options
+      - wep1: right hand weapon
+      - wep2: left hand weapon
+      - mobi: Mobility item, e.g. Jump Packs. 
+      - armour: required armour 
+      - gear: special equipment needed for certain roles, like a Roasrius or Narthecium
+    *   - type_data: names the squad, allows certain formations ? idk what that does yet*/
+  }
 }

--- a/datafiles/main/chapters/1.JSON
+++ b/datafiles/main/chapters/1.JSON
@@ -3,7 +3,7 @@
   {
     "id": 1, //number for your JSON file to be referenced in game files
     "name": "Dark Angels", //name of the chapter
-    "flavor": "The Dark Angels are the Progenitor Chapter formed from the First Legion of Primarch Lion El'Johnson. Though through their secretive nature their allegiance and actions may be questionable, they are some of the most deadly and well-armed Astartes in the Imperium", //the short description that appears on popup when you hover over a chapter image
+    "flavor": "The Dark Angels are the Progenitor Chapter formed from the First Legion of Primarch Lion El'Jonson. Though through their secretive nature their allegiance and actions may be questionable, they are some of the most deadly and well-armed Astartes in the Imperium", //the short description that appears on popup when you hover over a chapter image
     "battle_cry": "Repent! For tomorrow you die!", //this is where you cry. I mean this is where you say what are you crying about. I mean... fuck it just type shit here to scream at people
     "origin": 1, //[1] Founding [2] Successor [3] Other [4] Custom
     "points": 150, //creation points, feel free to cheat here for more wild stuff in custom if you don't like doing it via files

--- a/datafiles/main/squads/base_squads.json
+++ b/datafiles/main/squads/base_squads.json
@@ -60,7 +60,8 @@
         "devastator",
         "scout",
         "tactical"
-      ]
+      ],
+      "base" : "command"
     }
   },
 

--- a/scripts/scr_UnitGroup/scr_UnitGroup.gml
+++ b/scripts/scr_UnitGroup/scr_UnitGroup.gml
@@ -185,7 +185,7 @@ function UnitGroup(units) constructor {
             _squad = _unit.get_squad();
 
             if (!struct_exists(_squad_index, _squad.type)) {
-                _squad_index[_squad.type] = [];
+                _squad_index[$ _squad.type] = [];
             }
             array_push(_squad_index[$ _squad.type], _unit.squad);
         }

--- a/scripts/scr_chapter_new/scr_chapter_new.gml
+++ b/scripts/scr_chapter_new/scr_chapter_new.gml
@@ -489,6 +489,10 @@ function scr_chapter_new(chapter_identifier) {
             obj_creation.custom_advisors = chapter_object.custom_advisors;
         }
 
+        if (struct_exists(chapter_object, "companies")) {
+            obj_creation.companies = chapter_object.companies;
+        }
+        
         // Validate and clamp trait values to sane ranges (defaulting if missing/invalid)
         obj_creation.strength = clamp(is_real(chapter_object.strength) ? chapter_object.strength : 5, 1, 10);
         obj_creation.purity = clamp(is_real(chapter_object.purity) ? chapter_object.purity : 5, 1, 10);

--- a/scripts/scr_chapter_new/scr_chapter_new.gml
+++ b/scripts/scr_chapter_new/scr_chapter_new.gml
@@ -481,6 +481,10 @@ function scr_chapter_new(chapter_identifier) {
             obj_creation.custom_squads = chapter_object.custom_squads;
         }
 
+        if (struct_exists(chapter_object, "squad_builder")) {
+            obj_creation.squad_builder = chapter_object.squad_builder;
+        }
+
         if (struct_exists(chapter_object, "custom_advisors")) {
             obj_creation.custom_advisors = chapter_object.custom_advisors;
         }

--- a/scripts/scr_company_order/scr_company_order.gml
+++ b/scripts/scr_company_order/scr_company_order.gml
@@ -49,7 +49,7 @@ function scr_company_order(company) {
 
             _squad.update_fulfilment(_squadless_index);
 
-            if (!_squad.fulfilled && _squad.type != "command_squad") {
+            if (!_squad.fulfilled && _squad.base != "command") {
                 _squad.empty_squad_to_index(_squadless_index);
             }
         }
@@ -58,7 +58,7 @@ function scr_company_order(company) {
         for (var i = 0; i < array_length(_empty_squads); i++) {
             var _squad = _empty_squads[i];
             _squad.update_fulfilment(_squadless_index);
-            if (!_squad.fulfilled && _squad.type != "command_squad") {
+            if (!_squad.fulfilled && _squad.base != "command") {
                 _squad.empty_squad_to_index(_squadless_index);
             } else {
                 _squad.base_company = co;

--- a/scripts/scr_draw_management_unit/scr_draw_management_unit.gml
+++ b/scripts/scr_draw_management_unit/scr_draw_management_unit.gml
@@ -517,7 +517,7 @@ function scr_draw_management_unit(selected, yy = 0, xx = 0, draw = true, click_l
                 if (_unit.IsSpecialist(SPECIALISTS_COMMAND)) {
                     changed = true;
                 } else if (_unit.squad != "none") {
-                    if (fetch_squad(_unit.squad).type == "command_squad") {
+                    if (fetch_squad(_unit.squad).base == "command") {
                         changed = true;
                     }
                 }

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -1698,7 +1698,6 @@ function scr_initialize_custom() {
     // LOGGER.debug($"{custom_squads}");
 
     if (struct_exists(obj_creation, "squad_builder")){
-        LOGGER.info(obj_creation.squad_builder);
         for (var s=0; s<array_length(obj_creation.squad_builder);s++){
             var _custom_build = obj_creation.squad_builder[s];
             for (var i=0;i<array_length(obj_ini.chapter_squad_arrangement.companies);i++){
@@ -1708,7 +1707,6 @@ function scr_initialize_custom() {
                 }
             }
         }
-        LOGGER.info(obj_ini.chapter_squad_arrangement);
     }
 
     if (struct_exists(obj_creation, "custom_squads")) {
@@ -1716,7 +1714,6 @@ function scr_initialize_custom() {
         with (squad_types){
             move_data_to_current_scope(_customs);
         }
-        LOGGER.info(struct_get_names(squad_types));
     }
 
     // LOGGER.debug($"roles object for chapter {chapter_name} after setting from obj");

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -1697,24 +1697,26 @@ function scr_initialize_custom() {
     // LOGGER.debug($"squads object for chapter {chapter_name}");
     // LOGGER.debug($"{custom_squads}");
 
-    if (struct_exists(obj_creation, "custom_squads")) {
-        var custom_squads = obj_creation.custom_squads;
-        // LOGGER.debug($"custom roles {custom_squads}");
-        if (array_length(struct_get_names(custom_squads)) != 0) {
-            var names = struct_get_names(custom_squads);
-            // LOGGER.debug($"names {names}");
-            for (var n = 0; n < array_length(names); n++) {
-                var _squad_name = names[n];
-                // LOGGER.debug($"matched squad name name {_squad_name}");
-
-                if (struct_exists(custom_squads, _squad_name)) {
-                    var custom_squad = struct_get(custom_squads, _squad_name);
-                    // LOGGER.debug($"overwriting squad layout for {_squad_name}");
-                    // LOGGER.debug($"{custom_squad}")
-                    variable_struct_set(custom_squads, _squad_name, custom_squad);
+    if (struct_exists(obj_creation, "squad_builder")){
+        LOGGER.info(obj_creation.squad_builder);
+        for (var s=0; s<array_length(obj_creation.squad_builder);s++){
+            var _custom_build = obj_creation.squad_builder[s];
+            for (var i=0;i<array_length(obj_ini.chapter_squad_arrangement.companies);i++){
+                var _default_build = obj_ini.chapter_squad_arrangement.companies[i];
+                if (_custom_build.company == _default_build.company){
+                    obj_ini.chapter_squad_arrangement.companies[i] = _custom_build;
                 }
             }
         }
+        LOGGER.info(obj_ini.chapter_squad_arrangement);
+    }
+
+    if (struct_exists(obj_creation, "custom_squads")) {
+        var _customs = obj_creation.custom_squads;
+        with (squad_types){
+            move_data_to_current_scope(_customs);
+        }
+        LOGGER.info(struct_get_names(squad_types));
     }
 
     // LOGGER.debug($"roles object for chapter {chapter_name} after setting from obj");

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -2362,9 +2362,32 @@ function scr_initialize_custom() {
         LOGGER.info($"New Company Totals: eq specialists: {equal_specialists}: scout coy {scout_company_behaviour} equal_scouts: {equal_scouts}");
         // LOGGER.info($"Company {_coy.coy}: {json_stringify(_coy, true)}");
 
-        var attrs = struct_get_names(_coy);
-
+        var _set_company_makeup = function(old_values, new_values){
+            var _override_keys = struct_get_names(new_values);
+            var _override_keys_count = array_length(_override_keys);
+            for (var j = 0; j < _override_keys_count; j++) {
+                var _okey_hash = _override_keys[j];
+                var _okey_ins = new_values[$ _okey_hash];
+                LOGGER.info($"{_okey_hash}<{_okey_ins}<{old_values}")
+                old_values[$ _okey_hash] = _okey_ins;
+            }
+            return old_values;
+        }
+        if (struct_exists(obj_creation, "companies")) {
+            var _company_keys = ["first", "second", "third", "fourth", "fifth", "sixth", "seventh", "eighth", "ninth", "tenth"];
+            var _company_keys_count = array_length(_company_keys);
+            for (var i = 0; i < _company_keys_count; i++) {
+                var _company_string = _company_keys[i]
+                if (struct_exists(obj_creation.companies, _company_string) && struct_exists(companies, _company_string)) {
+                    var _ckey_ins = obj_creation.companies[$ _company_string];
+                    var _ckey_var = companies[$ _company_string];                    
+                    companies[$ _company_string] = _set_company_makeup(_ckey_var, _ckey_ins);
+                }
+            }
+        }
         // LOGGER.info($"attrs {attrs}");
+
+        var attrs = struct_get_names(_coy);
 
         for (var _a = 0, _alen = array_length(attrs); _a < _alen; _a++) {
             var _is_vehicle = false;

--- a/scripts/scr_squads/scr_squads.gml
+++ b/scripts/scr_squads/scr_squads.gml
@@ -224,8 +224,10 @@ function UnitSquad(squad_type = undefined, company = 0) constructor {
         if (struct_exists(type_data, "class")) {
             class = type_data.class;
         }
-        if (struct_exists(type_data, "base")){
+        if (struct_exists(type_data, "base")) {
             base = type_data.base;
+        } else {
+            base = "tactical";
         }
         if (struct_exists(type_data, "formation_options")) {
             formation_options = type_data.formation_options;

--- a/scripts/scr_squads/scr_squads.gml
+++ b/scripts/scr_squads/scr_squads.gml
@@ -50,6 +50,7 @@ function UnitSquad(squad_type = undefined, company = 0) constructor {
     class = [];
     squad_leader = "";
     type_data = {};
+    base = "tactical";
     formation_place = "";
     formation_options = [];
     uid = scr_uuid_generate();
@@ -222,6 +223,9 @@ function UnitSquad(squad_type = undefined, company = 0) constructor {
         display_name = type_data[$ "display_data"];
         if (struct_exists(type_data, "class")) {
             class = type_data.class;
+        }
+        if (struct_exists(type_data, "base")){
+            base = type_data.base;
         }
         if (struct_exists(type_data, "formation_options")) {
             formation_options = type_data.formation_options;


### PR DESCRIPTION
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
## Purpose and Description
<!-- Explain why and what your changes do in simple terms. -->
- Self-descriptive.
- as per pr title
- uses the data type of "base" = "command" rather than looking for the squad id  "command_squad"
- adds in company modding from tavish
- modding provided by tavish for da
## Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- None, and I understand the risks.

## Related things and/or additional context
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, screenshots etc. -->
-

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->

<!--- "Inspired" by the CDDA PR template -->




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-company `squad_builder` and company composition overrides, and finishes Dark Angels content with Deathwing/Ravenwing line and command squads, artifacts with slot assignments, and full/complex/company livery data. Command-squad behavior now keys off `type_data.base` instead of `type`.

- **New Features**
  - Data loading: `scr_chapter_new` now reads `squad_builder` and `companies`; `scr_initialize_custom` merges builders into `chapter_squad_arrangement`, injects `custom_squads` into `squad_types`, and applies per-company counts (e.g., veterans, vehicles).
  - Engine/UI: added `UnitSquad.base` (default `"tactical"`); command checks use `base == "command"` in company ordering and management UI; `base_squads.json` marks command squads; fixed `UnitGroup` squad index scoping.
  - Dark Angels (chapter `1`): expanded JSON with artifacts and slot assignments, full/complex/company liveries, updated names/titles and fleet/specialists; `squad_builder` auto-builds 1st (Deathwing) and 2nd (Ravenwing) with required command squads; new `deathwing_*` and `ravenwing_*` squads with `allowed_companies` and `type_data.base`.

- **Migration**
  - For custom command squads, set `"base": "command"` under `type_data` (defaults to `"tactical"`).
  - Replace any checks for `type == "command_squad"` with `base == "command"`.

<sup>Written for commit b797505c9b4d5454c0dd7861cce7c06ea95ad471. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



