### PR TITLE
chore: add more functionality to add trait unit method 

### DIFF
--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -450,15 +450,38 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
     };
 
     //adds a trait to a marines trait list
-    static add_trait = function(trait) {
-        var balance_value;
+    static add_trait = function(trait,return_stat_diff = false, return_description = false) {
+
+        if (return_stat_diff){
+            var _start_stats = get_stat_line();
+        }
         if (struct_exists(global.trait_list, trait)) {
             if (!array_contains(traits, trait)) {
+
+                var _return_string = "";
                 var selec_trait = global.trait_list[$ trait];
                 stat_boosts(selec_trait);
                 array_push(traits, trait);
+
+                if (return_stat_diff){
+                    var _end_stats = get_stat_line();
+
+                    var _stat_diff = compare_stats(_end_stats,_start_stats);
+                }
+
+                if (return_description){
+                    _return_string += $"{name_role()} Has gained the trait {selec_trait.display_name}";
+                }
+
+                if (return_stat_diff){
+                    _return_string +=$", {(print_stat_diffs(_stat_diff))}"
+                }
+
+                return _return_string
             }
         }
+
+        return "";
     };
 
     static has_trait = marine_has_trait;

--- a/scripts/scr_mission_functions/scr_mission_functions.gml
+++ b/scripts/scr_mission_functions/scr_mission_functions.gml
@@ -520,6 +520,7 @@ function complete_beast_hunt_mission(targ_planet, problem_index) {
         var _unit;
         var _unit_report_string = "";
         var _deaths = 0;
+        var _successful_hunters = [];
         if (!array_length(_hunters)) {
             remove_planet_problem(targ_planet, "hunt_beast");
             return;

--- a/scripts/scr_mission_functions/scr_mission_functions.gml
+++ b/scripts/scr_mission_functions/scr_mission_functions.gml
@@ -533,11 +533,8 @@ function complete_beast_hunt_mission(targ_planet, problem_index) {
                 }
             }
             if (_unit_pass[0]) {
-                var _start_stats = variable_clone(_unit.get_stat_line());
-                _unit.add_trait("beast_slayer");
-                var end_stat = _unit.get_stat_line();
-                var _stat_diff = compare_stats(end_stat, _start_stats);
-                _unit_report_string += $"{_unit.name_role()} Has gained the trait {global.trait_list.beast_slayer.display_name}, {print_stat_diffs(_stat_diff)}\n";
+                _unit_report_string += _unit.add_trait("beast_slayer",true, true);
+                array_push(_successful_hunters, _unit);
             } else {
                 var _tough_check = _tester.standard_test(_unit, "constitution", _unit.luck);
                 if (!_tough_check[0]) {


### PR DESCRIPTION
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
## Purpose and Description
<!-- Explain why and what your changes do in simple terms. -->
- Self-descriptive.

## Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- None, and I understand the risks.

## Related things and/or additional context
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, screenshots etc. -->
-

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->

<!--- "Inspired" by the CDDA PR template -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expanded `add_trait` to optionally return a formatted report with stat deltas and a description. Updated Beast Hunt mission to use it and initialize `_successful_hunters`, removing duplicate logic and preventing undefined variable errors.

- **New Features**
  - `add_trait(trait, return_stat_diff = false, return_description = false)` adds optional output.
  - On success, returns "<name> has gained <trait>, <stat diffs>"; returns "" otherwise.
  - Backwards-compatible.

- **Refactors**
  - Replaced manual stat diff/report in `complete_beast_hunt_mission` with `_unit.add_trait("beast_slayer", true, true)`.
  - Track successful hunters via `_successful_hunters`, now initialized in the mission.

<sup>Written for commit ab37b2f966554e3782202f34ec783c74f7946658. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

