### PR TITLE
fix: patch old saves causing crash in company sort

### DIFF
--- a/objects/obj_ini/Create_0.gml
+++ b/objects/obj_ini/Create_0.gml
@@ -257,6 +257,11 @@ deserialize = function(save_data) {
 
     // Automatic var setting
     var all_names = struct_get_names(save_data);
+
+    if (!array_contains(all_names, "chapter_squad_arrangement")){
+        obj_ini.chapter_squad_arrangement = json_to_gamemaker(working_directory + $"main\\squads\\company_squad_builds.json", json_parse);
+    }
+    
     var _len = array_length(all_names);
     for (var i = 0; i < _len; i++) {
         var var_name = all_names[i];


### PR DESCRIPTION
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
## Purpose and Description
<!-- Explain why and what your changes do in simple terms. -->
- Self-descriptive.

## Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- None, and I understand the risks.

## Related things and/or additional context
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, screenshots etc. -->
-

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->

<!--- "Inspired" by the CDDA PR template -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents crashes when loading old save files by initializing a missing chapter_squad_arrangement during deserialization. If the field is absent, it now loads defaults from main\squads\company_squad_builds.json so company sorting works.

<sup>Written for commit ad96e02205b80098e668bb8e7a2737c02f2a6744. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

