### PR TITLE
chore: add get_imperial_navy_fleets function

### DIFF
--- a/scripts/scr_imperial_navy_functions/scr_imperial_navy_functions.gml
+++ b/scripts/scr_imperial_navy_functions/scr_imperial_navy_functions.gml
@@ -1117,3 +1117,19 @@ function setup_start_imperial_navy_fleet(system) {
         }
     }
 }
+
+
+
+function get_imperial_navy_fleets(){
+    var _fleets = [];
+
+    with (obj_en_fleet){
+        if (owner != eFACTION.IMPERIUM || !navy){
+            continue;
+        } else if (owner == eFACTION.IMPERIUM && navy){
+            array_push(_fleets, id);
+        }
+    }
+
+    return _fleets;
+}


### PR DESCRIPTION
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
## Purpose and Description
<!-- Explain why and what your changes do in simple terms. -->
- Self-descriptive.
gets all imperial navy fleets
## Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- None, and I understand the risks.

## Related things and/or additional context
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, screenshots etc. -->
-

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->

<!--- "Inspired" by the CDDA PR template -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `get_imperial_navy_fleets()` to return a list of Imperial Navy fleet instance IDs. It scans all `obj_en_fleet` instances and collects those owned by `eFACTION.IMPERIUM` with `navy == true`.

<sup>Written for commit c80a848dce9c82b9d43d82146456e6b1c8c88c05. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

