### PR TITLE
chore: add uid to obj_en_fleets

### DIFF
--- a/objects/obj_en_fleet/Create_0.gml
+++ b/objects/obj_en_fleet/Create_0.gml
@@ -21,6 +21,9 @@ ii_check = floor(random(5)) + 1;
 etah = 0;
 safe = 0;
 last_turn_check = 0;
+
+
+uid = scr_uuid_generate();
 //TODO set up special save method for faction specific fleet variables
 inquisitor = -1;
 

--- a/scripts/scr_fleet_functions/scr_fleet_functions.gml
+++ b/scripts/scr_fleet_functions/scr_fleet_functions.gml
@@ -49,6 +49,17 @@ function scr_valid_fleet_target(target) {
     return valid;
 }
 
+function get_fleet_uid(search_uid){
+    var _fleet = undefined;
+    with (obj_en_fleet){
+        if (uid == search_uid){
+            _fleet = id;
+            break;
+        }
+    }
+    return _fleet;
+}
+
 function fleets_next_location(fleet = "none", visited = []) {
     var targ_location = "none";
 


### PR DESCRIPTION
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
## Purpose and Description
<!-- Explain why and what your changes do in simple terms. -->
- Self-descriptive.

## Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- None, and I understand the risks.

## Related things and/or additional context
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, screenshots etc. -->
-

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->

<!--- "Inspired" by the CDDA PR template -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a unique ID to enemy fleets and a lookup helper. `obj_en_fleet` sets `uid = scr_uuid_generate()` on create, and `get_fleet_uid(search_uid)` returns the fleet instance for a given UID.

<sup>Written for commit a5b63064bdd6035be23159ea40d28fba8767dce8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

