### PR TITLE
chore: add irandom_numeral function

### DIFF
--- a/scripts/scr_roman_numerals/scr_roman_numerals.gml
+++ b/scripts/scr_roman_numerals/scr_roman_numerals.gml
@@ -55,3 +55,8 @@ function int_to_roman(_num) {
 
     return _result;
 }
+
+
+function irandom_numeral(max_val){
+    return int_to_roman(irandom_range(1, max_val));
+}

--- a/scripts/scr_roman_numerals/scr_roman_numerals.gml
+++ b/scripts/scr_roman_numerals/scr_roman_numerals.gml
@@ -58,5 +58,6 @@ function int_to_roman(_num) {
 
 
 function irandom_numeral(max_val){
-    return int_to_roman(irandom_range(1, max_val));
+    var _bounded_max = clamp(max_val, 1, 100);
+    return int_to_roman(irandom_range(1, _bounded_max));
 }


### PR DESCRIPTION
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
## Purpose and Description
<!-- Explain why and what your changes do in simple terms. -->
- Self-descriptive.

## Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- None, and I understand the risks.

## Related things and/or additional context
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, screenshots etc. -->
-

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->

<!--- "Inspired" by the CDDA PR template -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `irandom_numeral(max_val)`, which returns a Roman numeral for a random integer from 1 to `max_val` (clamped to 1-100) using `int_to_roman`.

<sup>Written for commit 6c81b6108c4147b9c3f7bd8d276547b515eb45b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

