### PR TITLE
feat: marine epithets and name scaling

### DIFF
--- a/scripts/scr_buttons/scr_buttons.gml
+++ b/scripts/scr_buttons/scr_buttons.gml
@@ -88,6 +88,9 @@ function ReactiveString(text, x1 = 0, y1 = 0, data = false) constructor {
     h = 0;
     w = 0;
     scale_text = false;
+    with_outline = true;
+    min_scale = 0;
+    allow_line_breaks = true;
 
     move_data_to_current_scope(data);
 
@@ -106,7 +109,9 @@ function ReactiveString(text, x1 = 0, y1 = 0, data = false) constructor {
                 y2 = y1 + h;
             } else {
                 w = max_width;
-                scale = calc_text_scale_confines(text, max_width);
+                var _scale_edits = calc_text_scale_confines(text, max_width, 0,allow_line_breaks)
+                scale = _scale_edits.scale;
+                text = _scale_edits.text;
                 h = string_height(text) * scale;
             }
         } else {
@@ -133,7 +138,11 @@ function ReactiveString(text, x1 = 0, y1 = 0, data = false) constructor {
             if (!scale_text) {
                 draw_text_ext_outline(x1, y1, text, -1, max_width, c_black, colour);
             } else {
-                draw_text_transformed(x1, y1, text, scale, scale, 0);
+                if (with_outline) {
+                    draw_text_transformed_outline(x1, y1, text, scale, scale, 0);
+                } else {
+                    draw_text_transformed(x1, y1, text, scale, scale, 0);
+                }
             }
         } else {
             draw_text_outline(x1, y1, text, c_black, colour);
@@ -365,7 +374,11 @@ function UnitButtonObject(data = false) constructor {
                 w = string_width(label) + 10;
                 h = string_height(label) + 4;
             } else {
-                text_scale = calc_text_scale_confines(label, w, 10);
+                var _text_scale = calc_text_scale_confines(label, w, 10);
+
+                text_scale = _text_scale.scale;
+
+                text = _text_scale.text;
             }
             h = string_height(label) + 4;
         }

--- a/scripts/scr_buttons/scr_buttons.gml
+++ b/scripts/scr_buttons/scr_buttons.gml
@@ -378,7 +378,7 @@ function UnitButtonObject(data = false) constructor {
 
                 text_scale = _text_scale.scale;
 
-                text = _text_scale.text;
+                label = _text_scale.text;
             }
             h = string_height(label) + 4;
         }

--- a/scripts/scr_draw_text/scr_draw_text.gml
+++ b/scripts/scr_draw_text/scr_draw_text.gml
@@ -132,7 +132,7 @@ function draw_text_shadow(_x, _y, _text) {
 /// @returns {struct} { text, scale }
 function calc_text_scale_confines(text, width, buffer = 0, allow_line_breaking = true) {
 
-    var _usable_width = width - buffer;
+    var _usable_width = max(0, width - buffer);
     var _text         = text;
     var _scale        = 1;
 

--- a/scripts/scr_draw_text/scr_draw_text.gml
+++ b/scripts/scr_draw_text/scr_draw_text.gml
@@ -125,14 +125,59 @@ function draw_text_shadow(_x, _y, _text) {
     draw_text(_x, _y, _text);
 }
 
-function calc_text_scale_confines(text, width, buffer = 0) {
-    var _scale = 1;
-    var _string_width = string_width(text);
-    if (_string_width > (width - buffer)) {
-        _scale = (width - buffer) / _string_width;
+/// @param {string} text
+/// @param {real}   width
+/// @param {real}   buffer
+/// @param {bool}   allow_line_breaking
+/// @returns {struct} { text, scale }
+function calc_text_scale_confines(text, width, buffer = 0, allow_line_breaking = true) {
+
+    var _usable_width = width - buffer;
+    var _text         = text;
+    var _scale        = 1;
+
+    var _string_width = string_width(_text);
+
+    if (_string_width > _usable_width) {
+        _scale = _usable_width / _string_width;
+
+        // Only attempt line-breaking when scale has shrunk enough to warrant it
+        if (allow_line_breaking && _scale < 0.5) {
+
+            // ── Word-wrap pass ────────────────────────────────────────────
+            var _words      = string_split(_text, " ");   // GM 2022.1+
+            var _lines      = [""];
+            var _line_idx   = 0;
+
+            for (var i = 0; i < array_length(_words); i++) {
+                var _word      = _words[i];
+                var _candidate = (_lines[_line_idx] != "") 
+                                 ? _lines[_line_idx] + " " + _word 
+                                 : _word;
+
+                if (string_width(_candidate) > _usable_width && _lines[_line_idx] != "") {
+                    // Current line is full — open a new one
+                    _line_idx++;
+                    array_push(_lines, _word);
+                } else {
+                    _lines[_line_idx] = _candidate;
+                }
+            }
+
+            _text = string_join_ext("\n", _lines);        // GM 2022.6+
+
+            // ── Recalculate scale from the widest wrapped line ────────────
+            var _max_w = 0;
+            for (var i = 0; i < array_length(_lines); i++) {
+                var _lw = string_width(_lines[i]);
+                if (_lw > _max_w) _max_w = _lw;
+            }
+
+            _scale = (_max_w > _usable_width) ? (_usable_width / _max_w) : 1;
+        }
     }
 
-    return _scale;
+    return { text: _text, scale: _scale };
 }
 
 /// @function draw_text_ext_shadow

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -1787,14 +1787,14 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
         }
 
         if (include_epithet){
-            epithet = "";
+            var _epithet = "";
             if (array_length(epithets)){
-                epithet += $" {epithets[0].title}";
+                _epithet += $"{epithets[0].title}";
             }
         }
 
-        if (include_epithet && epithet != ""){
-            return string("{0} {1}", _name, epithet);
+        if (include_epithet && _epithet != ""){
+            return string("{0} {1}", _name, _epithet);
         }
 
         return _name;

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -1777,7 +1777,7 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
     };
 
     //quick way of getting name and role combined in string
-    static name_role = function() {
+    static name_role = function(include_epithet = true) {
         var temp_role = role();
         if (squad != "none") {
             var _squad = get_squad();
@@ -1788,6 +1788,16 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
                 }
             }
         }
+
+        if (include_epithet){
+            epithet = "";
+            if (array_length(epithets)){
+                epithet += $" {epithets[0].title}";
+            }
+
+            return string("{0} {1} {2}", temp_role, name(), epithet);
+        }
+
         return string("{0} {1}", temp_role, name());
     };
 

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -137,6 +137,7 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
     religion_sub_cult = "none";
     base_group = "none";
     role_history = [];
+    epithets = [];
     enum eROLE_TAG {
         Techmarine = 0,
         Librarian = 1,
@@ -928,6 +929,17 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
     static update_age = function(new_val) {
         obj_ini.age[company][marine_number] = new_val;
     };
+
+    //TODO build epithets in to marine profile
+    static add_epithet = function(epithet){
+        if (is_string(epithet)){
+            epithet = {
+                title : epithet,
+                story : "",
+            }
+        }
+        array_push(epithets,epithet);
+    }
 
     static name = function() {
         return obj_ini.name[company][marine_number];

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -1777,16 +1777,13 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
     };
 
     //quick way of getting name and role combined in string
-    static name_role = function(include_epithet = true) {
-        var temp_role = role();
-        if (squad != "none") {
-            var _squad = get_squad();
-            if (struct_exists(obj_ini.squad_types[$ _squad.type], temp_role)) {
-                var role_info = obj_ini.squad_types[$ _squad.type][$ temp_role];
-                if (struct_exists(role_info, "role")) {
-                    temp_role = role_info[$ "role"];
-                }
-            }
+    static name_role = function(include_epithet = true, include_role = true) {
+
+        var _name = name();
+
+         if (include_role){
+            var _temp_role = squad_role();
+            _name = string("{0} {1}", _temp_role, _name);
         }
 
         if (include_epithet){
@@ -1794,11 +1791,15 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
             if (array_length(epithets)){
                 epithet += $" {epithets[0].title}";
             }
-
-            return string("{0} {1} {2}", temp_role, name(), epithet);
         }
 
-        return string("{0} {1}", temp_role, name());
+        if (include_epithet && epithet != ""){
+            return string("{0} {1}", _name, epithet);
+        }
+
+        return _name;
+
+        
     };
 
     static controllable = function() {

--- a/scripts/scr_ui_manage/scr_ui_manage.gml
+++ b/scripts/scr_ui_manage/scr_ui_manage.gml
@@ -410,16 +410,57 @@ function reset_manage_unit_constants(unit) {
             font :fnt_40k_30b,
             scale_text :true,
             max_width : 250,
+            min_scale : 0.7
         };
 
-        var _name=unit.name();
-        if (array_length(unit.epithets)){
-            _name += unit.epithets[0].title;
-        }
+
+        var _name=unit.name_role(true, false);
+
         unit_manage_constants.name = new ReactiveString(_name,0,0,_string_data);
+
+
+        var _role_name = "";
+
+        var _comp_string = "";
+
+        if (unit.company <= 0) {
+            _role_name = $"{unit.squad_role()}";
+        } else if (unit.IsSpecialist()) {
+            _comp_string = $"{unit.company_roman()} Company";
+            _role_name = $"{unit.role()}";
+        } else {
+            _comp_string = $"{unit.company_roman()} Company";
+            _role_name = $"{unit.squad_role()}";
+        }      
+
+        _string_data = {
+            colour : #50a076,
+            scale : 1,
+            halign :fa_center,
+            font :fnt_40k_14b,
+            scale_text :true,
+            max_width : 250,
+        };
+
+        unit_manage_constants.role_name = new ReactiveString(_role_name,0,0,_string_data);
+
+
+        _string_data = {
+            colour : #50a076,
+            scale : 1,
+            halign :fa_center,
+            font :fnt_40k_14b,
+            scale_text :true,
+            max_width : 250,
+        };
+
+        unit_manage_constants.company_string = new ReactiveString(_comp_string,0,0,_string_data);
+
     // TODO
-}*/
-    } catch (_exception) {} //not sure handling with normal method exception could just be a pain here
+    } catch (_exception) {
+        handle_exception(_exception);
+        obj_controller.unit_focus = undefined;
+    } //not sure handling with normal method exception could just be a pain here
 }
 
 /// @mixin
@@ -638,30 +679,26 @@ function draw_sprite_and_unit_equip_data() {
             draw_set_color(line_color);
 
             // Draw unit name and role
-            var _name_box = {
+
+            unit_manage_constants.name.update({
+                x1: xx + 402,
+                y1: yy + 76,
+            });
+
+
+            unit_manage_constants.role_name.update({
+                x1: xx + 402,
+                y1: yy + 56,
+            });
+
+            unit_manage_constants.company_string.update({
                 x1: xx + 402,
                 y1: yy + 36,
-                text1: "",
-                text2: "",
-                text3: selected_unit.name(),
-            };
-            _name_box.y2 = _name_box.y1 + 20;
-            _name_box.y3 = _name_box.y2 + 20;
-            if (selected_unit.company <= 0) {
-                _name_box.text2 = $"{selected_unit.squad_role()}";
-            } else if (selected_unit.IsSpecialist()) {
-                _name_box.text1 = $"{selected_unit.company_roman()} Company";
-                _name_box.text2 = $"{selected_unit.role()}";
-            } else {
-                _name_box.text1 = $"{selected_unit.company_roman()} Company";
-                _name_box.text2 = $"{selected_unit.squad_role()}";
-            }
-            draw_set_halign(fa_center);
-            draw_set_font(fnt_40k_14b);
-            draw_text_transformed_outline(_name_box.x1, _name_box.y1, _name_box.text1, 1, 1, 0);
-            draw_text_transformed_outline(_name_box.x1, _name_box.y2, _name_box.text2, 1, 1, 0);
-            draw_set_font(fnt_40k_30b);
-            draw_text_transformed_outline(_name_box.x1, _name_box.y3, _name_box.text3, 0.7, 0.7, 0);
+            });
+
+            unit_manage_constants.name.draw();
+            unit_manage_constants.role_name.draw();
+            unit_manage_constants.company_string.draw();
 
             // Draw unit info
             draw_set_font(fnt_40k_14);

--- a/scripts/scr_ui_manage/scr_ui_manage.gml
+++ b/scripts/scr_ui_manage/scr_ui_manage.gml
@@ -402,7 +402,21 @@ function reset_manage_unit_constants(unit) {
         unit_manage_image = unit.draw_unit_image();
 
         temp[122] = unit.handle_stat_growth();
-        /*if (man[sel]="vehicle"){
+        
+        var _string_data = {
+            colour : #50a076,
+            scale : 0.7,
+            halign :fa_center,
+            font :fnt_40k_30b,
+            scale_text :true,
+            max_width : 250,
+        };
+
+        var _name=unit.name();
+        if (array_length(unit.epithets)){
+            _name += unit.epithets[0].title;
+        }
+        unit_manage_constants.name = new ReactiveString(_name,0,0,_string_data);
     // TODO
 }*/
     } catch (_exception) {} //not sure handling with normal method exception could just be a pain here


### PR DESCRIPTION
<img width="278" height="362" alt="Screenshot 2026-05-14 at 15 36 34" src="https://github.com/user-attachments/assets/b3835c90-bea1-453a-ac18-5817ff327833" />
<img width="336" height="353" alt="Screenshot 2026-05-14 at 15 36 47" src="https://github.com/user-attachments/assets/e97693d5-7c29-4fd7-bba2-6663ea382bea" />
<img width="321" height="367" alt="Screenshot 2026-05-14 at 15 36 29" src="https://github.com/user-attachments/assets/d66ee0bd-c03c-4b22-9f39-481330534cc3" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds epithets to marines and shows them in the Manage view. Improves text rendering with auto-scaling, optional word wrap, and an outline toggle via `ReactiveString` and the new `calc_text_scale_confines`.

- **New Features**
  - Marine epithets: stored on profile; `add_epithet()` accepts a string or `{ title, story }`; included in `name_role()` when enabled.
  - Text rendering: `calc_text_scale_confines(text, width, buffer, allow_line_breaking)` returns `{ text, scale }` and wraps long text; `ReactiveString` adds `with_outline`, `min_scale`, and `allow_line_breaks`.
  - Manage UI: name, role, and company lines use `ReactiveString` with centered layout and a 250px max width.

- **Refactors**
  - Updated callers (e.g., `UnitButtonObject`) to the new `calc_text_scale_confines` return shape.
  - `name_role(include_epithet, include_role)` replaces the old signature.
  - `reset_manage_unit_constants()` now handles errors with `handle_exception()` and clears unit focus.

<sup>Written for commit 1b5d5194a1e90853d784dedba88c521d40ca1c0b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



