### PR TITLE
fix: improve tables and table use

### DIFF
--- a/objects/obj_controller/Create_0.gml
+++ b/objects/obj_controller/Create_0.gml
@@ -1857,6 +1857,9 @@ instance_create(0, 0, obj_tooltip);
 
 action_set_alarm(2, 0);
 
+//ensure fleet tab isup to date at gae start
+location_viewer.update_fleet_table();
+
 armamentarium = new Armamentarium(self);
 
 //**! DO NOT PUT THINGS AT THE BOTTOM OF THIS FILE IF YOU NEED THEM TO WORK AFTER LOADING FROM A SAVE, SEE LINE 1550 -ish   */ 

--- a/objects/obj_en_fleet/Create_0.gml
+++ b/objects/obj_en_fleet/Create_0.gml
@@ -21,6 +21,7 @@ ii_check = floor(random(5)) + 1;
 etah = 0;
 safe = 0;
 last_turn_check = 0;
+events = [];
 
 
 uid = scr_uuid_generate();

--- a/scripts/scr_Table/scr_Table.gml
+++ b/scripts/scr_Table/scr_Table.gml
@@ -88,15 +88,23 @@ function Table(data) constructor {
                     draw_text(_col_draw_x + (column_widths[d] / 2), _row_level, _row[$ _key]);
                     _col_draw_x += column_widths[d] + col_spacing;
                 }
-                if (_row_entered && struct_exists(_row, "hover")) {
+                if (!_row_entered){
+                    continue;
+                }
+                if (struct_exists(_row, "hover")) {
                     //LOGGER.debug($"click : {struct_exists(_row,"click_left")}");
                     _row.hover();
                 }
-                if (_row_entered && struct_exists(_row, "click_left")) {
+                if (struct_exists(_row, "click_left")) {
                     if (mouse_button_clicked()) {
                         _row.click_left();
                     }
                 }
+                if (struct_exists(_row,"click_right")){
+                    if (mouse_button_clicked(mb_right)){
+                        _row.click_right();
+                    }
+                } 
             }
 
             _row_level += row_h;

--- a/scripts/scr_Table/scr_Table.gml
+++ b/scripts/scr_Table/scr_Table.gml
@@ -136,7 +136,9 @@ function Table(data) constructor {
                 draw_rectangle(x1, _row_level, x1 + w, _row_level + row_h, 1);
             }
 
-            row_method(_row, _row_entered);
+            if (is_struct(_row)) {
+                row_method(_row, _row_entered);
+            }
 
             _row_level += row_h;
         }

--- a/scripts/scr_Table/scr_Table.gml
+++ b/scripts/scr_Table/scr_Table.gml
@@ -12,9 +12,13 @@ function Table(data) constructor {
 
     halign = fa_center;
 
+    colour = CM_GREEN_COLOR;
+
     header_h = 0;
 
     col_spacing = 5;
+
+    font = fnt_40k_14;
 
     move_data_to_current_scope(data);
 
@@ -55,11 +59,44 @@ function Table(data) constructor {
         }
     };
 
+    static row_method = function(_row, _row_entered){
+
+        if (!_row_entered){
+            return;
+        }
+
+        if (struct_exists(_row, "hover")) {
+            //LOGGER.debug($"click : {struct_exists(_row,"click_left")}");
+            _row.hover();
+        }
+
+        if (struct_exists(_row, "click_left")) {
+            if (mouse_button_clicked()) {
+                _row.click_left();
+            }
+        }
+
+        if (struct_exists(_row,"click_right")){
+            if (mouse_button_clicked(mb_right)){
+                _row.click_right();
+            }
+        } 
+    }
+
+    static row_count = function(){
+        return array_length(row_data);
+    }
+
+
     static draw = function() {
         add_draw_return_values();
 
         draw_set_halign(halign);
         draw_set_valign(fa_top);
+        draw_set_color(colour);
+        draw_set_font(font);
+
+        row_h = max(row_h, string_height("a") + 1);
 
         var _col_draw_x = x1;
         for (var i = 0; i < array_length(headings); i++) {
@@ -69,6 +106,8 @@ function Table(data) constructor {
 
         var _row_level = y1 + header_h + 5;
         var _cols = array_length(column_widths);
+        var _row_entered = scr_hit_dimensions(_col_draw_x, _row_level, w, row_h);
+
         for (var i = 0; i < array_length(row_data); i++) {
             //TODO add built in support for scrolling tables
             if (_row_level > y2 - row_h) {
@@ -76,7 +115,6 @@ function Table(data) constructor {
             }
             _col_draw_x = x1;
             var _row = row_data[i];
-            var _row_entered = scr_hit_dimensions(_col_draw_x, _row_level, w, row_h);
             if (is_array(row_data[i])) {
                 for (var d = 0; d < array_length(_row) && d < _cols; d++) {
                     draw_text(_col_draw_x + (column_widths[d] / 2), _row_level, _row[d]);
@@ -85,27 +123,19 @@ function Table(data) constructor {
             } else if (is_struct(_row)) {
                 for (var d = 0; d < array_length(row_key_draw) && d < _cols; d++) {
                     var _key = row_key_draw[d];
-                    draw_text(_col_draw_x + (column_widths[d] / 2), _row_level, _row[$ _key]);
+                    var _scale_edits = calc_text_scale_confines(_row[$ _key], column_widths[d], 0);
+                    var _scale = min(1,_scale_edits.scale);
+                    var _text = _scale_edits.text;
+                    draw_text_transformed(_col_draw_x + (column_widths[d] / 2),_row_level, _text, _scale,_scale, 0)
                     _col_draw_x += column_widths[d] + col_spacing;
                 }
-                if (!_row_entered){
-                    continue;
-                }
-                if (struct_exists(_row, "hover")) {
-                    //LOGGER.debug($"click : {struct_exists(_row,"click_left")}");
-                    _row.hover();
-                }
-                if (struct_exists(_row, "click_left")) {
-                    if (mouse_button_clicked()) {
-                        _row.click_left();
-                    }
-                }
-                if (struct_exists(_row,"click_right")){
-                    if (mouse_button_clicked(mb_right)){
-                        _row.click_right();
-                    }
-                } 
             }
+
+            if (_row_entered){
+                draw_rectangle(x1, _row_level, x1 + w, _row_level + row_h, 1);
+            }
+
+            row_method(_row, _row_entered);
 
             _row_level += row_h;
         }

--- a/scripts/scr_Table/scr_Table.gml
+++ b/scripts/scr_Table/scr_Table.gml
@@ -106,7 +106,6 @@ function Table(data) constructor {
 
         var _row_level = y1 + header_h + 5;
         var _cols = array_length(column_widths);
-        var _row_entered = scr_hit_dimensions(_col_draw_x, _row_level, w, row_h);
 
         for (var i = 0; i < array_length(row_data); i++) {
             //TODO add built in support for scrolling tables
@@ -114,6 +113,8 @@ function Table(data) constructor {
                 break;
             }
             _col_draw_x = x1;
+            var _row_entered = scr_hit_dimensions(_col_draw_x, _row_level, w, row_h);
+            
             var _row = row_data[i];
             if (is_array(row_data[i])) {
                 for (var d = 0; d < array_length(_row) && d < _cols; d++) {

--- a/scripts/scr_unit_quick_find_pane/scr_unit_quick_find_pane.gml
+++ b/scripts/scr_unit_quick_find_pane/scr_unit_quick_find_pane.gml
@@ -205,7 +205,8 @@ function UnitQuickFindPanel() constructor {
             }
         }
         mission_log = temp_log;
-
+        var xx = main_panel.XX;
+        var yy = main_panel.YY;
         var _data = {
             x1  :  xx+60,
             y1  :  yy+50,

--- a/scripts/scr_unit_quick_find_pane/scr_unit_quick_find_pane.gml
+++ b/scripts/scr_unit_quick_find_pane/scr_unit_quick_find_pane.gml
@@ -132,27 +132,30 @@ function UnitQuickFindPanel() constructor {
         mission_log = [];
         var temp_log = [];
         var p, i, problems;
-        with (obj_star) {
-            for (i = 1; i <= planets; i++) {
+        with(obj_star){
+            for (i=1;i<=planets;i++){
                 problems = p_problem[i];
-                for (p = 0; p < array_length(problems); p++) {
-                    if (problems[p] != "") {
-                        if (problem_has_key_and_value(i, p, "stage", "preliminary")) {
-                            continue;
-                        }
-                        var mission_explain = mission_name_key(problems[p]);
-                        if (mission_explain != "none") {
-                            array_push(temp_log, {system: name, mission: mission_explain, time: p_timer[i][p], planet: i});
-                        }
+                for (p = 0;p<array_length(problems);p++){
+                    if (problems[p] == ""){
+                        continue;
                     }
-                }
-            }
-        }
-        for (i = 0; i < array_length(obj_controller.quest); i++) {
-            if (obj_controller.quest[i] != "") {
-                var mission_explain = mission_name_key(obj_controller.quest[i]);
-                if (mission_explain != "none") {
-                    array_push(temp_log, {system: "", mission: mission_explain, time: obj_controller.quest_end[i] - obj_controller.turn, planet: 0});
+                    if (problem_has_key_and_value(i,p,"stage","preliminary")) then continue;
+                    var mission_explain =  mission_name_key(problems[p]);
+                    if (mission_explain != "none"){
+                        var _data = {
+                            system  :  name,
+                            mission  :  mission_explain,
+                            time  :  p_timer[i][p],
+                            planet  :  i,
+                        };
+                        
+                        _data.click_left = method(_data,function(){
+                            set_map_pan_to_loc(system);
+                        });
+
+                        array_push(temp_log,_data);
+                    }
+        
                 }
             }
         }

--- a/scripts/scr_unit_quick_find_pane/scr_unit_quick_find_pane.gml
+++ b/scripts/scr_unit_quick_find_pane/scr_unit_quick_find_pane.gml
@@ -336,10 +336,9 @@ function UnitQuickFindPanel() constructor {
                                 _mission_data.click_right = method(_mission_data,function(){
                                     var _unit = fetch_unit_uid(important_person);
                                     if (_unit != "none"){
-                                        var _unit_l = [fetch_unit_uid(important_person)];
+                                        var _unit_l = [_unit];
+                                        group_selection(_unit_l);
                                     };
-
-                                    group_selection(_unit_l);
                                 });
 
                                 array_push(temp_log,_mission_data);

--- a/scripts/scr_unit_quick_find_pane/scr_unit_quick_find_pane.gml
+++ b/scripts/scr_unit_quick_find_pane/scr_unit_quick_find_pane.gml
@@ -156,8 +156,66 @@ function UnitQuickFindPanel() constructor {
                 }
             }
         }
+        with (obj_en_fleet){
+            if (array_length(events)){
+                for (var i=0;i<array_length(events);i++){
+                    var _event = events[i];
+                    if (struct_exists(_event, "turn_end")){
+                        switch (_event.turn_end){
+                            case "deliver_trophy_end_turn_check" : 
+                                var _mission = $"Deliver Trophy Guard";
+                                var _sys = fleets_next_location();
+                                var _mission_data = {
+                                    mission  :  _mission,
+                                    system  :  _sys.name,
+                                    system_id  :  _sys.id,
+                                    target  :  id,
+                                    important_person  :  _event.fleetevent_data.trophy_owner,
+                                    person_name  :  _event.fleetevent_data.delivering_marine,
+                                    planet  :  0,
+                                    start_system  :  _event.fleetevent_data.system,
+                                    time  :  _event.timer,
+                                };
+
+                                _mission_data.click_left = method(_mission_data,function(){
+                                    set_map_pan_to_loc(system_id);
+                                });
+
+                                _mission_data.hover = method(_mission_data,function(){
+                                    tooltip_draw($"You are to have {person_name} deliver trophy hunted on {start_system} to the {start_system} regiments\n\nLeft click to see target fleet intercept system right click to view the trophy bearing marine {person_name}");
+                                });
+
+                                _mission_data.click_right = method(_mission_data,function(){
+                                    var _unit = fetch_unit_uid(important_person);
+                                    if (_unit != "none"){
+                                        var _unit_l = [fetch_unit_uid(important_person)];
+                                    };
+
+                                    group_selection(_unit_l);
+                                });
+
+                                array_push(temp_log,_mission_data);
+                                break;
+                        }
+                    }
+                }
+            }
+        }
         mission_log = temp_log;
+
+        var _data = {
+            x1  :  xx+60,
+            y1  :  yy+50,
+            y2  :  yy  + h,
+            set_column_widths  :  [80,130],
+            headings  :  ["Location", "Mission","Time\nRemaining"],
+            row_data  :  mission_log,
+            row_key_draw  :  ["system","mission","time"],
+        }
+        mission_table = new Table(_data);
     };
+
+
     hover_item = "none";
     travel_target = [];
     travel_time = 0;

--- a/scripts/scr_unit_quick_find_pane/scr_unit_quick_find_pane.gml
+++ b/scripts/scr_unit_quick_find_pane/scr_unit_quick_find_pane.gml
@@ -290,10 +290,11 @@ function UnitQuickFindPanel() constructor {
                             mission  :  mission_explain,
                             time  :  p_timer[i][p],
                             planet  :  i,
+                            system_id : id
                         };
                         
                         _data.click_left = method(_data,function(){
-                            set_map_pan_to_loc(system);
+                            set_map_pan_to_loc(system_id);
                         });
 
                         array_push(temp_log,_data);
@@ -487,68 +488,72 @@ function UnitQuickFindPanel() constructor {
     };
 
     static draw = function() {
-        add_draw_return_values();
-        if (obj_controller.menu == 0 && obj_controller.zoomed == 0) {
-            if (!instances_exist_any([obj_fleet_select, obj_star_select])) {
-                var x_draw = 0;
-                var lower_draw = main_panel.height + 110;
-                if (hide_sequence == 30) {
-                    hide_sequence = 0;
-                }
-                if ((hide_sequence > 0 && hide_sequence < 15) || (hide_sequence > 15 && hide_sequence < 30)) {
-                    if (hide_sequence > 15) {
-                        x_draw = ((main_panel.width / 15) * (hide_sequence - 15)) - main_panel.width;
-                    } else {
-                        x_draw = -((main_panel.width / 15) * hide_sequence);
+        try {
+            add_draw_return_values();
+            if (obj_controller.menu == 0 && obj_controller.zoomed == 0) {
+                if (!instances_exist_any([obj_fleet_select, obj_star_select])) {
+                    var x_draw = 0;
+                    var lower_draw = main_panel.height + 110;
+                    if (hide_sequence == 30) {
+                        hide_sequence = 0;
                     }
-                    hide_sequence++;
-                }
-                if (hide_sequence > 15 || hide_sequence < 15) {
-                    main_panel.draw(x_draw, 110, 0.46, 0.75);
-                    if (tab_buttons.fleets.draw(x_draw, 79, "Fleets")) {
-                        view_area = "fleets";
-                        update_fleet_table();
+                    if ((hide_sequence > 0 && hide_sequence < 15) || (hide_sequence > 15 && hide_sequence < 30)) {
+                        if (hide_sequence > 15) {
+                            x_draw = ((main_panel.width / 15) * (hide_sequence - 15)) - main_panel.width;
+                        } else {
+                            x_draw = -((main_panel.width / 15) * hide_sequence);
+                        }
+                        hide_sequence++;
                     }
-                    if (tab_buttons.garrisons.draw(115 + x_draw, 79, "System Troops")) {
-                        view_area = "garrisons";
-                        update_garrison_log();
-                    }
-                    if (tab_buttons.missions.draw(230 + x_draw, 79, "Missions")) {
-                        view_area = "missions";
-                        update_garrison_log();
-                    }
-                    if (x_draw < 0) {
-                        tab_buttons.hider.draw(0, lower_draw, "Show");
-                    } else {
-                        if (tab_buttons.hider.draw(x_draw + 280, lower_draw, "Hide")) {
+                    if (hide_sequence > 15 || hide_sequence < 15) {
+                        main_panel.draw(x_draw, 110, 0.46, 0.75);
+                        if (tab_buttons.fleets.draw(x_draw, 79, "Fleets")) {
+                            view_area = "fleets";
+                            update_fleet_table();
+                        }
+                        if (tab_buttons.garrisons.draw(115 + x_draw, 79, "System Troops")) {
+                            view_area = "garrisons";
+                            update_garrison_log();
+                        }
+                        if (tab_buttons.missions.draw(230 + x_draw, 79, "Missions")) {
+                            view_area = "missions";
+                            update_mission_log();
+                        }
+                        if (x_draw < 0) {
+                            tab_buttons.hider.draw(0, lower_draw, "Show");
+                        } else {
+                            if (tab_buttons.hider.draw(x_draw + 280, lower_draw, "Hide")) {
+                                hide_sequence++;
+                            }
+                        }
+                    } else if (hide_sequence == 15) {
+                        if (tab_buttons.hider.draw(0, lower_draw, "Show")) {
                             hide_sequence++;
                         }
                     }
-                } else if (hide_sequence == 15) {
-                    if (tab_buttons.hider.draw(0, lower_draw, "Show")) {
-                        hide_sequence++;
+                    /*if (tab_buttons.troops.draw(345,79, "Troops")){
+    				    view_area="troops";
+    				}*/
+                }
+                if (array_length(travel_target) == 2) {
+                    if (obj_controller.x != travel_target[0] || obj_controller.y != travel_target[1]) {
+                        obj_controller.x += travel_increments[0];
+                        obj_controller.y += travel_increments[1];
+                        travel_time++;
+                    } else {
+                        travel_target = [];
+                    }
+                    if (travel_time == 15) {
+                        obj_controller.x = travel_target[0];
+                        obj_controller.y = travel_target[1];
+                        travel_target = [];
                     }
                 }
-                /*if (tab_buttons.troops.draw(345,79, "Troops")){
-				    view_area="troops";
-				}*/
             }
-            if (array_length(travel_target) == 2) {
-                if (obj_controller.x != travel_target[0] || obj_controller.y != travel_target[1]) {
-                    obj_controller.x += travel_increments[0];
-                    obj_controller.y += travel_increments[1];
-                    travel_time++;
-                } else {
-                    travel_target = [];
-                }
-                if (travel_time == 15) {
-                    obj_controller.x = travel_target[0];
-                    obj_controller.y = travel_target[1];
-                    travel_target = [];
-                }
-            }
+            pop_draw_return_values();
+        } catch(_exception){
+            //dangerous to handle wiljustmake game unplayable if crash does occur
         }
-        pop_draw_return_values();
     };
 }
 

--- a/scripts/scr_unit_quick_find_pane/scr_unit_quick_find_pane.gml
+++ b/scripts/scr_unit_quick_find_pane/scr_unit_quick_find_pane.gml
@@ -11,9 +11,37 @@ function UnitQuickFindPanel() constructor {
         "missions": new MainMenuButton(spr_ui_but_3, spr_ui_hov_3),
     };
 
+    hovered_fleet_data = undefined;
+
     static detail_slate = new DataSlateMKTwo();
 
     view_area = "fleets";
+    hover_item = "none";
+    travel_target = [];
+    travel_time = 0;
+    travel_increments = [];
+    is_entered = false;
+    start_fleet = 0;
+    start_system = 0;
+    garrison_log = {};
+    mission_log = [];
+    hide_sequence = 0;
+    current_hover = -1;
+    hover_count = 0;
+
+    var xx = main_panel.XX;
+    var yy = main_panel.YY;
+
+    fleet_table = new Table({
+        x1:               xx + 10,
+        y1:               yy + 50,
+        x2:               xx + main_panel.width,
+        y2:               yy + main_panel.height,
+        headings:         ["Capitals", "Frigates", "Escorts", "Location"],
+        row_key_draw:     ["capitals", "frigates", "escorts", "location"],
+        set_column_widths: [70,         70,          70,        100       ],
+        row_h:            20,
+    });
 
     static has_troops = function(name) {
         return struct_exists(garrison_log, name);
@@ -128,6 +156,121 @@ function UnitQuickFindPanel() constructor {
         }
     };
 
+    // ── UPDATER  (call in Step or whenever fleet data changes) ────────────────────
+    static update_fleet_table = function() {
+
+        var xx   = main_panel.XX;
+        var yy   = main_panel.YY;
+        var _rows = [];
+
+        for (var i = start_fleet; i < instance_number(obj_p_fleet); i++) {
+
+            var _cur_fleet = instance_find(obj_p_fleet, i);
+
+            // ── Resolve location string ───────────────────────────────────────────
+            var _loc = "";
+            var _zoomable = true;
+            var _point_data = _cur_fleet.point_breakdown;
+
+            if (_cur_fleet.action == "Lost") {
+                _loc  = "Lost";
+                _zoomable = false;
+
+            } else if (string_count("crusade", _cur_fleet.action)) {
+                _loc = "Crusading";
+                _zoomable = false;
+
+            } else if (_cur_fleet.action == "move") {
+                _loc = "Warp Travel";
+
+            } else {
+                var _near_star = instance_nearest(_cur_fleet.x, _cur_fleet.y, obj_star);
+                _loc = _near_star.name;
+                var _sys_points = obj_controller.specialist_point_handler.point_breakdown.systems;
+                if (struct_exists(_sys_points, _near_star.name)) {
+                    _point_data = _sys_points[$ _near_star.name][0];
+                }                
+            }
+
+            // ── Build row struct, capturing per-iteration values via method() ─────
+            var _row = {
+                capitals: _cur_fleet.capital_number,
+                frigates: _cur_fleet.frigate_number,
+                escorts:  _cur_fleet.escort_number,
+                location: _loc,
+                parent: self,
+                fleet: _cur_fleet,
+                point_data : _point_data
+            };
+            
+            _row.hover = method(
+                _row,
+                function() {
+                    obj_controller.location_viewer.hovered_fleet_data = point_data;
+                    tooltip_draw("left click to view");
+                }
+            )
+
+            // Click to pan camera — only when location is meaningful
+            if (_zoomable) {
+                _row.click_left = method(
+                    _row,
+                    function() {
+                        set_map_pan_to_loc(fleet);
+                    }
+                );
+            }
+
+            array_push(_rows, _row);
+        }
+
+        fleet_table.update({row_data: _rows });
+    }
+    static draw_fleet_area =  function(){
+        var xx = main_panel.XX;
+        var yy = main_panel.YY;
+
+        if (fleet_table.row_count() != instance_number(obj_p_fleet)){
+            update_fleet_table()
+        }
+
+        fleet_table.update({
+            x1  :  xx + 40,
+            y1  :  yy + 50,
+            y2 : yy + 50 + main_panel.height,
+            colour : c_white,
+            font : fnt_40k_14
+        });
+        
+        fleet_table.draw();
+
+        // ── Hover detail slate (drawn after table so it renders on top) ───────────
+        if (hovered_fleet_data != undefined) {
+            var _fpd = hovered_fleet_data;
+            var _sx  = main_panel.XX + main_panel.width - 10;
+            var _sy  = yy + 90 + 18;
+            detail_slate.draw(_sx, _sy, 1.5, 1.5);
+
+            draw_set_font(fnt_40k_12i);
+            draw_set_halign(fa_center);
+
+            // Headers
+            draw_text(_sx + 160, _sy + 10, "forge point\ntotal");
+            draw_text(_sx + 240, _sy + 10, "forge point\nuse");
+            draw_text(_sx + 320, _sy + 10, "apothecary\npoint total");
+            draw_text(_sx + 400, _sy + 10, "apothecary\npoint use");
+            draw_text(_sx + 60,  _sy + 50, "Orbiting");
+
+            // Values
+            var _vy = _sy + 50;
+            draw_text(_sx + 160, _vy, _fpd.forge_points);
+            draw_text(_sx + 240, _vy, _fpd.forge_points_use);
+            draw_text(_sx + 320, _vy, _fpd.heal_points);
+            draw_text(_sx + 400, _vy, _fpd.heal_points_use);
+
+            hovered_fleet_data = undefined;   // reset each frame
+        }
+    }
     update_mission_log = function() {
         mission_log = [];
         var temp_log = [];
@@ -165,6 +308,7 @@ function UnitQuickFindPanel() constructor {
                     var _event = events[i];
                     if (struct_exists(_event, "turn_end")){
                         switch (_event.turn_end){
+                            //this is being pre seeded for a later coming feature set
                             case "deliver_trophy_end_turn_check" : 
                                 var _mission = $"Deliver Trophy Guard";
                                 var _sys = fleets_next_location();
@@ -210,8 +354,8 @@ function UnitQuickFindPanel() constructor {
         var _data = {
             x1  :  xx+60,
             y1  :  yy+50,
-            y2  :  yy  + h,
-            set_column_widths  :  [80,130],
+            y2  :  yy  + main_panel.height + 50,
+            set_column_widths  :  [70,150],
             headings  :  ["Location", "Mission","Time\nRemaining"],
             row_data  :  mission_log,
             row_key_draw  :  ["system","mission","time"],
@@ -219,103 +363,13 @@ function UnitQuickFindPanel() constructor {
         mission_table = new Table(_data);
     };
 
-
-    hover_item = "none";
-    travel_target = [];
-    travel_time = 0;
-    travel_increments = [];
-    is_entered = false;
-    start_fleet = 0;
-    start_system = 0;
-    garrison_log = {};
-    mission_log = [];
-    hide_sequence = 0;
-    current_hover = -1;
-    hover_count = 0;
     main_panel.inside_method = function() {
         var xx = main_panel.XX;
         var yy = main_panel.YY;
         is_entered = scr_hit(xx, yy, xx + main_panel.width, yy + main_panel.height);
+        // ── DRAW ─────────────────────────────────────────────────────────────────────
         if (view_area == "fleets") {
-            var cur_fleet;
-            draw_set_color(c_white);
-            draw_set_halign(fa_center);
-            draw_text(xx + 80, yy + 50, "Capitals");
-            draw_text(xx + 160, yy + 50, "Frigates");
-            draw_text(xx + 240, yy + 50, "Escorts");
-            draw_text(xx + 310, yy + 50, "Location");
-            var i = start_fleet;
-            while (i < instance_number(obj_p_fleet) && (yy + 90 + (20 * i) + 12 + 20) < main_panel.YY + yy + main_panel.height) {
-                if (scr_hit(xx + 10, yy + 90 + (20 * i), xx + main_panel.width, yy + 90 + (20 * i) + 18)) {
-                    draw_set_color(c_gray);
-                    draw_rectangle(xx + 10 + 20, yy + 90 + (20 * i) - 2, xx + main_panel.width - 20, yy + 90 + (20 * i) + 18, 0);
-                    draw_set_color(c_white);
-                }
-                cur_fleet = instance_find(obj_p_fleet, i);
-                draw_text(xx + 80, yy + 90 + (20 * i), cur_fleet.capital_number);
-                draw_text(xx + 160, yy + 90 + (20 * i), cur_fleet.frigate_number);
-                draw_text(xx + 240, yy + 90 + (20 * i), cur_fleet.escort_number);
-                var _fleet_point_data = cur_fleet.point_breakdown;
-                var _loc_display_string = "";
-                var _zoomable_loc = true;
-                if (cur_fleet.action == "Lost") {
-                    _loc_display_string = "Lost";
-                    _zoomable_loc = false;
-                } else if (string_count("crusade", cur_fleet.action)) {
-                    _loc_display_string = "Crusading";
-                    _zoomable_loc = false;
-                } else if (cur_fleet.action == "move") {
-                    _loc_display_string = "Warp Travel";
-                } else {
-                    var _near_star = instance_nearest(cur_fleet.x, cur_fleet.y, obj_star);
-                    _loc_display_string = _near_star.name;
-
-                    var _special_points = obj_controller.specialist_point_handler.point_breakdown.systems;
-                    if (struct_exists(_special_points, _near_star)) {
-                        var _fleet_point_data = _special_points[$ _near_star.name][0];
-                    }
-                }
-                draw_text(xx + 310, yy + 90 + (20 * i), _loc_display_string);
-
-                var _fleet_coords = [
-                    xx + 10,
-                    yy + 90 + (20 * i) - 2,
-                    xx + main_panel.width,
-                    yy + 90 + (20 * i) + 18
-                ];
-
-                if (_zoomable_loc) {
-                    if (point_and_click([xx + 10, yy + 90 + (20 * i) - 2, xx + main_panel.width, yy + 90 + (20 * i) + 18])) {
-                        travel_target = [
-                            cur_fleet.x,
-                            cur_fleet.y
-                        ];
-                        travel_increments = [
-                            (travel_target[0] - obj_controller.x) / 15,
-                            (travel_target[1] - obj_controller.y) / 15
-                        ];
-                        travel_time = 0;
-                    }
-                }
-
-                if (scr_hit(_fleet_coords)) {
-                    detail_slate.draw(xx + main_panel.width - 10, _fleet_coords[1] - 20, 1.5, 1.5);
-                    var _xx = xx + main_panel.width - 10;
-                    var _yy = _fleet_coords[1] - 20;
-                    draw_set_font(fnt_40k_12i);
-                    draw_text(_xx + 160, _yy + 10, "forge point\ntotal");
-                    draw_text(_xx + 240, _yy + 10, "forge point\nuse");
-                    draw_text(_xx + 320, _yy + 10, "apothecary\npoint total");
-                    draw_text(_xx + 400, _yy + 10, "apothecary\npoint use");
-                    draw_text(_xx + 60, _yy + 50, "Orbiting");
-                    var _y_line = _yy + 50;
-                    draw_text(_xx + 160, _y_line, _fleet_point_data.forge_points);
-                    draw_text(_xx + 240, _y_line, _fleet_point_data.forge_points_use);
-                    draw_text(_xx + 320, _y_line, _fleet_point_data.heal_points);
-                    draw_text(_xx + 400, _y_line, _fleet_point_data.heal_points_use);
-                }
-                i++;
-            }
+            draw_fleet_area();
         } else if (view_area == "garrisons") {
             var system_data;
             draw_set_color(c_white);
@@ -424,50 +478,11 @@ function UnitQuickFindPanel() constructor {
                 }
             }
         } else if (view_area == "missions") {
-            draw_set_color(c_white);
-            draw_set_halign(fa_center);
-            draw_text(xx + 80, yy + 50, "Location");
-            draw_text(xx + 160, yy + 50, "Mission");
-            draw_text(xx + 290, yy + 50, "Time Remaining");
-            var i = 0;
-            while (i < array_length(mission_log) && (90 + (20 * i) + 12 + 20) < main_panel.height) {
-                mission = mission_log[i];
-                entered = false;
-                if (scr_hit(xx + 10, yy + 90 + (20 * i), xx + main_panel.width, yy + 90 + (20 * i) + 18)) {
-                    draw_set_color(c_gray);
-                    draw_rectangle(xx + 10 + 20, yy + 90 + (20 * i) - 2, xx + main_panel.width - 20, yy + 90 + (20 * i) + 18, 0);
-                    draw_set_color(c_white);
-                    entered = true;
-                }
-                if (mission.system != "") {
-                    draw_text(xx + 80, yy + 90 + (20 * i), $"{mission.system} {scr_roman_numerals()[mission.planet - 1]}");
-                }
-                draw_set_halign(fa_left);
-                if (entered) {
-                    draw_text(xx + 160 - 20, yy + 90 + (20 * i), mission.mission);
-                } else {
-                    draw_text(xx + 160 - 20, yy + 90 + (20 * i), string_truncate(mission.mission, 150));
-                }
-                draw_set_halign(fa_center);
-                if (!entered) {
-                    draw_text(xx + 310, yy + 90 + (20 * i), mission.time);
-                }
-                if (point_and_click([xx + 10, yy + 90 + (20 * i) - 2, xx + main_panel.width, yy + 90 + (20 * i) + 18])) {
-                    var star = find_star_by_name(mission.system);
-                    if (star != "none") {
-                        travel_target = [
-                            star.x,
-                            star.y
-                        ];
-                    }
-                    travel_increments = [
-                        (travel_target[0] - obj_controller.x) / 15,
-                        (travel_target[1] - obj_controller.y) / 15
-                    ];
-                    travel_time = 0;
-                }
-                i++;
-            }
+                    mission_table.update({
+                x1  :  xx+35,
+                y1  :  yy+50,
+            });
+            mission_table.draw();
         }
     };
 
@@ -492,6 +507,7 @@ function UnitQuickFindPanel() constructor {
                     main_panel.draw(x_draw, 110, 0.46, 0.75);
                     if (tab_buttons.fleets.draw(x_draw, 79, "Fleets")) {
                         view_area = "fleets";
+                        update_fleet_table();
                     }
                     if (tab_buttons.garrisons.draw(115 + x_draw, 79, "System Troops")) {
                         view_area = "garrisons";


### PR DESCRIPTION
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
## Purpose and Description
<!-- Explain why and what your changes do in simple terms. -->
- Self-descriptive.

## Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- None, and I understand the risks.

## Related things and/or additional context
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, screenshots etc. -->
-

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->

<!--- "Inspired" by the CDDA PR template -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilt the Fleets and Missions panels to use the shared `Table` with row hover/clicks, hover highlight, and per-cell text scaling. Lists are consistent, clickable, and readable; fleets initialize at game start and auto-refresh.

- **New Features**
  - `Table`: centralized row hover/left/right click via `row_method`, hover highlight, per-cell text scaling, min row height, `colour`/`font`, and `row_count()`.
  - Fleets: `update_fleet_table()`/`draw_fleet_area()` render via `Table`; left-click pans to fleet; hover shows forge/apothecary breakdown on a detail slate; auto-refresh when fleet count changes.
  - Missions: `mission_table` renders via `Table`; left-click pans to system; integrates `obj_en_fleet.events` (Deliver Trophy Guard) with hover tooltip; right-click selects the trophy-bearing marine.

- **Refactors**
  - Replaced manual draw loops with `Table`; update tables when tabs open; wrapped panel draw in a try-catch.
  - Initialize at game start with `location_viewer.update_fleet_table()`; added `events` to `obj_en_fleet` for mission UI data.

<sup>Written for commit 04edfd8c2b47feb85c011623165b5da5994c8c07. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

