### PR TITLE
ci: Add GoboCat config

### DIFF
--- a/.goborc.json
+++ b/.goborc.json
@@ -1,0 +1,9 @@
+{
+  "limitWidth": false,
+  "useTabs": false,
+  "tabWidth": 4,
+  "verticalStructs": true,
+  "verticalArrays": true,
+  "multilineTernary": false,
+  "blankLineAfterBlocks": false
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds `.goborc.json` to configure the `GoboCat` formatter and enforce consistent code style in CI and locally. Uses spaces with width 4, no line width limit, vertical structs/arrays, and disables multiline ternaries and blank lines after blocks.

<sup>Written for commit 30d6c64b53749cf093d2ccdf69399db553a74a63. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

