### PR TITLE
fix: squad crashes and bugs

### DIFF
--- a/ChapterMaster.yyp
+++ b/ChapterMaster.yyp
@@ -602,7 +602,7 @@
   "isEcma":false,
   "LibraryEmitters":[],
   "MetaData":{
-    "IDEVersion":"2024.1400.5.1055",
+    "IDEVersion":"2024.1400.5.1065",
   },
   "name":"ChapterMaster",
   "resources":[

--- a/objects/obj_controller/Create_0.gml
+++ b/objects/obj_controller/Create_0.gml
@@ -98,10 +98,7 @@ chapter_made = 0;
 map_scale = 1;
 scale_mod = 1;
 unit_manage_constants = {};
-unit_manage_constants.current_data = [
-    -1,
-    -1
-];
+unit_manage_constants.current_data = "";
 management_buttons = false;
 
 diplomacy_pathway = "";

--- a/scripts/scr_company_struct/scr_company_struct.gml
+++ b/scripts/scr_company_struct/scr_company_struct.gml
@@ -98,9 +98,6 @@ function CompanyStruct(comp) constructor {
             }
         }
         has_squads = array_length(company_squads);
-        if (has_squads) {
-            obj_controller.unit_focus = company_squads[0].fetch_member(0);
-        }
     };
 
     var xx = __view_get(e__VW.XView, 0) + 0;

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -1697,6 +1697,10 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
         }
         return armour_rating;
     };
+    
+    static in_squad = function(){
+        return squad != "none";
+    }
 
     static get_squad = function() {
         return fetch_squad(squad);

--- a/scripts/scr_squads/scr_squads.gml
+++ b/scripts/scr_squads/scr_squads.gml
@@ -476,6 +476,10 @@ function UnitSquad(squad_type = undefined, company = 0) constructor {
     };
 
     static add_member = function(comp, unit_number) {
+        if (is_struct(comp){
+            unit_number = comp.marine_number;
+            comp = comp.company;
+        }
         array_push(members, [comp, unit_number]);
         life_members++;
     };

--- a/scripts/scr_squads/scr_squads.gml
+++ b/scripts/scr_squads/scr_squads.gml
@@ -476,7 +476,7 @@ function UnitSquad(squad_type = undefined, company = 0) constructor {
     };
 
     static add_member = function(comp, unit_number) {
-        if (is_struct(comp){
+        if (is_struct(comp)){
             unit_number = comp.marine_number;
             comp = comp.company;
         }

--- a/scripts/scr_ui_manage/scr_ui_manage.gml
+++ b/scripts/scr_ui_manage/scr_ui_manage.gml
@@ -129,10 +129,7 @@ function reset_manage_unit_constants(unit) {
         }
 
         unit_manage_constants = {};
-        last_unit = [
-            unit.company,
-            unit.marine_number
-        ];
+
         marine_armour[0] = unit.armour();
         fix_right = 0;
         equip_data = unit.unit_equipment_data();
@@ -141,7 +138,7 @@ function reset_manage_unit_constants(unit) {
             unit_manage_constants.owner = unit.race();
         }
 
-        unit_manage_constants.current_data = last_unit;
+        unit_manage_constants.current_data = unit.uid;
 
         var _damage_res = unit.damage_resistance();
 
@@ -616,7 +613,7 @@ function draw_sprite_and_unit_equip_data() {
         draw_set_font(fnt_40k_14b);
         if (is_struct(obj_controller.unit_focus)) {
             var selected_unit = obj_controller.unit_focus; //unit struct
-            if (!array_equals([selected_unit.company, selected_unit.marine_number], unit_manage_constants.current_data)) {
+            if (selected_unit.uid != unit_manage_constants.current_data) {
                 reset_manage_unit_constants(selected_unit);
             }
             ///tooltip_text stacks hover over type tooltips into an array and draws them last so as not to create drawing order issues


### PR DESCRIPTION
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
## Purpose and Description
<!-- Explain why and what your changes do in simple terms. -->
- Self-descriptive.

## Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- None, and I understand the risks.

## Related things and/or additional context
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, screenshots etc. -->
-

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->

<!--- "Inspired" by the CDDA PR template -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes squad-related crashes and UI desync by tracking selected units via `uid` and removing unsafe auto-focus. Also lets you add squad members using a unit struct.

- **Bug Fixes**
  - Track selected unit by `uid` in manage UI; prevents stale comparisons, flicker, and crashes.
  - Remove auto `unit_focus` when a company has squads; avoids invalid access on empty squads.
  - Add `in_squad()` to marines for safe membership checks.

- **New Features**
  - `UnitSquad.add_member` now accepts a unit struct and extracts `company` and `marine_number` internally.

<sup>Written for commit 1e64d23255c85f13bb371342ac07cc9b7cf515ad. Summary will update on new commits. <a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1178?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

