### PR TITLE
fix: Squad algorithm demotes excess sgts

### DIFF
--- a/scripts/scr_company_order/scr_company_order.gml
+++ b/scripts/scr_company_order/scr_company_order.gml
@@ -87,6 +87,21 @@ function scr_company_order(company) {
             if (_data_match) {
                 _squadless.organise_by_template(_data, _squad_index, _empty_index, false);
             }
+
+            _squadless = _squadless.get_from({group : SPECIALISTS_SQUAD_LEADERS ,squadless : true});
+
+            _squadless.for_each(function(loop_unit){
+                var _sgts = role_groups(SPECIALISTS_SQUAD_LEADERS);
+                var _role_h_len = array_length(loop_unit.role_history);
+                for (var i = _role_h_len-1; i >= 0;i--){
+                    var _role = loop_unit.role_history[i][0];
+                    if (!array_contains(_sgts,_role)){
+                        loop_unit.update_role(_role);
+                        break;
+                    }
+                }
+                
+            });        
         }
 
         _company_marines.order_by_rank();

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -244,6 +244,8 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
         obj_ini.role[company][marine_number] = new_role;
         if (instance_exists(obj_controller)) {
             array_push(role_history, [role(), obj_controller.turn]);
+        } else {
+            array_push(role_history, [role(), "pre_game"]);
         }
         if (new_role == obj_ini.role[100][5]) {
             if (company == 2) {


### PR DESCRIPTION
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
## Purpose and Description
<!-- Explain why and what your changes do in simple terms. -->
- Self-descriptive.

## Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- None, and I understand the risks.

## Related things and/or additional context
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, screenshots etc. -->
-

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->

<!--- "Inspired" by the CDDA PR template -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes squad assignment by demoting excess squad leaders without a squad to their last non-leader role. Also ensures pre-game roles are tracked so demotion is reliable.

- **Bug Fixes**
  - During company ordering, detect squadless `SPECIALISTS_SQUAD_LEADERS` and restore their most recent non-leader role from `role_history`.
  - When initializing marines, add a `role_history` entry with timestamp `pre_game` if no controller exists, so prior roles are preserved.

<sup>Written for commit 746b72d03b475911a1ccf1e7783592d1a15bd808. Summary will update on new commits. <a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1179?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

