### PR TITLE
ci: Mark dev releases as latest

### DIFF
--- a/.github/workflows/release_dev.yml
+++ b/.github/workflows/release_dev.yml
@@ -261,7 +261,7 @@ jobs:
           body: ${{steps.build_changelog.outputs.changelog}}
           token: ${{ secrets.RELEASE_TOKEN_SECRET }}
           tag_name: ${{ needs.prepare_release.outputs.tag_name }}
-          prerelease: true
-          make_latest: false
+          prerelease: false
+          make_latest: true
           files: |
             ./build_output/${{ needs.gamemaker_build.outputs.built_file }}/*


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Mark dev releases as latest and not prereleases, so the newest dev build is the default download and users don’t pick old versions by mistake.

Updated `.github/workflows/release_dev.yml` to set `prerelease: false` and `make_latest: true` for dev release publishing.

<sup>Written for commit 7cb970fe14378485fdbd6705ea71aa6b4ecdb5e1. Summary will update on new commits. <a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1182?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

