### PR TITLE
fix: manage constants being reset constantly (poor frame rate)

### DIFF
--- a/ChapterMaster.yyp
+++ b/ChapterMaster.yyp
@@ -2,9 +2,9 @@
   "$GMProject":"v1",
   "%Name":"ChapterMaster",
   "AudioGroups":[
-    {"$GMAudioGroup":"","%Name":"audiogroup_default","name":"audiogroup_default","resourceType":"GMAudioGroup","resourceVersion":"2.0","targets":-1,},
-    {"$GMAudioGroup":"","%Name":"audiogroup_sfx","name":"audiogroup_sfx","resourceType":"GMAudioGroup","resourceVersion":"2.0","targets":-1,},
-    {"$GMAudioGroup":"","%Name":"audiogroup_music","name":"audiogroup_music","resourceType":"GMAudioGroup","resourceVersion":"2.0","targets":-1,},
+    {"$GMAudioGroup":"v1","%Name":"audiogroup_default","exportDir":"","name":"audiogroup_default","resourceType":"GMAudioGroup","resourceVersion":"2.0","targets":-1,},
+    {"$GMAudioGroup":"v1","%Name":"audiogroup_sfx","exportDir":"","name":"audiogroup_sfx","resourceType":"GMAudioGroup","resourceVersion":"2.0","targets":-1,},
+    {"$GMAudioGroup":"v1","%Name":"audiogroup_music","exportDir":"","name":"audiogroup_music","resourceType":"GMAudioGroup","resourceVersion":"2.0","targets":-1,},
   ],
   "configs":{
     "children":[],

--- a/objects/obj_controller/Step_0.gml
+++ b/objects/obj_controller/Step_0.gml
@@ -391,19 +391,6 @@ try {
             sel = top;
             yy += 77;
         }
-        if (is_struct(unit_focus)) {
-            // Checks if the marine is not hidden
-            var _unit = unit_focus;
-            if (!is_array(last_unit)) {
-                last_unit = [
-                    -1,
-                    -1
-                ];
-            }
-            if ((_unit.base_group != "none") && (last_unit[1] != _unit.marine_number || last_unit[0] != _unit.company)) {
-                reset_manage_unit_constants(_unit);
-            }
-        }
     }
 
     if (global.load >= 0) {

--- a/scripts/scr_ui_manage/scr_ui_manage.gml
+++ b/scripts/scr_ui_manage/scr_ui_manage.gml
@@ -1122,7 +1122,7 @@ function scr_ui_manage() {
             if (_draw_selec_buttons && instance_exists(obj_popup)) {
                 _draw_selec_buttons = obj_popup.type != ePOPUP_TYPE.EQUIP;
             }
-            if (_draw_selec_buttons) {
+            if (_draw_selec_buttons && is_struct(obj_controller.unit_focus)) {
                 draw_manage_selection_buttons(xx, yy);
             }
 


### PR DESCRIPTION
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
## Purpose and Description
<!-- Explain why and what your changes do in simple terms. -->
- Self-descriptive.

## Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- None, and I understand the risks.

## Related things and/or additional context
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, screenshots etc. -->
-

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->

<!--- "Inspired" by the CDDA PR template -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes poor frame rate by removing the per-step constants reset tied to unit focus. Adds a struct guard before drawing selection buttons to prevent invalid access and normalizes audio group metadata in `ChapterMaster.yyp` (no runtime impact).

<sup>Written for commit ee64157493cef823bd02721ea6cf442c9db13540. Summary will update on new commits. <a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1183?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

