### PR TITLE
ci: Dev build adjustments

### DIFF
--- a/.github/workflows/discord-prerelease-notification.yml
+++ b/.github/workflows/discord-prerelease-notification.yml
@@ -1,7 +1,6 @@
 name: Discord Release Notification
 on:
   release:
-    types: [prereleased]
 permissions:
     contents: read
 jobs:

--- a/.github/workflows/release_dev.yml
+++ b/.github/workflows/release_dev.yml
@@ -208,7 +208,7 @@ jobs:
           # Use Bash parameter expansion: ${parameter//pattern/string}
           # Replaces all occurrences of '/' with '-'
           formattedTagName="${rawTagName//\//-}"
-          releaseName="ChapterMaster $formattedTagName"
+          releaseName="$formattedTagName"
           echo "Calculated release name: $releaseName"
           # Set the output using standard Bash redirection to the GITHUB_OUTPUT file
           echo "release_name=$releaseName" >> $GITHUB_OUTPUT


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Discord release notifications now trigger on all GitHub release events, not just prereleases, by removing the `types: [prereleased]` filter from the `release` workflow. Dev releases no longer include the `ChapterMaster` prefix; `releaseName` is now set to the formatted tag only.

<sup>Written for commit 526bbf7357db0b14395066e4e4f0c4492eb761d6. Summary will update on new commits. <a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1184?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

