### PR TITLE
Merge branch stuff into main

### DIFF
--- a/datafiles/main/chapters/10.JSON
+++ b/datafiles/main/chapters/10.JSON
@@ -278,71 +278,82 @@
         */
         "squad_name": "Squad",
         "custom_squads": {
-            "scout_squad": [
-                [
-                    "Sergeant",
-                    {
-                        "max": 1,
-                        "min": 1,
-                        "role": "Sergeant",
-                        "loadout": {
-                            "required": {
-                                "wep1": [
-                                    "Chainsword",
-                                    1
-                                ],
-                                "wep2": [
-                                    "Bolt Pistol",
-                                    1
-                                ]
-                            }
-                        }
-                    }
-                ],
-                [
-                    "Neophyte",
-                    {
-                        "max": 9,
-                        "min": 4,
-                        "loadout": {
-                            "required": {
-                                "wep1": [
-                                    "Bolter",
-                                    2
-                                ],
-                            },
-                            "option": {
-                                "wep1": [
+            "scout_squad": {
+                "Neophyte": {
+                    "max": 9,
+                    "min": 4,
+                    "loadout": {
+                        "required": {
+                            "wep1": [
+                                "",
+                                0
+                            ],
+                            "wep2": [
+                                "Combat Knife",
+                                "max"
+                            ]
+                        },
+                        "option": {
+                            "wep1": [
+                                [
                                     [
-                                        [
-                                            "Chainsword"
-                                        ],
-                                        3,
-                                        {
-                                            "wep2": "Bolt Pistol"
-                                        }
-                                    ]
+                                        "Bolter",
+                                        "Bolter",
+                                        "Shotgun",
+                                        "Sniper Rifle",
+                                        "Stalker Pattern Bolter"
+                                    ],
+                                    8
+                                ],
+                                [
+                                    [
+                                        "Missile Launcher",
+                                        "Heavy Bolter"
+                                    ],
+                                    1
                                 ]
-                            }
+                            ]
                         }
                     }
-                ],
-                [
-                    "type_data",
-                    {
-                        "display_data": "Crusader Squad",
-                        "class": [
-                            "scout"
-                        ],
-                        "formation_options": [
-                            "scout",
-                            "tactical",
-                            "assault",
-                            "devastator"
-                        ],
+                },
+                "Sergeant": {
+                    "max": 1,
+                    "min": 1,
+                    "role": "Scout Sergeant",
+                    "loadout": {
+                        "required": {
+                            "wep1": [
+                                "",
+                                0
+                            ],
+                            "wep2": [
+                                "Combat Knife",
+                                1
+                            ]
+                        },
+                        "option": {
+                            "wep1": [
+                                [
+                                    "{WEAPON_LIST_RANGED}",
+                                    1
+                                ]
+                            ]
+                        }
                     }
-                ]
-            ]
+                },
+                "type_data": {
+                    "display_data": "Crusader Squad",
+                    "class": [
+                        "scout"
+                    ],
+                    "formation_options": [
+                        "scout",
+                        "tactical",
+                        "assault",
+                        "devastator"
+                    ]
+                }
+            }
         }
     }
 }

--- a/scripts/BugReporter/BugReporter.gml
+++ b/scripts/BugReporter/BugReporter.gml
@@ -60,20 +60,21 @@ function GameError() constructor {
         var _sections = [
             header,
             "",
-            $"Date-Time: {date_time}",
-            $"Game Version: {game_version}",
-            $"Build Date: {build_date}",
-            $"Commit Hash: {commit_hash}",
+            "### System Details:",
+            $"- Date-Time: {date_time}",
+            $"- Game Version: {game_version}",
+            $"- Build Date: {build_date}",
+            $"- Commit Hash: {commit_hash}",
             "",
-            "Save Details:",
-            $"Chapter Name: {chapter}",
-            $"Current Turn: {turn}",
-            $"Game Seed: {seed}",
+            "### Save Details:",
+            $"- Chapter Name: {chapter}",
+            $"- Current Turn: {turn}",
+            $"- Game Seed: {seed}",
             "",
-            "Error Details:",
+            "### Error Details:",
             message,
             "",
-            "Stacktrace:",
+            "### Stacktrace:",
             stacktrace,
         ];
         
@@ -100,15 +101,14 @@ function GameError() constructor {
     static build_player_message = function() {
         var _path_hint = string_replace_all(game_save_id, "/", "\\");
         var _msg = $"{header}\n\n{message}\n\n";
-    
-        if (critical) {
-            _msg += $"The error log is in your clipboard and saved at:\n{_path_hint}Logs\\\n\n";
-            _msg += "1) Create a bug report on Discord.\n2) Press CTRL+V to paste the log.\n\nThank you!";
+
+        _msg += $"The error log was saved at:\n{_path_hint}Logs\\\n\n";
+
+        if (critical) {            
+            _msg += "Do you want to send the error log, debug log, and your last autosave to our Discord as a bug report? The process is automated and takes a few seconds, you won't notice anything.";
         } else {
-            _msg += $"The error log was saved at:\n{_path_hint}Logs\\\n\n";
             _msg += "After closing this message, you will be prompted to describe what you were doing.\n";
-            _msg += "Your message and the error log will be sent to our Discord automatically.\n\n";
-            _msg += "Thank you!\n\n";
+            _msg += "Your message and the error log will be sent to our Discord automatically. You can decline by pressing 'cancel'.\n\n";
             _msg += $"{STR_ERROR_MESSAGE_PS}";
         }
         return _msg;
@@ -127,8 +127,9 @@ function BugReporter() constructor {
         global.active_bug_report = self; 
     };
 
-    /// @desc Sends the report to Discord
-    static send = function(_user_text) {
+    /// @desc Sends the report to Discord with optional user notes.
+    /// @param {string} _user_text Optional user description text.
+    static send = function(_user_text = "") {
         var _url = "__DISCORD_WEBHOOK_URL__";
 
         if (_url == "" || string_pos("__", _url) == 1) {
@@ -145,15 +146,30 @@ function BugReporter() constructor {
             var embed = new DiscordEmbed();
             embed.SetTitle("Error Details")
                 .SetDescription(pending_error.full_log)
-                .AddField("User Message", _user_text)
-                .SetColor(0x00ff00)
+                .SetColor(0x00ff00);
+
+            if (_user_text != "") {
+                embed.AddField("User Message:", _user_text);
+            }
 
             var _hook = new DiscordWebhook(_url);
             _hook.SetUser("Bug Reporter")
                 .SetThread(pending_error.report_title)
-                .AddEmbed(embed)
-                .Execute();
-            
+                .AddEmbed(embed);
+
+            if (file_exists(PATH_LAST_MESSAGES)) {
+                _hook.AddFile(PATH_LAST_MESSAGES);
+            }
+
+            if (file_exists(PATH_AUTOSAVE_FILE)) {
+                var _save_data = json_to_gamemaker(PATH_AUTOSAVE_FILE, json_parse);
+                var _seed = is_struct(_save_data) ? _save_data[$ "game_seed"] : undefined;
+                if (!is_undefined(_seed) && _seed == pending_error.seed) {
+                    _hook.AddFile(PATH_AUTOSAVE_FILE);
+                }
+            }
+
+            _hook.Execute();
 
             LOGGER.debug("Payload dispatched to Discord.");
         } catch (_ex) {

--- a/scripts/__init_external/__init_external.gml
+++ b/scripts/__init_external/__init_external.gml
@@ -30,7 +30,9 @@ function __init_external() {
     #macro PATH_CUSTOM_ICONS "Custom Files\\Custom Icons\\"
     #macro PATH_CHAPTER_ICONS working_directory + "\\images\\creation\\chapters\\icons\\"
     #macro PATH_INCLUDED_ICONS working_directory + "\\images\\creation\\customicons\\"
-    #macro PATH_LAST_MESSAGES "Logs/last_messages.log"
+    #macro PATH_LOG_DIRECTORY "Logs/"
+    #macro LAST_MESSAGES_LOG "last_messages.log"
+    #macro PATH_LAST_MESSAGES PATH_LOG_DIRECTORY + LAST_MESSAGES_LOG
 
     global.chapter_icons_map = ds_map_create();
 

--- a/scripts/scr_ComplexSet/scr_ComplexSet.gml
+++ b/scripts/scr_ComplexSet/scr_ComplexSet.gml
@@ -90,6 +90,9 @@ function ComplexSet(_unit) constructor {
     unit = _unit;
     draw_helms = instance_exists(obj_creation) ? obj_creation.draw_helms : obj_controller.draw_helms;
     //draw_helms = false;
+
+    current_texture_draws = {};
+
     static mk7_bits = {
         armour: spr_mk7_complex,
         left_trim: spr_mk7_left_trim,
@@ -737,8 +740,6 @@ function ComplexSet(_unit) constructor {
     };
 
     static draw_component_with_textures = function(resolved_sprite, resolved_choice, component_name) {
-        var _texture_draws = current_texture_draws;
-        var _tex_names = struct_get_names(_texture_draws);
         var _return_surface = surface_get_target();
         surface_reset_target();
         shader_reset();
@@ -750,8 +751,10 @@ function ComplexSet(_unit) constructor {
         shader_set_uniform_i(texture_use_shadow_uniform, shadow_enabled);
         set_component_shadow_packs(component_name, resolved_original_choice, resolved_sprite, resolved_choice);
 
+        var _tex_names = struct_get_names(current_texture_draws);
         for (var i = 0; i < array_length(_tex_names); i++) {
-            var _tex_data = _texture_draws[$ _tex_names[i]];
+            var _tex_name = _tex_names[i];
+            var _tex_data = current_texture_draws[$ _tex_name];
 
             var tex_frame = 0;
             if (component_name == "left_pauldron_base") {
@@ -843,7 +846,6 @@ function ComplexSet(_unit) constructor {
             }
 
             var _tex_names = struct_get_names(texture_draws);
-
             if (_flip_x && array_length(_tex_names) == 0) {
                 var _w = sprite_get_width(_resolved.sprite);
                 var _ox = sprite_get_xoffset(_resolved.sprite);

--- a/scripts/scr_ComplexSet/scr_ComplexSet.gml
+++ b/scripts/scr_ComplexSet/scr_ComplexSet.gml
@@ -101,11 +101,11 @@ function ComplexSet(_unit) constructor {
         right_knee: spr_mk7_complex_knees,
     };
 
-    _are_exceptions = false;
+    _has_exceptions = false;
     exceptions = [];
 
     static check_exception = function(exception_key) {
-        if (_are_exceptions) {
+        if (_has_exceptions) {
             var array_position = array_find_value(exceptions, exception_key);
             if (array_position > -1) {
                 array_delete(exceptions, array_position, 1);
@@ -126,8 +126,11 @@ function ComplexSet(_unit) constructor {
 
     right_arm_data = [];
 
+    // Tracks sprites that ComplexSet owns (e.g. weapon duplicates) for cleanup
+    owned_sprites = [];
+
     static base_modulars_checks = function(mod_item) {
-        _are_exceptions = false;
+        _has_exceptions = false;
         var _mod = mod_item;
         exceptions = [];
 
@@ -136,7 +139,7 @@ function ComplexSet(_unit) constructor {
         }
 
         if (struct_exists(_mod, "allow_either")) {
-            _are_exceptions = true;
+            _has_exceptions = true;
             exceptions = variable_clone(_mod.allow_either);
         }
         if (struct_exists(_mod, "max_saturation")) {
@@ -158,14 +161,14 @@ function ComplexSet(_unit) constructor {
                 var _increment_count = max(1, floor(_mod.max_saturation / 5));
                 var _increments = (_m_exp - _min) / _increment_count;
                 var _sat_roof = _mod.max_saturation;
-                var _mar_exp = unit.experience;
+                var _unit_exp = unit.experience;
 
-                if (_mar_exp >= _m_exp) {
+                if (_unit_exp >= _m_exp) {
                     spawn_chance = _mod.max_saturation;
                 } else {
-                    var calc_exp = max(0, _mar_exp - _min);
-                    var _inc_point = floor(calc_exp / _increments);
-                    _max_sat = clamp(_inc_point * 5, 0, _mod.max_saturation);
+                    var calc_exp = max(0, _unit_exp - _min);
+                    var _increment = floor(calc_exp / _increments);
+                    _max_sat = clamp(_increment * 5, 0, _mod.max_saturation);
                 }
             }
         }
@@ -607,7 +610,53 @@ function ComplexSet(_unit) constructor {
         }
     };
 
-    static set_component_shadow_packs = function(component_name, choice) {
+    /// Resolves a global frame choice for an area into (source_sprite, local_frame)
+    static resolve_area = function(area_name, global_choice) {
+        if (!struct_exists(self, area_name)) {
+            return undefined;
+        }
+
+        var _area_data = self[$ area_name];
+        if (is_struct(_area_data)) {
+            // Composite area with source references
+            var _total = _area_data.total;
+            var _choice = global_choice % _total;
+            for (var i = 0; i < array_length(_area_data.sources); i++) {
+                if (_choice < _area_data.offsets[i] + _area_data.source_frames[i]) {
+                    return {sprite: _area_data.sources[i], frame: _choice - _area_data.offsets[i]};
+                }
+            }
+
+            return undefined;
+        }
+
+        // Raw sprite ID (complex_helms head, or backward compat)
+        if (!sprite_exists(_area_data)) {
+            return undefined;
+        }
+
+        return {sprite: _area_data, frame: global_choice % sprite_get_number(_area_data)};
+    };
+
+    /// Gets the total number of frames for an area
+    static area_total_frames = function(area_name) {
+        if (!struct_exists(self, area_name)) {
+            return 0;
+        }
+
+        var _area_data = self[$ area_name];
+        if (is_struct(_area_data)) {
+            return _area_data.total;
+        }
+
+        if (sprite_exists(_area_data)) {
+            return sprite_get_number(_area_data);
+        }
+
+        return 0;
+    };
+
+    static set_component_shadow_packs = function(component_name, choice, resolved_sprite, resolved_frame) {
         if (struct_exists(shadow_set, component_name)) {
             var _shadow_set = shadow_set[$ component_name];
             for (var i = 0; i < array_length(_shadow_set); i++) {
@@ -617,12 +666,12 @@ function ComplexSet(_unit) constructor {
                     var _final_shadow_index = choice - _spec_shadow[0];
                     //LOGGER.debug($"final_index {_final_shadow_index}, {_spec_shadow[0]}, {_spec_shadow[1]}, {choice},{_shadow_item}");
 
-                    var _sprite = self[$ component_name];
                     // Compute UV transform for this shadow texture
-                    if (!sprite_exists(_sprite) || !sprite_exists(_shadow_item)) {
+                    if (!sprite_exists(resolved_sprite) || !sprite_exists(_shadow_item)) {
                         exit;
                     }
-                    var _shadow_transform_data = sprite_get_uvs_transformed(_sprite, choice, _shadow_item, _final_shadow_index);
+
+                    var _shadow_transform_data = sprite_get_uvs_transformed(resolved_sprite, resolved_frame, _shadow_item, _final_shadow_index);
 
                     if (valid_sprite_transform_data(_shadow_transform_data)) {
                         shader_set_uniform_f_array(shadow_transform_uniform, _shadow_transform_data);
@@ -687,7 +736,9 @@ function ComplexSet(_unit) constructor {
         }
     };
 
-    static draw_component_with_textures = function(_sprite, _choice, _tex_names, texture_draws, component_name) {
+    static draw_component_with_textures = function(resolved_sprite, resolved_choice, component_name) {
+        var _texture_draws = current_texture_draws;
+        var _tex_names = struct_get_names(_texture_draws);
         var _return_surface = surface_get_target();
         surface_reset_target();
         shader_reset();
@@ -697,10 +748,10 @@ function ComplexSet(_unit) constructor {
 
         shader_set(armour_texture);
         shader_set_uniform_i(texture_use_shadow_uniform, shadow_enabled);
-        set_component_shadow_packs(component_name, _choice);
+        set_component_shadow_packs(component_name, resolved_original_choice, resolved_sprite, resolved_choice);
 
         for (var i = 0; i < array_length(_tex_names); i++) {
-            var _tex_data = texture_draws[$ _tex_names[i]];
+            var _tex_data = _texture_draws[$ _tex_names[i]];
 
             var tex_frame = 0;
             if (component_name == "left_pauldron_base") {
@@ -724,7 +775,7 @@ function ComplexSet(_unit) constructor {
 			*/
 
             for (var t = 0; t < array_length(_tex_data.areas); t++) {
-                var _mask_transform_data = sprite_get_uvs_transformed(_sprite, _choice, _tex_data.texture, tex_frame);
+                var _mask_transform_data = sprite_get_uvs_transformed(resolved_sprite, resolved_choice, _tex_data.texture, tex_frame);
                 if (!valid_sprite_transform_data(_mask_transform_data)) {
                     continue;
                 }
@@ -732,7 +783,7 @@ function ComplexSet(_unit) constructor {
                 texture_set_stage(armour_texture_sampler, tex_texture);
                 shader_set_uniform_f_array(texture_replace_col_uniform, _tex_data.areas[t]);
 
-                draw_sprite(_sprite, _choice ?? 0, component_final_draw_x, component_final_draw_y);
+                draw_sprite(resolved_sprite, resolved_choice, component_final_draw_x, component_final_draw_y);
             }
         }
 
@@ -741,9 +792,9 @@ function ComplexSet(_unit) constructor {
         shader_reset();
 
         shader_set(full_livery_shader);
-        set_component_shadow_packs(component_name, _choice);
+        set_component_shadow_packs(component_name, resolved_original_choice, resolved_sprite, resolved_choice);
 
-        draw_sprite(_sprite, _choice ?? 0, component_final_draw_x, component_final_draw_y);
+        draw_sprite(resolved_sprite, resolved_choice ?? 0, component_final_draw_x, component_final_draw_y);
         draw_surface(global.base_component_surface, 0, 0);
     };
 
@@ -754,8 +805,9 @@ function ComplexSet(_unit) constructor {
         }
         if (struct_exists(self, component_name)) {
             shadow_enabled = 0;
-            var _sprite = self[$ component_name];
-            if (!sprite_exists(_sprite)) {
+            current_texture_draws = texture_draws;
+
+            if (!struct_exists(self, component_name)) {
                 return "error failed no sprite found";
             }
 
@@ -766,22 +818,40 @@ function ComplexSet(_unit) constructor {
             var component_map_choice = 3;
             if (struct_exists(variation_map, component_name) && choice_lock == -1) {
                 component_map_choice = variation_map[$ component_name];
-                _choice = component_map_choice % sprite_get_number(_sprite);
+                _choice = component_map_choice % area_total_frames(component_name);
             } else if (choice_lock > -1) {
                 _choice = choice_lock;
             }
 
+            // Resolve to (source_sprite, local_frame)
+            var _resolved = resolve_area(component_name, _choice);
+            if (!is_struct(_resolved) || !sprite_exists(_resolved.sprite)) {
+                return "error failed no sprite found";
+            }
+
+            resolved_original_choice = _choice;
+
             check_component_overides(component_name, _choice);
-            set_component_shadow_packs(component_name, _choice);
+            set_component_shadow_packs(component_name, _choice, _resolved.sprite, _resolved.frame);
 
             shader_set_uniform_i(use_shadow_uniform, shadow_enabled);
 
+            var _flip_x = false;
+            var _component_data = self[$ component_name];
+            if (is_struct(_component_data) && struct_exists(_component_data, "flip_x") && _component_data.flip_x) {
+                _flip_x = true;
+            }
+
             var _tex_names = struct_get_names(texture_draws);
 
-            if (array_length(_tex_names) > 0) {
-                draw_component_with_textures(_sprite, _choice, _tex_names, texture_draws, component_name);
+            if (_flip_x && array_length(_tex_names) == 0) {
+                var _w = sprite_get_width(_resolved.sprite);
+                var _ox = sprite_get_xoffset(_resolved.sprite);
+                draw_sprite_ext(_resolved.sprite, _resolved.frame ?? 0, component_final_draw_x + _w - _ox * 2, component_final_draw_y, -1, 1, 0, c_white, 1);
+            } else if (array_length(_tex_names) > 0) {
+                draw_component_with_textures(_resolved.sprite, _resolved.frame, component_name);
             } else {
-                draw_sprite(_sprite, _choice ?? 0, component_final_draw_x, component_final_draw_y);
+                draw_sprite(_resolved.sprite, _resolved.frame ?? 0, component_final_draw_x, component_final_draw_y);
             }
 
             handle_component_subcomponents(component_name, _choice);
@@ -926,7 +996,7 @@ function ComplexSet(_unit) constructor {
             }
         } else {
             if ((weapon_left.sprite != 0) && sprite_exists(weapon_left.sprite) && (weapon_right.ui_twoh == false)) {
-                weapon_left.sprite = return_sprite_mirrored(weapon_left.sprite);
+                weapon_left.flip_x = true;
                 draw_weapon(weapon_left, "left_weapon");
             }
         }
@@ -937,14 +1007,6 @@ function ComplexSet(_unit) constructor {
                     draw_unit_hands(i);
                 }
             }
-        }
-
-        // Draw hands above the weapon sprite;
-        if ((weapon_right.sprite != 0) && sprite_exists(weapon_right.sprite)) {
-            sprite_delete(weapon_right.sprite);
-        }
-        if ((weapon_left.sprite != 0) && sprite_exists(weapon_left.sprite)) {
-            sprite_delete(weapon_left.sprite);
         }
     };
 
@@ -959,6 +1021,13 @@ function ComplexSet(_unit) constructor {
         //LOGGER.debug($" shadows {_shadows}");
 
         add_to_area(position, weapon.sprite, "none", _subs, _shadows);
+
+        if (struct_exists(self, position)) {
+            var _component_data = self[$ position];
+            if (is_struct(_component_data)) {
+                _component_data.flip_x = struct_exists(weapon, "flip_x") && weapon.flip_x;
+            }
+        }
 
         draw_component(position, {}, choice_lock);
 
@@ -1011,13 +1080,11 @@ function ComplexSet(_unit) constructor {
 
         if (array_length(left_arm_data)) {
             weapon_left = variable_clone(left_arm_data[variation_map.left_weapon % array_length(left_arm_data)]);
-            weapon_left.sprite = sprite_duplicate(weapon_left.sprite);
         } else {
             weapon_left = {};
         }
         if (array_length(right_arm_data)) {
             weapon_right = variable_clone(right_arm_data[variation_map.right_weapon % array_length(right_arm_data)]);
-            weapon_right.sprite = sprite_duplicate(weapon_right.sprite);
         } else {
             weapon_right = {};
         }
@@ -1262,10 +1329,14 @@ function ComplexSet(_unit) constructor {
                         continue;
                     }
                     if ((_torso_purity_seals[i] + _exp) > 100) {
-                        draw_sprite(purity_seals, _torso_purity_seals[i], _x_offset + positions[i][0], _y_offset + positions[i][1]);
+                        var _resolved = resolve_area("purity_seals", _torso_purity_seals[i]);
+                        if (is_struct(_resolved) && sprite_exists(_resolved.sprite)) {
+                            draw_sprite(_resolved.sprite, _resolved.frame, _x_offset + positions[i][0], _y_offset + positions[i][1]);
+                        }
                     }
                 }
             }
+
             if (struct_exists(_body[$ "left_arm"], "purity_seal")) {
                 var _arm_seals = _body[$ "left_arm"][$ "purity_seal"];
                 if (armour_type == eARMOUR_TYPE.NORMAL) {
@@ -1300,10 +1371,14 @@ function ComplexSet(_unit) constructor {
                         continue;
                     }
                     if ((_arm_seals[i] + _exp) > 100) {
-                        draw_sprite(purity_seals, _arm_seals[i], _x_offset + positions[i][0], _y_offset + positions[i][1]);
+                        var _resolved = resolve_area("purity_seals", _arm_seals[i]);
+                        if (is_struct(_resolved) && sprite_exists(_resolved.sprite)) {
+                            draw_sprite(_resolved.sprite, _resolved.frame, _x_offset + positions[i][0], _y_offset + positions[i][1]);
+                        }
                     }
                 }
             }
+
             if (struct_exists(_body[$ "right_arm"], "purity_seal")) {
                 var _arm_seals = _body[$ "right_arm"][$ "purity_seal"];
                 if (armour_type == eARMOUR_TYPE.NORMAL) {
@@ -1342,7 +1417,10 @@ function ComplexSet(_unit) constructor {
                         continue;
                     }
                     if ((_arm_seals[i] + _exp) > 100) {
-                        draw_sprite(purity_seals, _arm_seals[i], _x_offset + positions[i][0], _y_offset + positions[i][1]);
+                        var _resolved = resolve_area("purity_seals", _arm_seals[i]);
+                        if (is_struct(_resolved) && sprite_exists(_resolved.sprite)) {
+                            draw_sprite(_resolved.sprite, _resolved.frame, _x_offset + positions[i][0], _y_offset + positions[i][1]);
+                        }
                     }
                 }
             }
@@ -1458,16 +1536,64 @@ function ComplexSet(_unit) constructor {
         shader_set(full_livery_shader);
     };
 
+    /// @desc Add a sprite reference to an area without duplicating or merging pixel data.
+    /// Stores source references in a composite struct. At draw time, resolve_area()
+    /// maps a global frame choice to the correct source sprite + local frame.
+    /// @param area {string} Area name
+    /// @param add_sprite {sprite} Source sprite to add (not duplicated — we store the reference!)
+    /// @param overide_data {any} Override data for this sprite's frame range
+    /// @param sub_components {any} Sub-component data for this sprite's frame range
+    /// @param shadow {any} Shadow data for this sprite's frame range
     static add_to_area = function(area, add_sprite, overide_data = "none", sub_components = "none", shadow = "none") {
         if (sprite_exists(add_sprite)) {
             var _add_sprite_length = sprite_get_number(add_sprite);
             if (!struct_exists(self, area)) {
-                self[$ area] = sprite_duplicate(add_sprite);
+                self[$ area] = {
+                    sources: [add_sprite],
+                    offsets: [0],
+                    source_frames: [_add_sprite_length],
+                    total: _add_sprite_length,
+                };
                 var _overide_start = 0;
             } else {
-                var _overide_start = sprite_get_number(self[$ area]);
-                sprite_merge(self[$ area], add_sprite);
+                var _existing_data = self[$ area];
+                if (is_struct(_existing_data)) {
+                    var _overide_start = _existing_data.total;
+                    array_push(_existing_data.sources, add_sprite);
+                    array_push(_existing_data.offsets, _overide_start);
+                    array_push(_existing_data.source_frames, _add_sprite_length);
+                    _existing_data.total += _add_sprite_length;
+                } else {
+                    var _overide_start = 0;
+                    if (sprite_exists(_existing_data)) {
+                        _overide_start = sprite_get_number(_existing_data);
+                        self[$ area] = {
+                            sources: [
+                                _existing_data,
+                                add_sprite,
+                            ],
+                            offsets: [
+                                0,
+                                _overide_start,
+                            ],
+                            source_frames: [
+                                sprite_get_number(_existing_data),
+                                _add_sprite_length,
+                            ],
+                            total: _overide_start + _add_sprite_length,
+                        };
+                    } else {
+                        self[$ area] = {
+                            sources: [add_sprite],
+                            offsets: [0],
+                            source_frames: [_add_sprite_length],
+                            total: _add_sprite_length,
+                        };
+                        var _overide_start = 0;
+                    }
+                }
             }
+
             if (overide_data != "none") {
                 add_overide(area, _overide_start, _add_sprite_length, overide_data);
             }
@@ -1533,7 +1659,6 @@ function ComplexSet(_unit) constructor {
 
     static remove_area = function(area) {
         if (struct_exists(self, area)) {
-            sprite_delete(self[$ area]);
             struct_remove(self, area);
             if (struct_exists(overides, area)) {
                 struct_remove(overides, area);
@@ -1636,6 +1761,11 @@ function ComplexSet(_unit) constructor {
     };
 
     static complex_helms = function(data) {
+        var _head_resolved = resolve_area("head", variation_map.head % area_total_frames("head"));
+        if (!is_struct(_head_resolved) || !sprite_exists(_head_resolved.sprite)) {
+            return;
+        }
+
         set_complex_shader_area(["eye_lense"], data.helm_lens);
         if (data.helm_pattern == 0) {
             set_complex_shader_area(["left_head", "right_head", "left_muzzle", "right_muzzle"], data.helm_primary);
@@ -1643,8 +1773,8 @@ function ComplexSet(_unit) constructor {
             set_complex_shader_area(["left_head", "right_head"], data.helm_primary);
             set_complex_shader_area(["left_muzzle", "right_muzzle"], data.helm_secondary);
         } else if (data.helm_pattern == 1 || data.helm_pattern == 3) {
-            var _surface_width = sprite_get_width(head);
-            var _surface_height = sprite_get_height(head);
+            var _surface_width = sprite_get_width(_head_resolved.sprite);
+            var _surface_height = sprite_get_height(_head_resolved.sprite);
             var _head_surface = surface_create(_surface_width, 60);
             //var _decoration_surface = surface_create(_surface_width, 60);
             surface_set_target(_head_surface);
@@ -1686,14 +1816,23 @@ function ComplexSet(_unit) constructor {
             //draw_sprite(spr_helm_stripe, data.helm_pattern==1?0:1, 0, 0);
             surface_reset_target();
 
-            if (sprite_exists(head)) {
-                sprite_delete(head);
-            }
-
-            head = sprite_create_from_surface(_head_surface, 0, 0, _surface_width, 60, false, false, 0, 0);
+            var _new_head = sprite_create_from_surface(_head_surface, 0, 0, _surface_width, 60, false, false, 0, 0);
             surface_clear_and_free(_head_surface);
             shader_set(full_livery_shader);
+            array_push(owned_sprites, _new_head);
+            self[$ "head"] = _new_head;
         }
+    };
+
+    /// @desc Cleans up owned sprites (weapon duplicates, generated sprites). Does NOT delete original asset sprites.
+    static destroy_images = function() {
+        for (var i = 0; i < array_length(owned_sprites); i++) {
+            if (sprite_exists(owned_sprites[i])) {
+                sprite_delete(owned_sprites[i]);
+            }
+        }
+
+        owned_sprites = [];
     };
 
     base_armour();

--- a/scripts/scr_UnitGroup/scr_UnitGroup.gml
+++ b/scripts/scr_UnitGroup/scr_UnitGroup.gml
@@ -720,7 +720,7 @@ function SearchConditions(data) constructor {
     static evaluate = function(unit) {
         self.unit = unit;
         if (unit.name() == "") {
-            LOGGER.error($"Empty name! Unit:\n{unit}");
+            // LOGGER.error($"Empty name! Unit:\n{unit}");
             return false;
         }
 

--- a/scripts/scr_UnitGroup/scr_UnitGroup.gml
+++ b/scripts/scr_UnitGroup/scr_UnitGroup.gml
@@ -432,7 +432,7 @@ function UnitGroup(units) constructor {
             _match_roles.add_units(self, {role: _wanted_role}, true, -1);
             for (var i = 0; i < array_length(_match_roles.units); i++) {
                 var _unit = _match_roles.units[i];
-                if (_unit.squad == "none" || array_contains(_sorted_squads, _unit.squad)) {
+                if (_unit.role() == "" || _unit.squad == "none" || array_contains(_sorted_squads, _unit.squad)) {
                     continue;
                 }
                 var _squad = fetch_squad(_unit.squad);
@@ -457,10 +457,16 @@ function UnitIndex(units) constructor {
     static add_to_index = function(units) {
         for (var i = 0; i < array_length(units); i++) {
             var _unit = units[i];
-            if (!struct_exists(role_index, _unit.role())) {
-                role_index[$ _unit.role()] = [_unit];
+            var _role = _unit.role();
+            if (_role == "") {
+                LOGGER.error($"Empty role! Unit:\n{_unit}");
+                continue;
+            }
+
+            if (!struct_exists(role_index, _role)) {
+                role_index[$ _role] = [_unit];
             } else {
-                array_push(role_index[$ _unit.role()], _unit);
+                array_push(role_index[$ _role], _unit);
             }
         }
     };
@@ -714,6 +720,7 @@ function SearchConditions(data) constructor {
     static evaluate = function(unit) {
         self.unit = unit;
         if (unit.name() == "") {
+            LOGGER.error($"Empty name! Unit:\n{unit}");
             return false;
         }
 
@@ -787,6 +794,7 @@ function collect_by_religeon(religion, sub_cult = "", location = "") {
             _add = false;
             _unit = obj_ini.TTRPG[com][i];
             if (_unit.name() == "") {
+                LOGGER.error($"Empty name! Unit:\n{_unit}");
                 continue;
             }
             if (_unit.religion == religion) {

--- a/scripts/scr_company_order/scr_company_order.gml
+++ b/scripts/scr_company_order/scr_company_order.gml
@@ -88,20 +88,22 @@ function scr_company_order(company) {
                 _squadless.organise_by_template(_data, _squad_index, _empty_index, false);
             }
 
-            _squadless = _squadless.get_from({group : SPECIALISTS_SQUAD_LEADERS ,squadless : true});
-
-            _squadless.for_each(function(loop_unit){
+            _squadless = _squadless.get_from({
+                group: SPECIALISTS_SQUAD_LEADERS,
+                squadless: true,
+            });
+            
+            _squadless.for_each(function(loop_unit) {
                 var _sgts = role_groups(SPECIALISTS_SQUAD_LEADERS);
                 var _role_h_len = array_length(loop_unit.role_history);
-                for (var i = _role_h_len-1; i >= 0;i--){
+                for (var i = _role_h_len - 1; i >= 0; i--) {
                     var _role = loop_unit.role_history[i][0];
-                    if (!array_contains(_sgts,_role)){
+                    if (!array_contains(_sgts, _role)) {
                         loop_unit.update_role(_role);
                         break;
                     }
                 }
-                
-            });        
+            });
         }
 
         _company_marines.order_by_rank();

--- a/scripts/scr_draw_unit_image/scr_draw_unit_image.gml
+++ b/scripts/scr_draw_unit_image/scr_draw_unit_image.gml
@@ -523,16 +523,10 @@ function scr_draw_unit_image(_background = false) {
     }
     surface_reset_target();
     shader_reset();
-    //LOGGER.debug($"1{get_marine_icon_set(2)}");
-    var _complex_sprite_names = struct_get_names(complex_set);
-    for (var i = 0; i < array_length(_complex_sprite_names); i++) {
-        var _area = _complex_sprite_names[i];
-        var _item = complex_set[$ _area];
-        if (!is_callable(_item) && !is_struct(_item) && !is_array(_item) && !is_string(_item)) {
-            if (sprite_exists(_item)) {
-                sprite_delete(_item);
-            }
-        }
+
+    // Clean up owned sprites (weapon duplicates, generated surfaces) but NOT original asset sprites
+    if (is_struct(complex_set) && struct_exists(complex_set, "destroy_images")) {
+        complex_set.destroy_images();
     }
 
     surface_clear_and_free(global.base_component_surface);

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -2491,7 +2491,7 @@ function scr_initialize_custom() {
             for (var j = 0; j < _override_keys_count; j++) {
                 var _okey_hash = _override_keys[j];
                 var _okey_ins = new_values[$ _okey_hash];
-                LOGGER.info($"{_okey_hash}<{_okey_ins}<{old_values}");
+                // LOGGER.info($"{_okey_hash}<{_okey_ins}<{old_values}");
                 old_values[$ _okey_hash] = _okey_ins;
             }
             return old_values;

--- a/scripts/scr_logging_functions/scr_logging_functions.gml
+++ b/scripts/scr_logging_functions/scr_logging_functions.gml
@@ -2,8 +2,6 @@
 #macro STR_ERROR_MESSAGE_HEAD2 $"Your game just encountered a critical error! :("
 #macro STR_ERROR_MESSAGE_HEAD3 "Your game just encountered and caught an error! ({0})"
 #macro STR_ERROR_MESSAGE_PS $"P.S. You can ALT-TAB and try to continue playing, though it’s recommended to wait for a response in the bug-report forum."
-#macro ERR_LOG_DIRECTORY "Logs/"
-#macro ERR_PATH_LAST_MESSAGES "last_messages.log"
 
 enum eLOG_LEVEL {
     DEBUG,
@@ -20,11 +18,11 @@ function create_error_file(_message) {
         return;
     }
 
-    if (!directory_exists(ERR_LOG_DIRECTORY)) {
-        directory_create(ERR_LOG_DIRECTORY);
+    if (!directory_exists(PATH_LOG_DIRECTORY)) {
+        directory_create(PATH_LOG_DIRECTORY);
     }
 
-    var _log_file = file_text_open_write($"{ERR_LOG_DIRECTORY}{DATE_TIME_1}_error.log");
+    var _log_file = file_text_open_write($"{PATH_LOG_DIRECTORY}{DATE_TIME_1}_error.log");
     file_text_write_string(_log_file, _message);
     file_text_close(_log_file);
 
@@ -33,15 +31,15 @@ function create_error_file(_message) {
 
 /// @description Creates a copy of the last_messages.log file, with the current date in the name, in the same folder.
 function copy_last_messages_file() {
-    if (!file_exists(ERR_PATH_LAST_MESSAGES)) {
+    if (!file_exists(PATH_LAST_MESSAGES)) {
         return;
     }
 
-    if (!directory_exists(ERR_LOG_DIRECTORY)) {
-        directory_create(ERR_LOG_DIRECTORY);
+    if (!directory_exists(PATH_LOG_DIRECTORY)) {
+        directory_create(PATH_LOG_DIRECTORY);
     }
 
-    file_copy(ERR_PATH_LAST_MESSAGES, $"{ERR_LOG_DIRECTORY}{DATE_TIME_1}_messages.log");
+    file_copy(PATH_LAST_MESSAGES, $"{PATH_LOG_DIRECTORY}{DATE_TIME_1}_messages.log");
 }
 
 /// @desc Provides game-specific state data to the error handler without tight coupling.
@@ -77,14 +75,17 @@ function handle_error(_header, _message, _stacktrace = "", _critical = false, _r
     show_debug_message(_stacktrace);
     show_debug_message(LB_92);
 
-    if (_critical
-        || (!variable_global_exists("active_error_dialogs")
-            || !ds_exists(global.active_error_dialogs, ds_type_map)
-            || !variable_global_exists("error_queue")
-            || !ds_exists(global.error_queue, ds_type_queue)))
-    {
-        clipboard_set_text(_error.clipboard_text);
-        show_message(_error.player_message);
+    if (_critical || (!variable_global_exists("active_error_dialogs") || !ds_exists(global.active_error_dialogs, ds_type_map) || !variable_global_exists("error_queue") || !ds_exists(global.error_queue, ds_type_queue))) {
+        var _send_report = show_question(_error.player_message);
+
+        if (!_send_report) {
+            return;
+        }
+
+        var _reporter = new BugReporter();
+        _reporter.pending_error = _error;
+        _reporter.send();
+
         return;
     } else if (ds_map_size(global.active_error_dialogs) == 0) {
         var _msg_id = show_message_async(_error.player_message);

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -244,8 +244,6 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
         obj_ini.role[company][marine_number] = new_role;
         if (instance_exists(obj_controller)) {
             array_push(role_history, [role(), obj_controller.turn]);
-        } else {
-            array_push(role_history, [role(), "pre_game"]);
         }
         if (new_role == obj_ini.role[100][5]) {
             if (company == 2) {
@@ -671,13 +669,8 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
                 ]; //marines_promotion and demotion history
                 marine_ascension = (obj_controller.millenium * 1000) + obj_controller.year; // on what day did this marine begin to exist
             } else {
-                role_history = [
-                    [
-                        obj_ini.role[company][marine_number],
-                        "pre_game"
-                    ]
-                ];
-                marine_ascension = "pre_game"; // on what day did turn did this marine begin to exist
+                role_history = [];
+                marine_ascension = 0; // on what turn did this marine begin to exist
             }
 
             roll_psionics();
@@ -1103,7 +1096,7 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
     };
 
     static roll_psionics = function() {
-        var _dice_count = marine_ascension == "pre_game" ? 1 : 2;
+        var _dice_count = 1;
         var _psionics_roll = roll_dice_chapter(_dice_count, 100);
 
         if (scr_has_adv("Warp Touched")) {

--- a/scripts/scr_start_load/scr_start_load.gml
+++ b/scripts/scr_start_load/scr_start_load.gml
@@ -39,7 +39,7 @@ function scr_start_load(fleet, load_from_star, load_options) {
     if (split_vets) {
         var comp_split = 0;
         var _squad_ids = get_squad_ids();
-        for (var squads = 0; squads < array_length(_squad_ids); squads++) {
+        for (var i = 0; i < array_length(_squad_ids); i++) {
             if (comp_split > 7 || !comp_has_units[comp_split + 2]) {
                 comp_split = 0;
             }
@@ -53,7 +53,7 @@ function scr_start_load(fleet, load_from_star, load_options) {
     if (split_scouts) {
         var comp_split = 0;
         var _squad_ids = get_squad_ids();
-        for (var squads = 0; squads < array_length(_squad_ids); squads++) {
+        for (var i = 0; i < array_length(_squad_ids); i++) {
             if (comp_split > 7 || !comp_has_units[comp_split + 2]) {
                 comp_split = 0;
             }

--- a/scripts/scr_unit_detail_text/scr_unit_detail_text.gml
+++ b/scripts/scr_unit_detail_text/scr_unit_detail_text.gml
@@ -47,10 +47,10 @@ function scr_unit_detail_text() {
     unit_data_string += "\n";
     if (base_group == "astartes") {
         var ascension_date = marine_ascension;
-        if (ascension_date == "pre_game") {
-            ascension_date = "when the chapter was created";
+        if (ascension_date == 0) {
+            ascension_date = "unknown";
         }
-        unit_data_string += $"{round(age())} years old. Ascended to an Astartes in the year {ascension_date}.";
+        unit_data_string += $"{round(age())} years old. Ascended to an Astartes in the {ascension_date} year.";
         if (struct_exists(spawn_data, "recruit_data")) {
             var recruit_data = spawn_data.recruit_data;
             unit_data_string += "\n";


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refactors unit image composition to stop sprite duplication, improve draw performance, and prevent asset-deletion crashes, and adds one-click Discord bug reports with log and autosave upload. Also fixes Black Templars scout squad data, squadless role recovery, and adds guards against empty roles/names and malformed texture structs.

- **New Features**
  - Discord bug reports: send full log as an embed with optional user notes; auto-attach `last_messages.log` and the latest autosave when the seed matches.
  - New path macros `PATH_LOG_DIRECTORY`, `LAST_MESSAGES_LOG`, `PATH_LAST_MESSAGES`.
  - Critical errors ask once and auto-send on confirm; non-critical errors prompt for a short description and can be declined.

- **Bug Fixes**
  - Black Templars: restructured `scout_squad` in `datafiles/main/chapters/10.JSON` into a keyed object with `Neophyte`, `Sergeant` (now “Scout Sergeant”), and `type_data`; cleaned loadouts and formation options.
  - Unit draw: stop duplicating/merging sprites; resolve areas at draw-time; flip left-hand weapons instead of recreating; only delete generated sprites via `destroy_images()`; guard against malformed texture structs during livery application.
  - Squadless marines: restore previous non-leadership roles; removed `"pre_game"` strings (use 0 when unknown) and updated unit detail text.
  - Defensive guards for empty `role()`/names in `UnitGroup`/`UnitIndex` and religion collectors; quieter logs; fixed loop variable typos in `scr_start_load` when splitting squads.

<sup>Written for commit c48f24a2f1bd1ed6ec5fbd788b447f39c4be5118. Summary will update on new commits. <a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1185?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

