### PR TITLE
Merge branch development into main

### DIFF
--- a/scripts/scr_draw_unit_image/scr_draw_unit_image.gml
+++ b/scripts/scr_draw_unit_image/scr_draw_unit_image.gml
@@ -529,8 +529,12 @@ function scr_draw_unit_image(_background = false) {
         complex_set.destroy_images();
     }
 
-    surface_clear_and_free(global.base_component_surface);
+    if (surface_exists(global.base_component_surface)) {
+        surface_clear_and_free(global.base_component_surface);
+    }
+
     global.base_component_surface = -1;
+
     var _keep_alive = [
         "unit",
         "_texture_draws",

--- a/scripts/scr_inquisition_mission/scr_inquisition_mission.gml
+++ b/scripts/scr_inquisition_mission/scr_inquisition_mission.gml
@@ -309,9 +309,9 @@ function mission_inquistion_hunt_inquisitor(star_id = -1) {
 
     var eta = scr_mission_eta(_star.x, _star.y, 1);
     eta = max(eta, 8);
-    var text = $"The Inquisition is trusting you with a special mission.  A radical inquisitor named {_name} will be visiting the {string(_star.name)} system in {string(eta)} month's time.  They are highly suspect of heresy, and as such, are to be put down.  Can your chapter handle this mission?";
+    var text = $"The Inquisition is trusting you with a special mission.  A radical inquisitor named {_name} will be visiting the {_star.name} system in {eta} month's time.  They are highly suspect of heresy, and as such, are to be put down.  Can your chapter handle this mission?";
     if (obj_controller.demanding) {
-        text = $"The Inquisition demands that your Chapter demonstrate its loyalty to the Imperium of Mankind and the Emperor.  A radical inquisitor is enroute to {_star.name}, expected within {estimate} months.  They are to be silenced and removed.";
+        text = $"The Inquisition demands that your Chapter demonstrate its loyalty to the Imperium of Mankind and the Emperor.  A radical inquisitor is enroute to {_star.name}, expected within {eta} months.  They are to be silenced and removed.";
     }
     var _options = [
         {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a safety check before clearing `global.base_component_surface` to avoid freeing a non-existent surface, and fix the Inquisition hunt mission text to use `eta` with correct interpolation.

- **Bug Fixes**
  - `scr_draw_unit_image`: Call `surface_clear_and_free` only if `surface_exists(global.base_component_surface)`; still reset to `-1`.
  - `scr_inquisition_mission`: Use `_star.name` and `eta` in interpolated strings so the system name and months show correctly.

<sup>Written for commit 1d9c44ce1d0c9ba26659ffc3f8f1b1995ba1d01e. Summary will update on new commits. <a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1187?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

