### PR TITLE
ci: Fix build notifications triggers

### DIFF
--- a/.github/workflows/discord-prerelease-notification.yml
+++ b/.github/workflows/discord-prerelease-notification.yml
@@ -1,6 +1,7 @@
 name: Discord Release Notification
 on:
   release:
+    types: [released, prereleased]
 permissions:
     contents: read
 jobs:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Send Discord notifications for both releases and prereleases by updating the GitHub Actions trigger. Adds released and prereleased types to the release event in .github/workflows/discord-prerelease-notification.yml.

<sup>Written for commit c2c1599ff1456e8ea25588152d545461ae7abeb0. Summary will update on new commits. <a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1189?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

