### PR TITLE
fix: difficult to press ship/squad buttons on raid/attack screen

### DIFF
--- a/objects/obj_drop_select/Create_0.gml
+++ b/objects/obj_drop_select/Create_0.gml
@@ -266,6 +266,41 @@ if (purge == 0) {
         forces += 1;
         force_present[forces] = 13;
     }
+
+    //TODO fold race_quantities and races into a struct
+    race_quantities = [
+        0,
+        sisters,
+        eldar,
+        ork,
+        tau,
+        tyranids,
+        traitors,
+        csm,
+        demons,
+        necrons
+    ];
+    races = [
+        "",
+        "Ecclesiarchy",
+        "Eldar",
+        "Orks",
+        "Tau",
+        "Tyranids",
+        "Heretics",
+        "CSMs",
+        "Daemons",
+        "Necrons"
+    ];
+    threat_levels = [
+        "",
+        "Minima (1)",
+        "Parvus (2)",
+        "Moderatus (3)",
+        "Significus (4)",
+        "Enormicus (5)",
+        "Extremis (6)"
+    ];
 } else {
     var _viable_ground_forces = roster.marines_total();
     bombard_purge = new PurgeButton(4, 631, 231, eDROP_TYPE.PURGEBOMBARD);

--- a/scripts/scr_buttons/scr_buttons.gml
+++ b/scripts/scr_buttons/scr_buttons.gml
@@ -1178,7 +1178,9 @@ function ToggleButton(data = {}) constructor {
     clicked_check_default = false;
 
     update = function(data) {
-        move_data_to_current_scope(data, true);
+        if (is_struct(data)) {
+            move_data_to_current_scope(data, true);
+        }
         add_draw_return_values();
         draw_set_font(font);
         if (style == "default") {

--- a/scripts/scr_buttons/scr_buttons.gml
+++ b/scripts/scr_buttons/scr_buttons.gml
@@ -38,6 +38,16 @@ function pop_draw_return_values() {
     }
 }
 
+function standard_loc_data() {
+    x1 = 0;
+    y1 = 0;
+    y2 = 0;
+    x2 = 0;
+    w = 0;
+    h = 0;
+}
+
+
 // --------------------
 // 🟩 UI ELEMENTS
 // --------------------
@@ -329,15 +339,6 @@ function draw_unit_buttons(position, text, size_mod = [1.5, 1.5], colour = c_gra
     return [position[0], position[1], x2, y2];
 }
 
-function standard_loc_data() {
-    x1 = 0;
-    y1 = 0;
-    y2 = 0;
-    x2 = 0;
-    w = 0;
-    h = 0;
-}
-
 /// @function UnitButtonObject(data)
 /// @constructor
 /// @category UI
@@ -345,10 +346,7 @@ function standard_loc_data() {
 /// @param {struct|bool} [data=false] Initial property overrides.
 /// @returns {UnitButtonObject}
 function UnitButtonObject(data = false) constructor {
-    x1 = 0;
-    y1 = 0;
-    w = 102;
-    h = 30;
+    standard_loc_data();
     h_gap = 4;
     v_gap = 4;
     text_scale = 1;
@@ -882,16 +880,15 @@ function MultiSelect(options_array, title, data = {}) constructor {
     self.title = title;
     x_gap = 10;
     y_gap = 5;
-    x1 = 0;
-    y1 = 0;
-    x2 = 0;
-    y2 = 0;
+    standard_loc_data();
     on_change = false;
     active_col = CM_GREEN_COLOR;
     inactive_col = c_gray;
     max_width = 0;
     max_height = 0;
     toggles = [];
+    changed = false;
+    draw_alighn = "horizontal";
     for (var i = 0; i < array_length(options_array); i++) {
         var _next_tog = new ToggleButton(options_array[i]);
         _next_tog.active = false;
@@ -901,39 +898,67 @@ function MultiSelect(options_array, title, data = {}) constructor {
 
     update(data);
 
-    static draw = function(allow_changes = true) {
-        add_draw_return_values();
-        var _change_method = is_callable(on_change);
-        draw_text(x1, y1, title);
-
-        var _prev_x = x1;
-        var _prev_y = y1 + string_height(title) + 10;
-        var items_on_row = 0;
-        for (var i = 0; i < array_length(toggles); i++) {
-            var _cur_opt = toggles[i];
-            _cur_opt.x1 = _prev_x;
-            _cur_opt.y1 = _prev_y;
-            _cur_opt.update();
-            if (_cur_opt.clicked() && allow_changes) {
-                if (_change_method) {
-                    on_change();
-                }
-            }
-            _cur_opt.button_color = _cur_opt.active ? active_col : inactive_col;
-            _cur_opt.draw();
-            items_on_row++;
-
-            _prev_x = _cur_opt.x2 + x_gap;
-
-            x2 = _prev_x > x2 ? _prev_x : x2;
-            y2 = _prev_y + _cur_opt.height;
+    static draw_toggle = function(index){
+        var _cur_opt = toggles[index];
+        _cur_opt.update(next_draw);
+        if (_cur_opt.clicked() && allow_changes) {
+            changed = true;
+        }
+        _cur_opt.button_color = _cur_opt.active ? active_col : inactive_col;
+        _cur_opt.draw();
+        next_draw.row_or_column_draw_count++;
+        //TODO probably set an enum up for this later
+        if (draw_alighn == "horizontal"){
+            next_draw.x1 = _cur_opt.x2 + x_gap;
+            x2 = next_draw.x1 > x2 ? next_draw.x1 : x2;
+            y2 = next_draw.y1 + _cur_opt.h;
             if (max_width > 0) {
-                if (_prev_x - x1 > max_width) {
-                    _prev_x = x1;
-                    _prev_y += _cur_opt.height + y_gap;
-                    items_on_row = 0;
+                if (next_draw.x1 - x1 > max_width) {
+                    next_draw.x1 = x1;
+                    next_draw.y1 += _cur_opt.h + y_gap;
+                    next_draw.row_or_column_draw_count = 0;
                 }
             }
+        } else {
+            next_draw.y1 = _cur_opt.y2 + y_gap;
+            y2 = next_draw.y1 > y2 ? next_draw.y1 : y2;
+            x2 = next_draw.x1 + _cur_opt.w;
+            if (max_height > 0) {
+                if (next_draw.y1 - y1 > max_height) {
+                    next_draw.y1 = y1;
+                    next_draw.x1 += _cur_opt.w + x_gap;
+                    next_draw.row_or_column_draw_count = 0;
+                }
+            }            
+        }
+    }
+
+    static reset_next_draw = function(){
+        next_draw = {
+            x1 : x1,
+            y1 : y1,
+            row_or_column_draw_count : 0,
+        }
+    }
+
+    static draw = function(allow_changes = true) {
+        changed = false;
+        self.allow_changes = allow_changes;
+        add_draw_return_values();
+        has_change_method = is_callable(on_change);
+
+        reset_next_draw();
+
+        if (title != ""){
+            draw_text(x1, y1, title);
+            next_draw.y1 += string_height(title) + 10;
+        }
+
+        for (var i = 0; i < array_length(toggles); i++) {
+            draw_toggle(i);
+        }
+        if (changed && has_change_method) {
+            on_change();
         }
         pop_draw_return_values();
     };
@@ -953,6 +978,13 @@ function MultiSelect(options_array, title, data = {}) constructor {
         for (var i = 0; i < array_length(toggles); i++) {
             var _cur_opt = toggles[i];
             _cur_opt.active = false;
+        }
+    };
+
+    static select_all = function() {
+        for (var i = 0; i < array_length(toggles); i++) {
+            var _cur_opt = toggles[i];
+            _cur_opt.active = true;
         }
     };
 
@@ -989,6 +1021,7 @@ function item_data_updater(data) {
 /// @returns {RadioSet}
 function RadioSet(options_array, title = "", data = {}) constructor {
     toggles = [];
+    standard_loc_data();
     current_selection = 0;
     self.title = title;
     active_col = CM_GREEN_COLOR;
@@ -996,8 +1029,6 @@ function RadioSet(options_array, title = "", data = {}) constructor {
     allow_changes = true;
     x_gap = 10;
     y_gap = 5;
-    x1 = 0;
-    y1 = 0;
     title_font = fnt_40k_14b;
     draw_title = true;
     space_evenly = false;
@@ -1064,7 +1095,7 @@ function RadioSet(options_array, title = "", data = {}) constructor {
 
             _prev_x = _cur_opt.x2 + x_gap;
             row_width = _prev_x - x1;
-            row_height = max(row_height, _cur_opt.height);
+            row_height = max(row_height, _cur_opt.h);
 
             var row_full = (max_width > 0) && (row_width > max_width);
             var last_item = i == array_length(toggles) - 1;
@@ -1127,14 +1158,12 @@ function RadioSet(options_array, title = "", data = {}) constructor {
 /// @param {struct} [data={}] Initial properties.
 /// @returns {ToggleButton}
 function ToggleButton(data = {}) constructor {
-    x1 = 0;
-    y1 = 0;
-    x2 = 0;
-    y2 = 0;
+    standard_loc_data();
     tooltip = "";
     str1 = "";
-    width = 0;
-    height = 0;
+    w = 0;
+    h = 0;
+    text_padding = 0.03;
     state_alpha = 1;
     hover_alpha = 1;
     active = true;
@@ -1143,32 +1172,34 @@ function ToggleButton(data = {}) constructor {
     button_color = c_gray;
     font = fnt_40k_12;
     style = "default";
+    hover_func = undefined;
 
     //make true to run clicked() within draw sequence
     clicked_check_default = false;
 
-    update = function() {
+    update = function(data) {
+        move_data_to_current_scope(data, true);
         add_draw_return_values();
         draw_set_font(font);
         if (style == "default") {
-            if (width == 0) {
-                width = string_width(str1) + 4;
+            if (w == 0) {
+                w = string_width(str1);
+                w *= (1 + (text_padding * 2));
             }
-            if (height == 0) {
-                height = string_height(str1) + 4;
+            if (h == 0) {
+                h = string_height(str1);
+                h *= (1 + (text_padding * 2));
             }
         } else if (style == "box") {
-            width = max(32, string_width(str1)) + 6;
-            height = 32 + 2 + string_height(str1);
+            w = max(32, string_width(str1) * (1 + (text_padding * 2))) + 6;
+            h = 32 +  (string_height(str1) * (1 + (text_padding * 2)));
         }
-        x2 = x1 + width;
-        y2 = y1 + height;
+        x2 = x1 + w;
+        y2 = y1 + h;
         pop_draw_return_values();
     };
 
-    move_data_to_current_scope(data, true);
-
-    update();
+    update(data);
 
     hover = function() {
         return scr_hit(x1, y1, x2, y2);
@@ -1184,18 +1215,20 @@ function ToggleButton(data = {}) constructor {
         }
     };
 
-    draw = function(is_active = active) {
-        self.active = is_active;
+    draw = function(is_active = undefined) {
+        if (is_active != undefined){
+            self.active = is_active;
+        }
         add_draw_return_values();
         draw_set_font(font);
         var str1_h = string_height(str1);
-        var text_padding = width * 0.03;
-        var text_x = x1 + text_padding;
-        var text_y = y1 + text_padding;
+        var _text_padding = w * 0.03;
+        var text_x = x1 + _text_padding;
+        var text_y = y1 + _text_padding;
         var total_alpha;
 
         if (text_halign == fa_center) {
-            text_x = x1 + (width / 2);
+            text_x = x1 + (w / 2);
         }
 
         if (!active) {
@@ -1216,16 +1249,21 @@ function ToggleButton(data = {}) constructor {
                 } // Increase state_alpha when not hovered
             }
         }
-        if (tooltip != "") {
-            if (hover()) {
+       
+        if (hover()) {
+            if (tooltip != "") {
                 tooltip_draw(tooltip);
             }
+            if (is_callable(hover_func)){
+                hover_func();
+            }
         }
+
 
         total_alpha = state_alpha * hover_alpha;
 
         if (style == "default") {
-            draw_rectangle_color_simple(x1, y1, x1 + width, y1 + str1_h, 1, button_color, total_alpha);
+            draw_rectangle_color_simple(x1, y1, x1 + w, y1 + h, 1, button_color, total_alpha);
             draw_set_halign(text_halign);
             draw_set_valign(fa_top);
             draw_text_color_simple(text_x, text_y, str1, text_color, total_alpha);
@@ -1244,10 +1282,10 @@ function ToggleButton(data = {}) constructor {
             draw_set_alpha(1);
         }
 
-        if (clicked_check_default) {
-            clicked();
-        }
         pop_draw_return_values();
+        if (clicked_check_default) {
+            return clicked();
+        }
     };
 }
 

--- a/scripts/scr_drop_select_function/scr_drop_select_function.gml
+++ b/scripts/scr_drop_select_function/scr_drop_select_function.gml
@@ -7,437 +7,384 @@ enum eDROP_TYPE {
     PURGEASSASSINATE,
 }
 
-function drop_select_draw() {
-    with (obj_drop_select) {
-        if (purge != eDROP_TYPE.PURGESELECT) {
-            w = 660;
-            h = 520;
-            // Center of the screen
-            var _x_center = main_slate.XX;
-            var _y_center = main_slate.YY;
-            var x1 = _x_center;
-            var y1 = _y_center;
-            var x2 = x1 + w;
-            var y2 = y1 + h;
-            var x3 = (x1 + x2) / 2;
-            var y3 = (y1 + y2) / 2;
+function drop_select_unit_selection(){
+    w = 660;
+    h = 520;
+    // Center of the screen
+    var _x_center = main_slate.XX;
+    var _y_center = main_slate.YY;
+    var x1 = _x_center;
+    var y1 = _y_center;
+    var x2 = x1 + w;
+    var y2 = y1 + h;
+    var x3 = (x1 + x2) / 2;
 
-            if (purge == eDROP_TYPE.RAIDATTACK) {
-                draw_set_font(fnt_40k_30b);
+    if (purge == eDROP_TYPE.RAIDATTACK) {
+        draw_set_font(fnt_40k_30b);
 
-                // var xx,yy;
-                // xx=view_xview[0]+545;yy=view_yview[0]+212;
-                draw_set_halign(fa_left);
-                draw_set_color(c_gray);
-                var attack_type = attack ? "Attacking" : "Raiding";
-                draw_text_transformed(x1 + 40, y1 + 38, $"{attack_type} ({planet_numeral_name(planet_number, p_target)} )", 0.6, 0.6, 0);
-                var _offset = x1 + 40;
-                draw_set_font(fnt_40k_14);
-                for (var i = 0; i < array_length(roster.company_buttons); i++) {
-                    var _button = roster.company_buttons[i];
-                    _button.x1 = _offset;
-                    _button.y1 = y1 + 60;
-                    _button.update();
-                    _button.draw();
-                    if (_button.company_present) {
-                        if (_button.clicked()) {
-                            roster.update_roster();
-                        }
-                    }
-                    _offset += _button.width;
-                }
-
-                // Planet icon here
-                // draw_rectangle(xx+1084,yy+215,xx+1142,yy+273,0);
-
-                // Formation
-                formation.x1 = x1 + 420;
-                formation.y1 = y1 + 80;
-                formation.str1 = $"Formation: {obj_controller.bat_formation[formation_possible[formation_current]]}";
-                formation.update();
-                formation.draw();
-                if (formation.clicked()) {
-                    formation_current++;
-                    if (formation_current >= array_length(formation_possible)) {
-                        formation_current = 0;
-                    }
-                }
-
-                // Ships Are Up, Fuck Me
-                draw_set_color(c_gray);
-                draw_text(x1 + 40, 273, "Available Forces:");
-            }
-            var e = 0;
-            var sigh = 0;
-            var sip = 1;
-            var column = 1;
-            var row = 1;
-            var x8 = 552;
-            var y8 = 299;
-
-            var add_ground = 0;
-
-            // Local force button;
-
-            // Ship buttons;
-            if (purge != eDROP_TYPE.PURGEBOMBARD) {
-                var _local_button = roster.local_button;
-                _local_button.x1 = x8;
-                _local_button.y1 = y8;
-                _local_button.update();
-                _local_button.draw();
-                if (_local_button.clicked()) {
-                    roster.update_roster();
-                }
-            }
-            y8 += 21;
-
-            var _all_active = true;
-
-            for (var e = 0; e < array_length(roster.ships); e++) {
-                var _ship_button = roster.ships[e];
-                _ship_button.x1 = x8;
-                _ship_button.y1 = y8;
-                _ship_button.update();
-                _ship_button.draw();
-                if (_ship_button.clicked()) {
-                    roster.update_roster();
-                }
-                if (_ship_button.hover()) {
-                    roster.update_local_string(_ship_button.ship_id);
-                }
-                if (!_ship_button.active) {
-                    _all_active = false;
-                }
-                y8 += 21;
-                if (e % 9 == 0 && e != 0) {
-                    y8 = 320;
-                    x8 = 700;
-                }
-            }
-
-            var _select_all_button = roster.select_all_ships;
-
-            if (_select_all_button.draw()) {
-                for (var e = 0; e < array_length(roster.ships); e++) {
-                    var _ship_button = roster.ships[e];
-                    _ship_button.active = !_ship_button.active;
-                }
-                roster.update_roster();
-            }
-            draw_set_font(fnt_40k_14);
-            draw_set_color(c_gray);
-            draw_set_alpha(1);
-
-            // Unit types buttons;
-            var _squads_box = {
-                header: "Selected Squads:",
-                x1: x1 + 40,
-                y1: y2 - 180,
-            };
-            draw_text(_squads_box.x1, _squads_box.y1, _squads_box.header);
-            var _x_offset = 0;
-            var _row = 0;
-            var loop_cycle = array_length(roster.squad_buttons);
-            if (array_length(roster.vehicle_buttons) > 0) {
-                loop_cycle += array_length(roster.vehicle_buttons);
-            }
-            var _squad_length = array_length(roster.squad_buttons);
-            var _button;
-            for (var i = 0; i < loop_cycle; i++) {
-                if (i < _squad_length) {
-                    _button = roster.squad_buttons[i];
-                } else {
-                    _button = roster.vehicle_buttons[i - _squad_length];
-                }
-
-                if (_x_offset + _button.width > 590) {
-                    _row++;
-                    _x_offset = 0;
-                }
-                _button.x1 = _squads_box.x1 + _x_offset;
-                _button.y1 = (_squads_box.y1 + string_height(_squads_box.header) + 10) + _row * 28;
-                _button.update();
-                _button.draw();
-
+        // var xx,yy;
+        // xx=view_xview[0]+545;yy=view_yview[0]+212;
+        draw_set_halign(fa_left);
+        draw_set_color(c_gray);
+        var attack_type = attack ? "Attacking" : "Raiding";
+        draw_text_transformed(x1 + 40, y1 + 38, $"{attack_type} ({planet_numeral_name(planet_number, p_target)} )", 0.6, 0.6, 0);
+        var _offset = x1 + 40;
+        draw_set_font(fnt_40k_14);
+        for (var i = 0; i < array_length(roster.company_buttons); i++) {
+            var _button = roster.company_buttons[i];
+            _button.x1 = _offset;
+            _button.y1 = y1 + 60;
+            _button.update();
+            _button.draw();
+            if (_button.company_present) {
                 if (_button.clicked()) {
                     roster.update_roster();
                 }
-
-                _x_offset += _button.width + 10;
             }
+            _offset += _button.width;
+        }
 
-            // draw_text(x2 + 14, y2 + 352, string_hash_to_newline("Selection: " + string(smin) + "/" + string(smax)));
+        // Planet icon here
+        // draw_rectangle(xx+1084,yy+215,xx+1142,yy+273,0);
 
-            // Target
-            var race_quantity = 0;
-            if (purge == eDROP_TYPE.RAIDATTACK) {
-                var target_race = "", target_threat = "", race_quantity = 0;
-                var races = [
-                    "",
-                    "Ecclesiarchy",
-                    "Eldar",
-                    "Orks",
-                    "Tau",
-                    "Tyranids",
-                    "Heretics",
-                    "CSMs",
-                    "Daemons",
-                    "Necrons"
-                ];
-                var threat_levels = [
-                    "",
-                    "Minima (1)",
-                    "Parvus (2)",
-                    "Moderatus (3)",
-                    "Significus (4)",
-                    "Enormicus (5)",
-                    "Extremis (6)"
-                ];
-                var race_quantities = [
-                    0,
-                    sisters,
-                    eldar,
-                    ork,
-                    tau,
-                    tyranids,
-                    traitors,
-                    csm,
-                    demons,
-                    necrons
-                ];
-
-                if (attacking >= 5 && attacking <= 13) {
-                    race_quantity = race_quantities[attacking - 4];
-                    target_race = races[attacking - 4];
-                }
-
-                if (race_quantity >= 1 && race_quantity <= 6) {
-                    target_threat = threat_levels[race_quantity];
-                } else if (race_quantity >= 6) {
-                    target_threat = threat_levels[6];
-                }
-                target.x1 = formation.x1;
-                target.y1 = formation.y2 + 10;
-                target.str1 = "Target: ";
-                if (race_quantity != 0) {
-                    target.str1 += $"{target_race} ({target_threat} Threat)";
-                } else {
-                    target.str1 += "None";
-                }
-                target.update();
-                target.draw();
-                draw_sprite(spr_faction_icons, attacking, x2 - 100, y1 + 40);
-                var q = 0;
-                repeat (20) {
-                    q += 1;
-                    if (target.clicked() && force_present[q] != 0) {
-                        if (attacking != force_present[q] && force_present[q] > 0) {
-                            attacking = force_present[q];
-                        }
-                    }
-                }
-                target.locked = force_present[q] == 0;
+        // Formation
+        formation.x1 = x1 + 420;
+        formation.y1 = y1 + 80;
+        formation.str1 = $"Formation: {obj_controller.bat_formation[formation_possible[formation_current]]}";
+        formation.update();
+        formation.draw();
+        if (formation.clicked()) {
+            formation_current++;
+            if (formation_current >= array_length(formation_possible)) {
+                formation_current = 0;
             }
+        }
 
-            // Back / Purge buttons
-            btn_back.x1 = x3 - 100;
-            btn_back.y1 = y2 - 60;
-            btn_back.update();
-            btn_back.draw();
-            if (btn_back.clicked()) {
-                menu = 0;
-                purge = 0;
-                instance_destroy();
-            }
+        // Ships Are Up, Fuck Me
+        draw_set_color(c_gray);
+        draw_text(x1 + 40, 273, "Available Forces:");
+    }
+    var _buttons_x = 552;
+    var _buttons_y = 299;
 
-            // Attack / Raid buttons
-            btn_attack.x1 = btn_back.x1 + btn_attack.width + 10;
-            btn_attack.y1 = btn_back.y1;
-            if (purge == eDROP_TYPE.RAIDATTACK) {
-                btn_attack.str1 = (attack) ? "ATTACK!" : "RAID!";
-                btn_attack.active = array_length(roster.selected_units) > 0 && race_quantity > 0;
-            } else if (purge > 1) {
-                btn_attack.str1 = "PURGE";
-                btn_attack.active = array_length(roster.selected_units) > 0;
-            }
-            btn_attack.update();
-            btn_attack.draw();
-            if (btn_attack.clicked()) {
-                if (purge == 0) {
-                    combating = 1; // Start battle here
+    // Local force button;
 
-                    if (attack == 1) {
-                        obj_controller.last_attack_form = formation_possible[formation_current];
-                    }
-                    if (attack == 0) {
-                        obj_controller.last_raid_form = formation_possible[formation_current];
-                    }
+    if (purge != eDROP_TYPE.PURGEBOMBARD) {
+        var _local_button = roster.local_button;
+        _local_button.x1 = _buttons_x;
+        _local_button.y1 = _buttons_y;
+        _local_button.update();
+        _local_button.draw();
+        if (_local_button.clicked()) {
+            roster.update_roster();
+        }
+    }
+    _buttons_y += 21;
 
-                    instance_deactivate_all(true);
-                    instance_activate_object(obj_controller);
-                    instance_activate_object(obj_ini);
-                    instance_activate_object(obj_drop_select);
+    // Ship buttons;
+    roster.ship_multi_selector.update({
+        x1 : _buttons_x,
+        y1 : _buttons_y
+    });
 
-                    // 135 ; temporary balancing
-                    if (sh_target != -50) {
-                        sh_target.acted += 1;
-                    }
+    roster.ship_multi_selector.draw();
 
-                    if ((attacking == 10) || (attacking == 11)) {
-                        remove_planet_problem(planet_number, "meeting", p_target);
-                        remove_planet_problem(planet_number, "meeting_trap", p_target);
-                    }
 
-                    instance_create(0, 0, obj_ncombat);
-                    obj_ncombat.battle_object = p_target;
-                    obj_ncombat.battle_loc = p_target.name;
-                    obj_ncombat.battle_id = planet_number;
-                    obj_ncombat.dropping = 1 - attack;
-                    obj_ncombat.attacking = attack;
-                    obj_ncombat.enemy = attacking;
-                    obj_ncombat.formation_set = formation_possible[formation_current];
-                    obj_ncombat.defending = false;
-                    obj_ncombat.local_forces = roster.local_button.active;
+    if (roster.select_all_ships.draw()) {
+        roster.ship_multi_selector.select_all();
+    }
 
-                    var _planet = obj_ncombat.battle_object.p_feature[obj_ncombat.battle_id];
-                    if (obj_ncombat.battle_object.space_hulk == 1) {
-                        obj_ncombat.battle_special = "space_hulk";
-                    }
-                    if ((planet_feature_bool(_planet, eP_FEATURES.WARLORD6) == 1) && (obj_ncombat.enemy == 6) && (obj_controller.faction_defeated[6] == 0)) {
-                        obj_ncombat.leader = 1;
-                    }
-                    if ((obj_ncombat.enemy == 7) && (obj_controller.faction_defeated[7] <= 0)) {
-                        if (planet_feature_bool(_planet, eP_FEATURES.ORKWARBOSS)) {
-                            obj_ncombat.leader = 1;
-                            obj_ncombat.Warlord = _planet[search_planet_features(_planet, eP_FEATURES.ORKWARBOSS)[0]];
-                        }
-                    }
+    if (roster.ship_multi_selector.changed){
+        roster.update_roster();
+    }
 
-                    if ((obj_ncombat.enemy == 9) && (obj_ncombat.battle_object.space_hulk == 0)) {
-                        if (has_problem_planet(planet_number, "tyranid_org", p_target)) {
-                            obj_ncombat.battle_special = "tyranid_org";
-                        }
-                    }
+    draw_set_font(fnt_40k_14);
+    draw_set_color(c_gray);
+    draw_set_alpha(1);
+    draw_set_halign(fa_left);
 
-                    if (obj_ncombat.enemy == 11) {
-                        if (planet_feature_bool(obj_ncombat.battle_object.p_feature[obj_ncombat.battle_id], eP_FEATURES.CHAOSWARBAND) == 1) {
-                            obj_ncombat.battle_special = "ChaosWarband";
-                            obj_ncombat.leader = 1;
-                        }
-                    }
+    // Unit types buttons;
+    var _squads_box = {
+        header: "Selected Squads:",
+        x1: x1 + 40,
+        y1: y2 - 180,
+    };
+    draw_text(_squads_box.x1, _squads_box.y1, _squads_box.header);
+    var _x_offset = 0;
+    var _row = 0;
+    var loop_cycle = array_length(roster.squad_buttons);
+    if (array_length(roster.vehicle_buttons) > 0) {
+        loop_cycle += array_length(roster.vehicle_buttons);
+    }
+    var _squad_length = array_length(roster.squad_buttons);
+    var _button;
+    for (var i = 0; i < loop_cycle; i++) {
+        if (i < _squad_length) {
+            _button = roster.squad_buttons[i];
+        } else {
+            _button = roster.vehicle_buttons[i - _squad_length];
+        }
 
-                    var _threats = [
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        sisters,
-                        eldar,
-                        ork,
-                        tau,
-                        tyranids,
-                        traitors,
-                        csm,
-                        demons,
-                        necrons
-                    ];
-                    if (obj_ncombat.enemy >= 5 && obj_ncombat.enemy <= 13) {
-                        obj_ncombat.threat = _threats[obj_ncombat.enemy];
-                    }
+        if (_x_offset + _button.width > 590) {
+            _row++;
+            _x_offset = 0;
+        }
+        _button.x1 = _squads_box.x1 + _x_offset;
+        _button.y1 = (_squads_box.y1 + string_height(_squads_box.header) + 10) + _row * 28;
+        _button.update();
+        _button.draw();
 
-                    if (obj_ncombat.enemy == 8) {
-                        var eth;
-                        eth = 0;
-                        eth = scr_quest(4, "ethereal_capture", 8, 0);
-                        if ((eth > 0) && (obj_ncombat.battle_object.p_owner[obj_ncombat.battle_id] == 8)) {
-                            var rolli;
-                            rolli = irandom_range(1, 100);
-                            if ((obj_ncombat.threat == 6) && (rolli <= 80)) {
-                                obj_ncombat.ethereal = 1;
-                            }
-                            if ((obj_ncombat.threat == 5) && (rolli <= 65)) {
-                                obj_ncombat.ethereal = 1;
-                            }
-                            if ((obj_ncombat.threat == 4) && (rolli <= 50)) {
-                                obj_ncombat.ethereal = 1;
-                            }
-                            if ((obj_ncombat.threat == 3) && (rolli <= 35)) {
-                                obj_ncombat.ethereal = 1;
-                            }
-                        }
-                        // show_message("Ethereal Quest?: "+string(eth)+"#Ethereal?: "+string(obj_ncombat.ethereal));
-                    }
+        if (_button.clicked()) {
+            roster.update_roster();
+        }
 
-                    // if (obj_ncombat.threat>1) and (obj_ncombat.enemy!=13) then obj_ncombat.threat-=1;
-                    if ((obj_ncombat.threat > 1) && (obj_ncombat.battle_special != "ChaosWarband") && (attack == 0)) {
-                        obj_ncombat.threat -= 1;
-                    }
-                    if (obj_ncombat.threat < 1) {
-                        obj_ncombat.threat = 1;
-                    }
-                    if ((obj_ncombat.enemy == 10) && (obj_ncombat.battle_object.p_type[obj_ncombat.battle_id] == "Daemon")) {
-                        obj_ncombat.threat = 7;
-                    }
+        _x_offset += _button.width + 10;
+    }
 
-                    var _battle_place = obj_ncombat.battle_object;
-                    var _battle_sub_loc = obj_ncombat.battle_id;
-                    var _chaos_lord_jump_possible = attacking == 0 || attacking == 10 || attacking == 11;
-                    var _no_know_chaos = _battle_place.p_traitors[_battle_sub_loc] == 0 && _battle_place.p_chaos[_battle_sub_loc] == 0;
+    // draw_text(x2 + 14, y2 + 352, string_hash_to_newline("Selection: " + string(smin) + "/" + string(smax)));
 
-                    var _chaos_warlord_present = planet_feature_bool(_battle_place.p_feature[obj_ncombat.battle_id], eP_FEATURES.WARLORD10);
+    // Target
+    var race_quantity = 0;
+    if (purge == eDROP_TYPE.RAIDATTACK) {
+        var target_race = "", target_threat = "", race_quantity = 0;
 
-                    var _chaos_popup_turn_reached = obj_controller.turn >= obj_controller.chaos_turn;
+        if (attacking >= 5 && attacking <= 13) {
+            race_quantity = race_quantities[attacking - 4];
+            target_race = races[attacking - 4];
+        }
 
-                    var _chaos_unknown = (obj_controller.known[eFACTION.CHAOS] == 0) && (obj_controller.faction_gender[10] == 1);
-
-                    if (_chaos_lord_jump_possible && _no_know_chaos) {
-                        if (_chaos_popup_turn_reached && _chaos_warlord_present) {
-                            if (_chaos_unknown) {
-                                var pop;
-                                pop = instance_create(0, 0, obj_popup);
-                                pop.image = "chaos_symbol";
-                                pop.title = "Concealed Heresy";
-                                pop.text = $"Your astartes set out and begin to cleanse {planet_numeral_name(_battle_sub_loc, _battle_place)} of possible heresy.  The general populace appears to be devout in their faith, but a disturbing trend appears- the odd citizen cursing your forces, frothing at the mouth, and screaming out heresy most foul.  One week into the cleansing a large hostile force is detected approaching and encircling your forces.";
-                                cancel_combat();
-                                combating = 0;
-                                instance_activate_all();
-                                exit;
-                            }
-                            if (obj_controller.known[eFACTION.CHAOS] >= 2 && obj_controller.faction_gender[10] == 1) {
-                                with (obj_drop_select) {
-                                    obj_ncombat.enemy = 11;
-                                    obj_ncombat.threat = 0;
-                                    cancel_combat();
-                                    combating = 0;
-                                    instance_destroy();
-                                    instance_activate_all();
-                                    exit;
-                                }
-                            }
-                        }
-                    }
-
-                    scr_battle_allies();
-                    setup_battle_formations();
-                    roster.add_to_battle();
-                } else if (purge > 1) {
-                    draw_set_alpha(0.2);
-                    draw_rectangle(954, 556, 1043, 579, 0);
-                    draw_set_alpha(1);
-                    var _purge_score = 0;
-                    if (purge == 2) {
-                        _purge_score = roster.purge_bombard_score();
-                    }
-
-                    if (purge >= 3) {
-                        _purge_score = array_length(roster.selected_units);
-                    }
-
-                    scr_purge_world(p_target, planet_number, purge, _purge_score);
+        if (race_quantity >= 1 && race_quantity <= 6) {
+            target_threat = threat_levels[race_quantity];
+        } else if (race_quantity >= 6) {
+            target_threat = threat_levels[6];
+        }
+        target.x1 = formation.x1;
+        target.y1 = formation.y2 + 10;
+        target.str1 = "Target: ";
+        if (race_quantity != 0) {
+            target.str1 += $"{target_race} ({target_threat} Threat)";
+        } else {
+            target.str1 += "None";
+        }
+        target.update();
+        target.draw();
+        draw_sprite(spr_faction_icons, attacking, x2 - 100, y1 + 40);
+        var q = 0;
+        repeat (20) {
+            q += 1;
+            if (target.clicked() && force_present[q] != 0) {
+                if (attacking != force_present[q] && force_present[q] > 0) {
+                    attacking = force_present[q];
                 }
             }
+        }
+        target.locked = force_present[q] == 0;
+    }
+
+    // Back / Purge buttons
+    btn_back.x1 = x3 - 100;
+    btn_back.y1 = y2 - 60;
+    btn_back.update();
+    btn_back.draw();
+    if (btn_back.clicked()) {
+        menu = 0;
+        purge = 0;
+        instance_destroy();
+    }
+
+    // Attack / Raid buttons
+    btn_attack.x1 = btn_back.x1 + btn_attack.width + 10;
+    btn_attack.y1 = btn_back.y1;
+    if (purge == eDROP_TYPE.RAIDATTACK) {
+        btn_attack.str1 = (attack) ? "ATTACK!" : "RAID!";
+        btn_attack.active = array_length(roster.selected_units) > 0 && race_quantity > 0;
+    } else if (purge > 1) {
+        btn_attack.str1 = "PURGE";
+        btn_attack.active = array_length(roster.selected_units) > 0;
+    }
+    btn_attack.update();
+    btn_attack.draw();
+    if (btn_attack.clicked()) {
+        if (purge == 0) {
+            combating = 1; // Start battle here
+
+            if (attack == 1) {
+                obj_controller.last_attack_form = formation_possible[formation_current];
+            }
+            if (attack == 0) {
+                obj_controller.last_raid_form = formation_possible[formation_current];
+            }
+
+            instance_deactivate_all(true);
+            instance_activate_object(obj_controller);
+            instance_activate_object(obj_ini);
+            instance_activate_object(obj_drop_select);
+
+            // 135 ; temporary balancing
+            if (sh_target != -50) {
+                sh_target.acted += 1;
+            }
+
+            if ((attacking == 10) || (attacking == 11)) {
+                remove_planet_problem(planet_number, "meeting", p_target);
+                remove_planet_problem(planet_number, "meeting_trap", p_target);
+            }
+
+            instance_create(0, 0, obj_ncombat);
+            obj_ncombat.battle_object = p_target;
+            obj_ncombat.battle_loc = p_target.name;
+            obj_ncombat.battle_id = planet_number;
+            obj_ncombat.dropping = 1 - attack;
+            obj_ncombat.attacking = attack;
+            obj_ncombat.enemy = attacking;
+            obj_ncombat.formation_set = formation_possible[formation_current];
+            obj_ncombat.defending = false;
+            obj_ncombat.local_forces = roster.local_button.active;
+
+            var _planet = obj_ncombat.battle_object.p_feature[obj_ncombat.battle_id];
+            if (obj_ncombat.battle_object.space_hulk == 1) {
+                obj_ncombat.battle_special = "space_hulk";
+            }
+            if ((planet_feature_bool(_planet, eP_FEATURES.WARLORD6) == 1) && (obj_ncombat.enemy == 6) && (obj_controller.faction_defeated[6] == 0)) {
+                obj_ncombat.leader = 1;
+            }
+            if ((obj_ncombat.enemy == 7) && (obj_controller.faction_defeated[7] <= 0)) {
+                if (planet_feature_bool(_planet, eP_FEATURES.ORKWARBOSS)) {
+                    obj_ncombat.leader = 1;
+                    obj_ncombat.Warlord = _planet[search_planet_features(_planet, eP_FEATURES.ORKWARBOSS)[0]];
+                }
+            }
+
+            if ((obj_ncombat.enemy == 9) && (obj_ncombat.battle_object.space_hulk == 0)) {
+                if (has_problem_planet(planet_number, "tyranid_org", p_target)) {
+                    obj_ncombat.battle_special = "tyranid_org";
+                }
+            }
+
+            if (obj_ncombat.enemy == 11) {
+                if (planet_feature_bool(obj_ncombat.battle_object.p_feature[obj_ncombat.battle_id], eP_FEATURES.CHAOSWARBAND) == 1) {
+                    obj_ncombat.battle_special = "ChaosWarband";
+                    obj_ncombat.leader = 1;
+                }
+            }
+
+            var _threats = [
+                0,
+                0,
+                0,
+                0,
+                0,
+                sisters,
+                eldar,
+                ork,
+                tau,
+                tyranids,
+                traitors,
+                csm,
+                demons,
+                necrons
+            ];
+            if (obj_ncombat.enemy >= 5 && obj_ncombat.enemy <= 13) {
+                obj_ncombat.threat = _threats[obj_ncombat.enemy];
+            }
+
+            if (obj_ncombat.enemy == 8) {
+                var eth;
+                eth = 0;
+                eth = scr_quest(4, "ethereal_capture", 8, 0);
+                if ((eth > 0) && (obj_ncombat.battle_object.p_owner[obj_ncombat.battle_id] == 8)) {
+                    var rolli;
+                    rolli = irandom_range(1, 100);
+                    if ((obj_ncombat.threat == 6) && (rolli <= 80)) {
+                        obj_ncombat.ethereal = 1;
+                    }
+                    if ((obj_ncombat.threat == 5) && (rolli <= 65)) {
+                        obj_ncombat.ethereal = 1;
+                    }
+                    if ((obj_ncombat.threat == 4) && (rolli <= 50)) {
+                        obj_ncombat.ethereal = 1;
+                    }
+                    if ((obj_ncombat.threat == 3) && (rolli <= 35)) {
+                        obj_ncombat.ethereal = 1;
+                    }
+                }
+                // show_message("Ethereal Quest?: "+string(eth)+"#Ethereal?: "+string(obj_ncombat.ethereal));
+            }
+
+            // if (obj_ncombat.threat>1) and (obj_ncombat.enemy!=13) then obj_ncombat.threat-=1;
+            if ((obj_ncombat.threat > 1) && (obj_ncombat.battle_special != "ChaosWarband") && (attack == 0)) {
+                obj_ncombat.threat -= 1;
+            }
+            if (obj_ncombat.threat < 1) {
+                obj_ncombat.threat = 1;
+            }
+            if ((obj_ncombat.enemy == 10) && (obj_ncombat.battle_object.p_type[obj_ncombat.battle_id] == "Daemon")) {
+                obj_ncombat.threat = 7;
+            }
+
+            var _battle_place = obj_ncombat.battle_object;
+            var _battle_sub_loc = obj_ncombat.battle_id;
+            var _chaos_lord_jump_possible = attacking == 0 || attacking == 10 || attacking == 11;
+            var _no_know_chaos = _battle_place.p_traitors[_battle_sub_loc] == 0 && _battle_place.p_chaos[_battle_sub_loc] == 0;
+
+            var _chaos_warlord_present = planet_feature_bool(_battle_place.p_feature[obj_ncombat.battle_id], eP_FEATURES.WARLORD10);
+
+            var _chaos_popup_turn_reached = obj_controller.turn >= obj_controller.chaos_turn;
+
+            var _chaos_unknown = (obj_controller.known[eFACTION.CHAOS] == 0) && (obj_controller.faction_gender[10] == 1);
+
+            if (_chaos_lord_jump_possible && _no_know_chaos) {
+                if (_chaos_popup_turn_reached && _chaos_warlord_present) {
+                    if (_chaos_unknown) {
+                        var pop;
+                        pop = instance_create(0, 0, obj_popup);
+                        pop.image = "chaos_symbol";
+                        pop.title = "Concealed Heresy";
+                        pop.text = $"Your astartes set out and begin to cleanse {planet_numeral_name(_battle_sub_loc, _battle_place)} of possible heresy.  The general populace appears to be devout in their faith, but a disturbing trend appears- the odd citizen cursing your forces, frothing at the mouth, and screaming out heresy most foul.  One week into the cleansing a large hostile force is detected approaching and encircling your forces.";
+                        cancel_combat();
+                        combating = 0;
+                        instance_activate_all();
+                        exit;
+                    }
+                    if (obj_controller.known[eFACTION.CHAOS] >= 2 && obj_controller.faction_gender[10] == 1) {
+                        with (obj_drop_select) {
+                            obj_ncombat.enemy = 11;
+                            obj_ncombat.threat = 0;
+                            cancel_combat();
+                            combating = 0;
+                            instance_destroy();
+                            instance_activate_all();
+                            exit;
+                        }
+                    }
+                }
+            }
+
+            scr_battle_allies();
+            setup_battle_formations();
+            roster.add_to_battle();
+        } else if (purge > 1) {
+            draw_set_alpha(0.2);
+            draw_rectangle(954, 556, 1043, 579, 0);
+            draw_set_alpha(1);
+            var _purge_score = 0;
+            if (purge == 2) {
+                _purge_score = roster.purge_bombard_score();
+            }
+
+            if (purge >= 3) {
+                _purge_score = array_length(roster.selected_units);
+            }
+
+            scr_purge_world(p_target, planet_number, purge, _purge_score);
+        }
+    }
+}
+
+function drop_select_draw() {
+    with (obj_drop_select) {
+        if (purge != eDROP_TYPE.PURGESELECT) {
+           drop_select_unit_selection();
         }
 
         // Purge shit happens bellow;

--- a/scripts/scr_roster/scr_roster.gml
+++ b/scripts/scr_roster/scr_roster.gml
@@ -10,21 +10,21 @@ function Roster() constructor {
     squad_buttons = [];
     company_buttons = [];
     roster_local_string = "";
-    local_button = new ToggleButton();
-    local_button.str1 = "Local Forces";
-    local_button.text_halign = fa_center;
-    local_button.text_color = CM_GREEN_COLOR;
-    local_button.button_color = CM_GREEN_COLOR;
-    local_button.width = string_width(local_button.str1) + 10;
-    local_button.active = false;
+    local_button = new ToggleButton({
+        str1 : "Local Forces",
+        text_halign : fa_center,
+        text_color : CM_GREEN_COLOR,
+        button_color : CM_GREEN_COLOR,
+        active : false
+    }); 
 
-    select_all_ships = new UnitButtonObject();
-    select_all_ships.x1 = 700;
-    select_all_ships.y1 = 299;
-    select_all_ships.x2 = select_all_ships.x1 + select_all_ships.w;
-    select_all_ships.y2 = select_all_ships.y1 + select_all_ships.h;
-    select_all_ships.label = "All Ships";
-    select_all_ships.color = CM_GREEN_COLOR;
+    select_all_ships = new UnitButtonObject({
+        x1 : 700,
+        y1 : 299,
+        label : "All Ships",
+        text_color : CM_GREEN_COLOR,
+        button_color : CM_GREEN_COLOR
+    });
 
     static only_locals = function() {
         for (var i = 0; i < array_length(ships); i++) {
@@ -33,7 +33,7 @@ function Roster() constructor {
         }
         local_button.active = true;
     };
-
+    
     static format_roster_string = function() {
         roster_string = "";
         var _roster_types = struct_get_names(selected_roster);
@@ -179,16 +179,30 @@ function Roster() constructor {
         array_push(squad_buttons, _button);
     };
 
+    ship_multi_selector = new MultiSelect([], "", {
+        draw_alighn : "vertical",
+        max_height : 200,
+    });
+
     static new_ship_button = function(display, ship_id) {
         var _button = new ToggleButton();
-        _button.str1 = display;
-        _button.text_halign = fa_center;
-        _button.text_color = CM_GREEN_COLOR;
-        _button.button_color = CM_GREEN_COLOR;
-        _button.width = string_width(display) + 10;
-        _button.active = false;
-        _button.ship_id = ship_id;
+        _button.update({
+            str1 : display,
+            text_halign : fa_center,
+            text_color : CM_GREEN_COLOR,
+            button_color : CM_GREEN_COLOR,
+            width : string_width(display) + 10,
+            active : false,
+            ship_id,
+        });
+
+        _button.roster = self;
+        _button.hover_func = method(_button, function(){
+            roster.update_local_string(ship_id);
+        });
+        
         array_push(ships, _button);
+        array_push(ship_multi_selector.toggles, _button);
     };
 
     static update_local_string = function(ship_id) {


### PR DESCRIPTION
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
## Purpose and Description
<!-- Explain why and what your changes do in simple terms. -->
- Self-descriptive.

## Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- None, and I understand the risks.

## Related things and/or additional context
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, screenshots etc. -->
-

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->

<!--- "Inspired" by the CDDA PR template -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes hard-to-click ship and squad buttons on the raid/attack screen by enlarging hit areas and improving layout. Streamlines the drop screen code and corrects target info display.

- **Bug Fixes**
  - Replaced per-ship buttons with a vertical `MultiSelect` (column wraps, 200px max height); added “All Ships” to select all; ship hovers update local info; changes trigger roster refresh.
  - Standardized UI geometry with `standard_loc_data()` and refactored `ToggleButton` to use `w/h`, text padding, and `hover_func` for larger, reliable hitboxes; updated `RadioSet`/`UnitButtonObject`.
  - Extracted `drop_select_unit_selection()` from the draw routine for clarity; no gameplay changes beyond better interaction.
  - Target panel now uses prebuilt race/threat arrays defined in `obj_drop_select.Create` and locks when no valid target; faction icon rendering unchanged.
  - Squads/vehicles wrap neatly across rows; clicks consistently update the roster.

<sup>Written for commit 9e87d57959c69c56f91b573de10a1135492108c4. Summary will update on new commits. <a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1190?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

