### PR TITLE
fix: crash from legacy squad variables

### DIFF
--- a/objects/obj_star_select/Mouse_50.gml
+++ b/objects/obj_star_select/Mouse_50.gml
@@ -43,19 +43,18 @@ if (__b__) {
                     sel_plan = 0;
                     obj_controller.cooldown = 8000;
                     if (obj_controller.menu == 1 && obj_controller.view_squad) {
-                        var company_data = obj_controller.company_data;
-                        var squad_index = company_data.company_squads[company_data.cur_squad];
-                        var current_squad = fetch_squad(squad_index);
+                        var _company_data = obj_controller.company_data;
+                        var _current_squad = _company_data.grab_current_squad();
                         if (sel_plan > 0) {
                             var planet = sel_plan;
                             for (var i = 0; i < array_length(target.p_operatives[planet]); i++) {
                                 operation = target.p_operatives[planet][i];
-                                if (operation.type == "squad" && operation.reference == squad_index) {
+                                if (operation.type == "squad" && operation.reference == _current_squad.uid) {
                                     array_delete(target.p_operatives[planet], i, 1);
                                 }
                             }
                         }
-                        current_squad.assignment = "none";
+                        _current_squad.assignment = "none";
                     }
                     instance_destroy();
                 }


### PR DESCRIPTION
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
## Purpose and Description
<!-- Explain why and what your changes do in simple terms. -->
- Self-descriptive.

## Testing done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
- None, and I understand the risks.

## Related things and/or additional context
<!-- Other PRs, Discord bug reports, messages, threads, outside docs, screenshots etc. -->
-

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->

<!--- "Inspired" by the CDDA PR template -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented a crash in the star selection click handler by replacing legacy squad indexes with the new current squad API and uid matching. Clearing a squad now safely removes its planet operation and resets the squad assignment to "none".

<sup>Written for commit 0c1bdbec959233c25e50c0eaf52d8fe22d415527. Summary will update on new commits. <a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1191?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

