### PR TITLE
docs: Simplify pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,18 +1,10 @@
+<!--- YOU CAN DELETE ALL OF THIS AFTER READING. -->
+
 <!--- Make use of markdown lists. They make stuff much easier to read through. -->
-## Purpose and Description
-<!-- Explain why and what your changes do in simple terms. -->
-- Self-descriptive.
-
-## Testing done
-<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. -->
-- None, and I understand the risks.
-
-## Related things and/or additional context
-<!-- Other PRs, Discord bug reports, messages, threads, outside docs, screenshots etc. -->
--
+<!--- Explain why and what your changes do in simple terms. --->
+<!--- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. --->
 
 <!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
 <!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
-<!--- You can add "@coderabbitai" into the title, so that the bot auto-generates a title -->
 
 <!--- "Inspired" by the CDDA PR template -->


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Simplified the pull request template by removing the “Purpose,” “Testing,” and “Related” sections and replacing them with brief guidance comments. This reduces boilerplate, keeps title/commit guidelines, adds a “delete after reading” note, and removes the bot tip.

<sup>Written for commit b568a0d5394af913f8707b2213e7dc06e01079d7. Summary will update on new commits. <a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1192?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

