### PR TITLE
fix: poor initialisation of marines nuking command section

### DIFF
--- a/objects/obj_ini/Create_0.gml
+++ b/objects/obj_ini/Create_0.gml
@@ -185,24 +185,24 @@ if (global.load == -1) {
 serialize = function() {
     var object_ini = self;
 
-    var marines = array_create(0);
-    for (var coy = 0; coy <= 10; coy++) {
-        for (var mar = 0; mar <= 500; mar++) {
-            var marine_json;
-            if (obj_ini.name[coy][mar] != "") {
-                marine_json = jsonify_marine_struct(coy, mar, false);
-                array_push(marines, marine_json);
-            } else if (mar > 0) {
+    var _marines = array_create(0);
+    for (var _coy = 0; _coy <= 10; _coy++) {
+        for (var _mar = 0; _mar <= 500; _mar++) {
+            var _marine_json;
+            if (obj_ini.name[_coy][_mar] != "") {
+                _marine_json = jsonify_marine_struct(_coy, _mar, false);
+                array_push(_marines, _marine_json);
+            } else if (_mar > 0 && _mar <= 499 && obj_ini.name[_coy][_mar + 1] == "") {
                 break;
             }
         }
     }
 
-    var artifact_struct_trimmed = [];
+    var _artifact_struct_trimmed = [];
     var _artifact_count = array_length(artifact_struct);
     for (var i = 0; i < _artifact_count; i++) {
         if (artifact_struct[i].name != "") {
-            array_push(artifact_struct_trimmed, artifact_struct[i]);
+            array_push(_artifact_struct_trimmed, artifact_struct[i]);
         }
     }
 
@@ -215,8 +215,8 @@ serialize = function() {
         company_liveries: company_liveries,
         complex_livery_data: complex_livery_data,
         squad_types: squad_types,
-        artifact_struct: artifact_struct_trimmed,
-        marine_structs: marines,
+        artifact_struct: _artifact_struct_trimmed,
+        marine_structs: _marines,
         squad_structs: squads,
         equipment: equipment,
         gene_slaves: gene_slaves, // squads // marines,
@@ -305,19 +305,28 @@ deserialize = function(save_data) {
     }
 
     var _marine_structs = save_data[$ "marine_structs"];
+
+    function load_marine_struct(company, marine, struct) {
+        obj_ini.TTRPG[company][marine] = new TTRPG_stats("chapter", company, marine, "blank");
+        obj_ini.TTRPG[company][marine].load_json_data(struct);
+    }
+
+    obj_ini.TTRPG = array_create(11, array_create(501,[]));
+    for (var _coy = 0; _coy < 11; _coy++) {
+        for (var _mar = 0; _mar <= 500; _mar++) {
+            obj_ini.TTRPG[_coy][_mar] = new TTRPG_stats("chapter", _coy, _mar, "blank");
+        }
+    }
+    
     if (is_array(_marine_structs)) {
-        obj_ini.TTRPG = array_create(11, []);
         var _m_ar_len = array_length(_marine_structs);
         for (var m = 0; m < _m_ar_len; m++) {
-            var marine_json = _marine_structs[m];
-            var coy = marine_json.company;
-            var mar = marine_json.marine_number;
-            load_marine_struct(coy, mar, marine_json);
-        }
-        for (var coy = 0; coy < 11; coy++) {
-            var mar_start = array_length(obj_ini.TTRPG[coy]);
-            for (var mar = mar_start; mar < 501; mar++) {
-                obj_ini.TTRPG[coy][mar] = new TTRPG_stats("chapter", coy, mar, "blank");
+            var _marine_json = _marine_structs[m];
+            var _coy = _marine_json.company;
+            var _mar = _marine_json.marine_number;
+            load_marine_struct(_coy, _mar, _marine_json);
+            if (!is_struct(fetch_unit([_coy, _mar]))){
+                obj_ini.TTRPG[_coy][_mar] = new TTRPG_stats("chapter", _coy, _mar, "blank");
             }
         }
     }

--- a/scripts/scr_UnitGroup/scr_UnitGroup.gml
+++ b/scripts/scr_UnitGroup/scr_UnitGroup.gml
@@ -429,10 +429,14 @@ function UnitGroup(units) constructor {
         var _sorted_squads = [];
         for (var role_name = 0; role_name < _role_shuffle_length; role_name++) {
             var _wanted_role = _role_orders[role_name];
+            if (_wanted_role == ""){
+                continue;
+            }
             _match_roles.add_units(self, {role: _wanted_role}, true, -1);
             for (var i = 0; i < array_length(_match_roles.units); i++) {
                 var _unit = _match_roles.units[i];
-                if (_unit.role() == "" || _unit.squad == "none" || array_contains(_sorted_squads, _unit.squad)) {
+                if (_unit.squad == "none" || array_contains(
+                    base_group, _unit.squad)) {
                     continue;
                 }
                 var _squad = fetch_squad(_unit.squad);
@@ -720,7 +724,14 @@ function SearchConditions(data) constructor {
     static evaluate = function(unit) {
         self.unit = unit;
         if (unit.name() == "") {
+            unit.base_group = "none";
             // LOGGER.error($"Empty name! Unit:\n{unit}");
+            return false;
+        }
+
+        if (unit.role() == ""){
+            unit.set_name("");
+            unit.base_group = "none";
             return false;
         }
 

--- a/scripts/scr_UnitGroup/scr_UnitGroup.gml
+++ b/scripts/scr_UnitGroup/scr_UnitGroup.gml
@@ -436,7 +436,7 @@ function UnitGroup(units) constructor {
             for (var i = 0; i < array_length(_match_roles.units); i++) {
                 var _unit = _match_roles.units[i];
                 if (_unit.squad == "none" || array_contains(
-                    base_group, _unit.squad)) {
+                    _sorted_squads, _unit.squad)) {
                     continue;
                 }
                 var _squad = fetch_squad(_unit.squad);

--- a/scripts/scr_load/scr_load.gml
+++ b/scripts/scr_load/scr_load.gml
@@ -1,7 +1,4 @@
-function load_marine_struct(company, marine, struct) {
-    obj_ini.TTRPG[company][marine] = new TTRPG_stats("chapter", company, marine, "blank");
-    obj_ini.TTRPG[company][marine].load_json_data(struct);
-}
+
 
 function scr_load(save_part, save_id) {
     var t1 = get_timer();

--- a/scripts/scr_management/scr_management.gml
+++ b/scripts/scr_management/scr_management.gml
@@ -87,6 +87,7 @@ function scr_management(argument0) {
             nam[i] = "";
         }
 
+        //TODO update all this old shit to use UnitIndex
         // ****** MAIN PANEL ******
         q = 0;
         company = 0;

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -940,6 +940,10 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
         return obj_ini.name[company][marine_number];
     }; // get marine name
 
+    static set_name = function(new_name){
+        return obj_ini.name[company][marine_number] = new_name
+    }
+
     static gear = function(raw = false) {
         var wep = obj_ini.gear[company][marine_number];
         if (is_string(wep) || raw) {

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -941,7 +941,8 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
     }; // get marine name
 
     static set_name = function(new_name){
-        return obj_ini.name[company][marine_number] = new_name
+        obj_ini.name[company][marine_number] = new_name;
+        return new_name;
     }
 
     static gear = function(raw = false) {

--- a/scripts/scr_special_view/scr_special_view.gml
+++ b/scripts/scr_special_view/scr_special_view.gml
@@ -98,7 +98,7 @@ function scr_special_view(command_group) {
     last_man = b;
     last_vehicle = 0;
 
-    for (var i = 0; i < 101; i++) {
+    for (var i = 0; i < array_length(obj_ini.veh_race[company]); i++) {
         // 100
         if (obj_ini.veh_race[company][i] != 0) {
             add_vehicle_to_manage_arrays([company, i]);

--- a/scripts/scr_special_view/scr_special_view.gml
+++ b/scripts/scr_special_view/scr_special_view.gml
@@ -41,7 +41,6 @@ function scr_special_view(command_group) {
         }
     }
 
-    v = 0;
     if ((command_group == 13) || (command_group == 0)) {
         // Librarium
         var libs = collect_role_group([SPECIALISTS_LIBRARIANS, true]);
@@ -52,7 +51,6 @@ function scr_special_view(command_group) {
         }
     }
 
-    v = 0;
     if ((command_group == 14) || (command_group == 0)) {
         // Reclusium
         var chaps = collect_role_group([SPECIALISTS_CHAPLAINS, true]);
@@ -63,7 +61,6 @@ function scr_special_view(command_group) {
         }
     }
 
-    v = 0;
     squads = 0;
     if ((command_group == 15) || (command_group == 0)) {
         // Armamentarium
@@ -82,17 +79,17 @@ function scr_special_view(command_group) {
             if (obj_ini.name[0][v] == "") {
                 continue;
             }
-            if (obj_ini.TTRPG[0][v].ship_location > -1) {
-                var ham = obj_ini.TTRPG[0][v].ship_location;
+            var _unit = fetch_unit([0 , v]);
+            if (_unit.ship_location > -1) {
+                var ham = _unit.ship_location;
                 if (obj_ini.ship_location[ham] == "Lost") {
                     continue;
                 }
             }
 
-            unit = obj_ini.TTRPG[0][v];
-            yep = !(unit.IsSpecialist(SPECIALISTS_TECHS) || unit.IsSpecialist(SPECIALISTS_CHAPLAINS) || unit.IsSpecialist(SPECIALISTS_LIBRARIANS) || unit.IsSpecialist(SPECIALISTS_APOTHECARIES));
+            yep = !(_unit.IsSpecialist(SPECIALISTS_TECHS) || _unit.IsSpecialist(SPECIALISTS_CHAPLAINS) || _unit.IsSpecialist(SPECIALISTS_LIBRARIANS) || _unit.IsSpecialist(SPECIALISTS_APOTHECARIES));
             if (yep) {
-                add_man_to_manage_arrays(unit);
+                add_man_to_manage_arrays(_unit);
             }
         }
     }
@@ -101,7 +98,7 @@ function scr_special_view(command_group) {
     last_man = b;
     last_vehicle = 0;
 
-    for (var i = 1; i < 101; i++) {
+    for (var i = 0; i < 101; i++) {
         // 100
         if (obj_ini.veh_race[company][i] != 0) {
             add_vehicle_to_manage_arrays([company, i]);
@@ -110,7 +107,7 @@ function scr_special_view(command_group) {
 
     squads = 0;
     //TODO unify this data with other_manage_data() method
-    for (var i = 1; i < array_length(display_unit); i++) {
+    for (var i = 0; i < array_length(display_unit); i++) {
         onceh = 0;
         var ahuh = 0;
         if (man[i] == "man") {


### PR DESCRIPTION
<!--- YOU CAN DELETE ALL OF THIS AFTER READING. -->

<!--- Make use of markdown lists. They make stuff much easier to read through. -->
<!--- Explain why and what your changes do in simple terms. --->
<!--- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. --->

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->

<!--- "Inspired" by the CDDA PR template -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes marine initialization that was wiping command sections. Marines are now safely pre-initialized, and invalid units are filtered out during grouping and special views.

- **Bug Fixes**
  - Pre-initialize `obj_ini.TTRPG` for all companies (0–10) and marines (0–500); load saved structs and backfill blanks when data is missing or invalid.
  - Filter units with empty names or roles; clear names via `set_name()` and set `base_group = "none"` to prevent corrupt command groups.
  - Improve role-based squad collection: ignore empty role entries and avoid duplicates by checking squad membership.
  - Stabilize special views and vehicle loops: start at index 0, respect array lengths, use `fetch_unit`, and stop marine serialization early when trailing slots are empty.
  - Trim `artifact_struct` before saving; remove duplicate `load_marine_struct` from `scr_load` and define it locally where needed.

<sup>Written for commit f862e051fc7b217ab20dc5bb09ecfa3b3a09855c. Summary will update on new commits. <a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1193?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

