### PR TITLE
feat: Remove chipping damage to vehicles

### DIFF
--- a/scripts/scr_clean/scr_clean.gml
+++ b/scripts/scr_clean/scr_clean.gml
@@ -325,9 +325,9 @@ function damage_vehicles(_damage_data, _shots, _damage, _weapon_index) {
         veh_index = array_random_element(valid_vehicles);
 
         // Apply damage
-        var _modified_damage = _damage - (veh_ac[veh_index] * _armour_mod);
+        var _modified_damage = _damage - veh_ac[veh_index] * _armour_mod;
         if (_modified_damage < 0) {
-            _modified_damage = 0.25;
+            _modified_damage = 0;
         }
         if (enemy == 13 && _modified_damage < 1) {
             _modified_damage = 1;


### PR DESCRIPTION
Makes chip damage ineffective at killing very tanky targets.

### **Purpose**
-Removed "chip" damage from the scr_clean so that thousands of toothpicks cannot cause armoured behemoths to explode

### **Testing**
- Ran multiple battles vs force level 3 tyranids with solely 6 land-raiders (durability marginally improved against small arms)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops chip damage from killing heavily armored vehicles by clamping negative post-armor damage to 0. Land Raiders and similar tanks now ignore small-arms chip damage.

- **Bug Fixes**
  - In `damage_vehicles`, lowered the post-armor damage floor from 0.25 to 0 (special-case min 1 for enemy 13 still applies) to prevent chip kills.

<sup>Written for commit ba104af4cb6db98574cfd3ace277b80d64ff5f1e. Summary will update on new commits. <a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1194?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

