### PR TITLE
chore: refactor scr_management

### DIFF
--- a/objects/obj_managment_panel/Create_0.gml
+++ b/objects/obj_managment_panel/Create_0.gml
@@ -9,25 +9,65 @@ panel_width = 0;
 panel_height = 0;
 
 line = [];
-italic[0] = 0;
-bold[0] = 0;
-var i;
-i = 0;
-repeat (30) {
-    i += 1;
-    line[i] = "";
-    italic[i] = 0;
-    bold[i] = 0;
-}
-
 slate_panel = new DataSlate();
 
-
+scroll_active = 0;
+scroll_delay = 0;
+scroll_offset = 0;
 draw_lines = function (_x, _y, increment, truncate_line){
-    for (var l = 0;l < array_length(line); l++){
-        if (line[l] != "") {
-            var _line = truncate_line ? string_truncate(line[l], 134) : line[l];
-            draw_text(_x, _y + ((l) * increment), _line);
+    var _total_lines = array_length(line);
+
+    if (_total_lines > 16){
+        if (!scroll_active){
+            scroll_delay++;
         }
+        if (scroll_delay > 45){
+            scroll_active = 1;
+            scroll_delay = 0;
+        }
+        if (scroll_active == 1){
+            scroll_offset++;
+        } else if (scroll_active == 2){
+            scroll_offset--;
+        }
+    }
+
+    for (var l = 0;l < array_length(line); l++){
+        var _y_depth = (l * increment);
+
+        if ((_y_depth - scroll_offset) < 0){
+            continue;
+        }
+
+        if (_y_depth - scroll_offset > (increment * 16)){
+            continue;
+        }
+
+        draw_set_font(fnt_40k_12);
+        var _draw_func = draw_text;
+        var _is_struct = is_struct(line[l]);
+        if (_is_struct){
+            var _struc = line[l];
+            if (_struc.italic){
+                draw_set_font(fnt_40k_12i);
+            }
+            if (_struc.bold){
+                _draw_func = draw_text_bold;
+            }
+            var _line = truncate_line ? string_truncate(_struc.str1, 134) : _struc.str1;
+        } else {
+            var _line = truncate_line ? string_truncate(line[l], 134) : line[l];
+        }
+        _draw_func(_x, _y + _y_depth - scroll_offset, _line);
+
+        if (scroll_active == 1 && l == _total_lines-1){
+            if (_y_depth - scroll_offset < increment * 12){
+                scroll_active = 2;
+            }
+        }
+        if (scroll_active == 2 && scroll_offset == 0){
+            scroll_active = 0;
+        }
+
     }    
 }

--- a/objects/obj_managment_panel/Create_0.gml
+++ b/objects/obj_managment_panel/Create_0.gml
@@ -8,7 +8,7 @@ occupants = "";
 panel_width = 0;
 panel_height = 0;
 
-line[0] = "";
+line = [];
 italic[0] = 0;
 bold[0] = 0;
 var i;
@@ -21,3 +21,13 @@ repeat (30) {
 }
 
 slate_panel = new DataSlate();
+
+
+draw_lines = function (_x, _y, increment, truncate_line){
+    for (var l = 0;l < array_length(line); l++){
+        if (line[l] != "") {
+            var _line = truncate_line ? string_truncate(line[l], 134) : line[l];
+            draw_text(_x, _y + ((l) * increment), _line);
+        }
+    }    
+}

--- a/objects/obj_managment_panel/Draw_64.gml
+++ b/objects/obj_managment_panel/Draw_64.gml
@@ -46,18 +46,17 @@ slate_panel.inside_method = function() {
         }
         draw_set_font(fnt_cul_14);
         draw_text(x + (panel_width / 2), y + 89, string_hash_to_newline(title));
-        if (line[1] != "") {
-            if (italic[1] == 1) {
+        if (array_length(line) > 0 && line[0] != "") {
+            if (italic[0] == 1) {
                 draw_set_font(fnt_40k_14i);
             } else {
                 draw_set_font(fnt_40k_14);
             }
-            draw_text_glow(x + (panel_width / 2), y + 112, string_hash_to_newline(line[1]), c_white, #50a076);
+            draw_text_glow(x + (panel_width / 2), y + 112, string_hash_to_newline(line[0]), c_white, #50a076);
             draw_set_font(fnt_40k_12);
         }
-        var l = 1;
-        repeat (10) {
-            l += 1;
+        draw_lines(x + (panel_width / 2), y + 112, 20,false)
+        for (var l = 0;l < array_length(line); l++){
             if (line[l] != "") {
                 draw_text(x + (panel_width / 2), y + 112 + ((l - 1) * 20), string_hash_to_newline(line[l]));
             }
@@ -88,42 +87,30 @@ slate_panel.inside_method = function() {
         draw_set_font(fnt_cul_14);
         draw_text(x + (panel_width / 2), y + 20, string_hash_to_newline(title));
         draw_set_font(fnt_40k_12);
-        if (line[1] != "") {
-            if (italic[1] == 1) {
+        if (array_length(line) > 0 && line[0] != "") {
+            if (italic[0] == 1) {
                 draw_set_font(fnt_40k_12i);
             }
-            draw_func = (bold[1] == 1) ? draw_text_bold : draw_text;
-            draw_func(x + (panel_width / 2), y + 43, string_hash_to_newline(line[1]));
+            draw_func = (bold[0] == 1) ? draw_text_bold : draw_text;
+            draw_func(x + (panel_width / 2), y + 43, string_hash_to_newline(line[0]));
             draw_set_font(fnt_40k_12);
         }
-        var l = 1;
-        repeat (10) {
-            l += 1;
-            if (line[l] != "") {
-                draw_text(x + (panel_width / 2), y + 43 + ((l - 1) * 20), string_hash_to_newline(line[l]));
-            }
-        }
+        draw_lines(x + (panel_width / 2), y + 43, 20, false);
     } else if (header == 1) {
         draw_sprite_stretched(spr_master_title, 0, x, y - 2, panel_width + 2, 4);
         draw_set_font(fnt_cul_14);
         draw_text(x + (panel_width / 2), y + 30, string_hash_to_newline(title));
         draw_set_font(fnt_40k_12);
-        if (line[1] != "") {
-            if (italic[1] == 1) {
+        if (line[0] != "") {
+            if (italic[0] == 1) {
                 draw_set_font(fnt_40k_12i);
             }
-            draw_func = (bold[1] == 1) ? draw_text_bold : draw_text;
-            draw_func(x + (panel_width / 2), y + 53, string_hash_to_newline(line[1]));
+            draw_func = (bold[0] == 1) ? draw_text_bold : draw_text;
+            draw_func(x + (panel_width / 2), y + 53, string_hash_to_newline(line[0]));
             draw_set_font(fnt_40k_12);
         }
-        var l;
-        l = 1;
-        repeat (24) {
-            l += 1;
-            if (line[l] != "") {
-                draw_text(x + (panel_width / 2), y + 53 + ((l - 1) * 18), string_truncate(line[l], 134));
-            }
-        }
+
+        draw_lines(x + (panel_width / 2), y + 53, 18, true);
     }
     draw_set_color(c_white);
 };
@@ -133,7 +120,7 @@ var y_scale = panel_height / 860;
 
 try {
     slate_panel.draw(x, y, x_scale, y_scale);
-    // draw_text(x+(panel_width/2),y-60,string(manage)+") "+string(line[1])+"#"+string(line[2])+"#"+string(line[3]));
+    // draw_text(x+(panel_width/2),y-60,string(manage)+") "+string(line[0])+"#"+string(line[2])+"#"+string(line[3]));
 
     if (point_and_click([x, y, x + panel_width, y + panel_height])) {
         obj_controller.managing = manage;

--- a/objects/obj_managment_panel/Draw_64.gml
+++ b/objects/obj_managment_panel/Draw_64.gml
@@ -46,21 +46,9 @@ slate_panel.inside_method = function() {
         }
         draw_set_font(fnt_cul_14);
         draw_text(x + (panel_width / 2), y + 89, string_hash_to_newline(title));
-        if (array_length(line) > 0 && line[0] != "") {
-            if (italic[0] == 1) {
-                draw_set_font(fnt_40k_14i);
-            } else {
-                draw_set_font(fnt_40k_14);
-            }
-            draw_text_glow(x + (panel_width / 2), y + 112, string_hash_to_newline(line[0]), c_white, #50a076);
-            draw_set_font(fnt_40k_12);
-        }
+
         draw_lines(x + (panel_width / 2), y + 112, 20,false)
-        for (var l = 0;l < array_length(line); l++){
-            if (line[l] != "") {
-                draw_text(x + (panel_width / 2), y + 112 + ((l - 1) * 20), string_hash_to_newline(line[l]));
-            }
-        }
+
     } else if (header == 2) {
         slate_panel.draw_top_piece = false;
         draw_sprite_stretched(spr_company_title, company, x + 40, y - 2, panel_width - 80, 4);
@@ -87,28 +75,13 @@ slate_panel.inside_method = function() {
         draw_set_font(fnt_cul_14);
         draw_text(x + (panel_width / 2), y + 20, string_hash_to_newline(title));
         draw_set_font(fnt_40k_12);
-        if (array_length(line) > 0 && line[0] != "") {
-            if (italic[0] == 1) {
-                draw_set_font(fnt_40k_12i);
-            }
-            draw_func = (bold[0] == 1) ? draw_text_bold : draw_text;
-            draw_func(x + (panel_width / 2), y + 43, string_hash_to_newline(line[0]));
-            draw_set_font(fnt_40k_12);
-        }
+
         draw_lines(x + (panel_width / 2), y + 43, 20, false);
     } else if (header == 1) {
         draw_sprite_stretched(spr_master_title, 0, x, y - 2, panel_width + 2, 4);
         draw_set_font(fnt_cul_14);
         draw_text(x + (panel_width / 2), y + 30, string_hash_to_newline(title));
         draw_set_font(fnt_40k_12);
-        if (line[0] != "") {
-            if (italic[0] == 1) {
-                draw_set_font(fnt_40k_12i);
-            }
-            draw_func = (bold[0] == 1) ? draw_text_bold : draw_text;
-            draw_func(x + (panel_width / 2), y + 53, string_hash_to_newline(line[0]));
-            draw_set_font(fnt_40k_12);
-        }
 
         draw_lines(x + (panel_width / 2), y + 53, 18, true);
     }

--- a/scripts/scr_UnitGroup/scr_UnitGroup.gml
+++ b/scripts/scr_UnitGroup/scr_UnitGroup.gml
@@ -489,6 +489,18 @@ function UnitIndex(units) constructor {
         return struct_get_names(role_index);
     };
 
+    static hierarchy_keys = function(){
+        var _keys = keys();
+        var _all_roles = role_hierarchy();
+        for (var i = array_length(_all_roles)-1;i >= 0; i-- ){
+            if (!array_contains(_keys , _all_roles[i])){
+                array_delete(_all_roles, i, 1);
+            }
+        }
+
+        return _all_roles;
+    }
+
     static pop_role_member = function(role) {
         return array_pop(role_index[$ role]);
     };
@@ -504,6 +516,20 @@ function UnitIndex(units) constructor {
         }
         return new UnitGroup(_units);
     };
+
+    static create_plural_strings_array = function(arrange_with_hierarchy = true){
+        var _strings_array = [];
+        if (arrange_with_hierarchy){
+            var _keys = hierarchy_keys();
+        } else{
+            _keys = keys();
+        }
+        for (var i = 0;i<array_length(_keys); i++){
+            array_push(_strings_array, string_plural_count(_keys[i], role_count(_keys[i]), false));
+        }
+
+        return _strings_array;
+    }
 }
 
 //TODO write this out with proper formatting when i can be assed

--- a/scripts/scr_UnitGroup/scr_UnitGroup.gml
+++ b/scripts/scr_UnitGroup/scr_UnitGroup.gml
@@ -517,15 +517,38 @@ function UnitIndex(units) constructor {
         return new UnitGroup(_units);
     };
 
-    static create_plural_strings_array = function(arrange_with_hierarchy = true){
+    static create_plural_strings_array = function(arrange_with_hierarchy = true, allow_draw_data = true, use_names_for_heads = true){
         var _strings_array = [];
+		var _keys;
         if (arrange_with_hierarchy){
-            var _keys = hierarchy_keys();
+            _keys = hierarchy_keys();
         } else{
             _keys = keys();
         }
         for (var i = 0;i<array_length(_keys); i++){
-            array_push(_strings_array, string_plural_count(_keys[i], role_count(_keys[i]), false));
+            var _count = role_count(_keys[i]);
+            if (_count == 0){
+                continue;
+            }
+            if (_count == 1){
+                if (allow_draw_data){
+                    var _string = _keys[i];
+                    var _italic = false;
+                    if (use_names_for_heads && is_specialist(_keys[i],SPECIALISTS_HEADS) || _keys[i] == active_roles()[eROLE.CAPTAIN]){
+                        _string = role_index[$ _keys[i]][0].name();
+                        _italic = true;
+                    }
+                    array_push(_strings_array, {
+                        str1 : _string,
+                        bold : true,
+                        italic : _italic,
+                    });
+                } else {
+                    array_push(_strings_array, string(_keys[i]));
+                }
+            }else {
+                array_push(_strings_array, string_plural_count(_keys[i], role_count(_keys[i]), false));
+            }
         }
 
         return _strings_array;

--- a/scripts/scr_UnitGroup/scr_UnitGroup.gml
+++ b/scripts/scr_UnitGroup/scr_UnitGroup.gml
@@ -477,6 +477,10 @@ function UnitIndex(units) constructor {
 
     add_to_index(units);
 
+    static role_count = function(role){
+        return array_length(role_index[$ role])
+    }
+
     static has_role = function(role) {
         return struct_exists(role_index, role) && array_length(role_index[$ role]) > 0;
     };

--- a/scripts/scr_management/scr_management.gml
+++ b/scripts/scr_management/scr_management.gml
@@ -427,82 +427,24 @@ function scr_management(argument0) {
             nam[9] = (role_names[eROLE.CHAMPION] == "Champion") ? "Champion" : role_names[eROLE.CHAMPION];
             nam[10] = role_names[eROLE.TERMINATOR];
             nam[11] = role_names[eROLE.SERGEANT];
-            nam[12] = (role_names[eROLE.VETERANSERGEANT] == "Veteran Sergeant") ? "Sergeant" : role_names[eROLE.VETERANSERGEANT];
+            nam[12] = (role_names[eROLE.VETERANSERGEANT] == "Veteran Sergeant") ? "Vet Sergeant" : role_names[eROLE.VETERANSERGEANT];
             nam[13] = role_names[eROLE.VETERAN];
             nam[14] = role_names[eROLE.TACTICAL];
             nam[15] = role_names[eROLE.ASSAULT];
             nam[16] = role_names[eROLE.DEVASTATOR];
             nam[17] = role_names[eROLE.SCOUT];
-            nam[18] = role_names[eROLE.DREADNOUGHT]; // Venerable Dreadnought, just the role name is too long for the company box
+            nam[18] = "Venerable " + role_names[eROLE.DREADNOUGHT]; // Venerable Dreadnought, just the role name is too long for the company box
             nam[19] = role_names[eROLE.DREADNOUGHT];
             nam[20] = "Land Raider";
             nam[21] = "Predator";
             nam[22] = "Rhino";
             nam[23] = "Land Speeder";
             nam[24] = "Whirlwind";
-            for (var i = 0; i < array_length(obj_ini.TTRPG[company]); i++) {
-                unit = obj_ini.TTRPG[company][i];
-                if (unit.name() == "") {
-                    continue;
-                }
-                if (unit.role() == role_names[eROLE.CAPTAIN]) {
-                    num[1]++;
-                    nam[1] = unit.name();
-                }
-                // Space Wolves exception
-                if (chapter_name != "Iron Hands" && unit.role() == role_names[eROLE.CHAPLAIN]) {
-                    num[2]++;
-                }
-                if (chapter_name != "Space Wolves" && unit.role() == role_names[eROLE.APOTHECARY]) {
-                    num[3]++;
-                }
-                if (unit.role() == role_names[eROLE.TECHMARINE]) {
-                    num[4]++;
-                }
-                if (unit.role() == role_names[eROLE.LIBRARIAN]) {
-                    num[5]++;
-                }
-                if (unit.role() == "Codiciery") {
-                    num[6]++;
-                }
-                if (unit.role() == "Lexicanum") {
-                    num[7]++;
-                }
-                if (unit.role() == role_names[eROLE.ANCIENT]) {
-                    num[8]++;
-                }
-                if (unit.role() == role_names[eROLE.CHAMPION]) {
-                    num[9]++;
-                }
-                if (unit.role() == role_names[eROLE.TERMINATOR]) {
-                    num[10]++;
-                }
-                if (unit.role() == role_names[eROLE.SERGEANT]) {
-                    num[11]++;
-                }
-                if (unit.role() == role_names[eROLE.VETERANSERGEANT]) {
-                    num[12]++;
-                }
-                if (unit.role() == role_names[eROLE.VETERAN]) {
-                    num[13]++;
-                }
-                if (unit.role() == role_names[eROLE.TACTICAL]) {
-                    num[14]++;
-                }
-                if (unit.role() == role_names[eROLE.ASSAULT]) {
-                    num[15]++;
-                }
-                if (unit.role() == role_names[eROLE.DEVASTATOR]) {
-                    num[16]++;
-                }
-                if (unit.role() == role_names[eROLE.SCOUT]) {
-                    num[17]++;
-                }
-                if (unit.role() == "Venerable " + string(role_names[eROLE.DREADNOUGHT])) {
-                    num[18]++;
-                }
-                if (unit.role() == role_names[eROLE.DREADNOUGHT]) {
-                    num[19]++;
+
+            var _company_group = collect_company(company).index_roles();
+            for (var i = 2; i <= 19 ; i++){
+                if (_company_group.has_role(nam[i])){
+                    num[i] = _company_group.role_count(nam[i]);
                 }
             }
 

--- a/scripts/scr_management/scr_management.gml
+++ b/scripts/scr_management/scr_management.gml
@@ -25,12 +25,6 @@ function scr_management(argument0) {
 
         var _reclusium_units = _command_company.get_from({group:[SPECIALISTS_CHAPLAINS, true, true]}, true, true);
 
-        var _head = _reclusium_units.get_from({group : SPECIALISTS_HEADS, max_wanted : 1});
-
-        if (_head.number() > 0){
-            pane.line = [_head.units[0].name()];
-        }
-
         var _reclusium_units = _reclusium_units.index_roles();
 
         pane.line = array_join(pane.line,_reclusium_units.create_plural_strings_array());
@@ -42,11 +36,7 @@ function scr_management(argument0) {
         pane.title = "APOTHECARIUM";
 
         var _apothecary_units = _command_company.get_from({group:[SPECIALISTS_APOTHECARIES, true, true]}, true, true);
-        var _head = _apothecary_units.get_from({group : SPECIALISTS_HEADS, max_wanted : 1});
 
-        if (_head.number() > 0){
-            pane.line = [_head.units[0].name()];
-        }
         var _apothecary_units = _apothecary_units.index_roles();
 
         pane.line = array_join(pane.line,_apothecary_units.create_plural_strings_array());
@@ -57,11 +47,7 @@ function scr_management(argument0) {
         pane.header = 2;
         pane.title = "ARMOURY";
         var _armoury_units = _command_company.get_from({group:[SPECIALISTS_TECHS, true, true]}, true, true);
-        var _head = _armoury_units.get_from({group : SPECIALISTS_HEADS, max_wanted : 1});
 
-        if (_head.number() > 0){
-            pane.line = [_head.units[0].name()];
-        }
         var _armoury_units = _armoury_units.index_roles();
 
         pane.line = array_join(pane.line, _armoury_units.create_plural_strings_array());
@@ -74,11 +60,7 @@ function scr_management(argument0) {
         pane.title = "LIBRARIUM";
 
         var _lib_units = _command_company.get_from({group:[SPECIALISTS_LIBRARIANS, true, true]}, true, true);
-        var _head = _lib_units.get_from({group : SPECIALISTS_HEADS, max_wanted : 1});
 
-        if (_head.number() > 0){
-            pane.line = [_head.units[0].name()];
-        }
         var _lib_units = _lib_units.index_roles();
 
         pane.line = array_join(pane.line,_lib_units.create_plural_strings_array());
@@ -88,116 +70,60 @@ function scr_management(argument0) {
         pane.manage = 11;
         pane.header = 3;
         pane.title = "HEADQUARTERS";
-        var _head = _command_company.get_from({group : SPECIALISTS_HEADS, max_wanted : 1});
 
-        if (_head.number() > 0){
-            pane.line = [_head.units[0].name()];
-        }
         var _command_units = _command_company.index_roles();
 
-        pane.line = array_join(pane.line,_command_units.create_plural_strings_array())
+        pane.line = array_join(pane.line,_command_units.create_plural_strings_array());
 
         // Coordinates declaration and text initiation
         var xx = 25, yy = 400 - 48, t;
 
         // Creates the first 10 companies using roman numerals
-        for (var i = 1; i <= 10; i++) {
-            t = string_upper(scr_convert_company_to_string(i));
+        for (var company = 1; company <= 10; company++) {
+            t = string_upper(scr_convert_company_to_string(company));
 
             var pane = instance_create(xx, yy, obj_managment_panel);
-            pane.company = i;
-            pane.manage = i;
+            pane.company = company;
+            pane.manage = company;
             pane.header = 1;
             pane.title = t;
 
-            xx += 156;
-        }
-
-        // Generates the company if there are more than 10 companites
-        // TODO improve logic or add extra romanNumerals to array TBD
-
-        // ** Marines and vehicles per company and HQ by ranks **
-        for (company = 1; company <= obj_ini.companies; company++) {
-            q = 0;
-            obj_controller.temp[71] = company;
-
-            for (var i = 0; i < 50; i++) {
-                num[i] = 0;
-                nam[i] = "";
-            }
-            // Indexing the names to nam array
-            nam[1] = role_names[eROLE.CAPTAIN];
-            nam[2] = role_names[eROLE.CHAPLAIN];
-            nam[3] = role_names[eROLE.APOTHECARY];
-            nam[4] = role_names[eROLE.TECHMARINE];
-            nam[5] = role_names[eROLE.LIBRARIAN];
-            nam[6] = "Codiciery";
-            nam[7] = "Lexicanum";
-            nam[8] = "Company" + role_names[eROLE.ANCIENT];
-            nam[9] = (role_names[eROLE.CHAMPION] == "Champion") ? "Champion" : role_names[eROLE.CHAMPION];
-            nam[10] = role_names[eROLE.TERMINATOR];
-            nam[11] = role_names[eROLE.SERGEANT];
-            nam[12] = (role_names[eROLE.VETERANSERGEANT] == "Veteran Sergeant") ? "Vet Sergeant" : role_names[eROLE.VETERANSERGEANT];
-            nam[13] = role_names[eROLE.VETERAN];
-            nam[14] = role_names[eROLE.TACTICAL];
-            nam[15] = role_names[eROLE.ASSAULT];
-            nam[16] = role_names[eROLE.DEVASTATOR];
-            nam[17] = role_names[eROLE.SCOUT];
-            nam[18] = "Venerable " + role_names[eROLE.DREADNOUGHT]; // Venerable Dreadnought, just the role name is too long for the company box
-            nam[19] = role_names[eROLE.DREADNOUGHT];
-            nam[20] = "Land Raider";
-            nam[21] = "Predator";
-            nam[22] = "Rhino";
-            nam[23] = "Land Speeder";
-            nam[24] = "Whirlwind";
-
             var _company_group = collect_company(company).index_roles();
-            for (var i = 2; i <= 19 ; i++){
-                if (_company_group.has_role(nam[i])){
-                    num[i] = _company_group.role_count(nam[i]);
-                }
-            }
 
+            pane.line = array_join(pane.line,_company_group.create_plural_strings_array());
+
+            var num = array_create(5, 0);
+            var nam = [
+                "Land Raider",
+                "Predator",
+                "Rhino",
+                "Land Speeder",
+                 "Whirlwind",
+            ]
             // Vehicles
             for (var i = 0; i < array_length(obj_ini.veh_role[company]); i++) {
-                if (obj_ini.veh_role[company][i] == "Land Raider") {
-                    num[20]++;
-                }
-                if (obj_ini.veh_role[company][i] == "Predator") {
-                    num[21]++;
-                }
-                if (obj_ini.veh_role[company][i] == "Rhino") {
-                    num[22]++;
-                }
-                if (obj_ini.veh_role[company][i] == "Land Speeder") {
-                    num[23]++;
-                }
-                if (obj_ini.veh_role[company][i] == "Whirlwind") {
-                    num[24]++;
-                }
-            }
-
-            with (obj_managment_panel) {
-                if (manage != obj_controller.temp[71]) {
-                    instance_deactivate_object(id);
-                }
-            }
-
-            q = 0;
-            for (var d = 1; d <= 24; d++) {
-                if (num[d] > 0) {
-                    q += 1;
-                    if (d == 1) {
-                        obj_managment_panel.line[q] = string(nam[d]);
-                        // obj_managment_panel.italic[q] = 1;
-                        obj_managment_panel.bold[q] = 1;
-                    } else {
-                        obj_managment_panel.line[q] = string_plural_count(nam[d], num[d], false);
+                for (var s = 0;s<array_length(nam);s++){
+                    if (obj_ini.veh_role[company][i] == nam[s]){
+                        num[s]++;
                     }
                 }
             }
 
-            instance_activate_object(obj_managment_panel);
+            for (var d = 0; d < 5; d++) {
+                if (num[d] > 0) {
+                    if (d == 1) {
+                        array_push(pane.line, {
+                            str1 : nam[d],
+                            bold : true,
+                            italic : false,
+                        });
+                        // obj_managment_panel.italic[q] = 1;
+                    } else {
+                        array_push(pane.line, nam[d], string_plural_count(nam[d], num[d], false));
+                    }
+                }
+            }
+            xx += 156;
         }
     }
 }

--- a/scripts/scr_management/scr_management.gml
+++ b/scripts/scr_management/scr_management.gml
@@ -15,12 +15,7 @@ function scr_management(argument0) {
         }
 
         var pane;
-
-        pane = instance_create(700, 180 - 48, obj_managment_panel);
-        pane.company = 0;
-        pane.manage = 11;
-        pane.header = 3;
-        pane.title = "HEADQUARTERS";
+        var _command_company = collect_company(0);
 
         pane = instance_create(475, 180 - 48, obj_managment_panel);
         pane.company = 0;
@@ -28,23 +23,79 @@ function scr_management(argument0) {
         pane.header = 2;
         pane.title = "RECLUSIUM";
 
+        var _reclusium_units = _command_company.get_from({group:[SPECIALISTS_CHAPLAINS, true, true]}, true, true);
+
+        var _head = _reclusium_units.get_from({group : SPECIALISTS_HEADS, max_wanted : 1});
+
+        if (_head.number() > 0){
+            pane.line = [_head.units[0].name()];
+        }
+
+        var _reclusium_units = _reclusium_units.index_roles();
+
+        pane.line = array_join(pane.line,_reclusium_units.create_plural_strings_array());
+
         pane = instance_create(275, 180 - 48, obj_managment_panel);
         pane.company = 0;
         pane.manage = 12;
         pane.header = 2;
         pane.title = "APOTHECARIUM";
 
+        var _apothecary_units = _command_company.get_from({group:[SPECIALISTS_APOTHECARIES, true, true]}, true, true);
+        var _head = _apothecary_units.get_from({group : SPECIALISTS_HEADS, max_wanted : 1});
+
+        if (_head.number() > 0){
+            pane.line = [_head.units[0].name()];
+        }
+        var _apothecary_units = _apothecary_units.index_roles();
+
+        pane.line = array_join(pane.line,_apothecary_units.create_plural_strings_array());
+
         pane = instance_create(925, 180 - 48, obj_managment_panel);
         pane.company = 0;
         pane.manage = 15;
         pane.header = 2;
         pane.title = "ARMOURY";
+        var _armoury_units = _command_company.get_from({group:[SPECIALISTS_TECHS, true, true]}, true, true);
+        var _head = _armoury_units.get_from({group : SPECIALISTS_HEADS, max_wanted : 1});
 
+        if (_head.number() > 0){
+            pane.line = [_head.units[0].name()];
+        }
+        var _armoury_units = _armoury_units.index_roles();
+
+        pane.line = array_join(pane.line, _armoury_units.create_plural_strings_array());
+
+        pane = instance_create(925, 180 - 48, obj_managment_panel);
         pane = instance_create(1125, 180 - 48, obj_managment_panel);
         pane.company = 0;
         pane.manage = 13;
         pane.header = 2;
         pane.title = "LIBRARIUM";
+
+        var _lib_units = _command_company.get_from({group:[SPECIALISTS_LIBRARIANS, true, true]}, true, true);
+        var _head = _lib_units.get_from({group : SPECIALISTS_HEADS, max_wanted : 1});
+
+        if (_head.number() > 0){
+            pane.line = [_head.units[0].name()];
+        }
+        var _lib_units = _lib_units.index_roles();
+
+        pane.line = array_join(pane.line,_lib_units.create_plural_strings_array());
+
+        pane = instance_create(700, 180 - 48, obj_managment_panel);
+        pane.company = 0;
+        pane.manage = 11;
+        pane.header = 3;
+        pane.title = "HEADQUARTERS";
+        var _head = _command_company.get_from({group : SPECIALISTS_HEADS, max_wanted : 1});
+
+        if (_head.number() > 0){
+            pane.line = [_head.units[0].name()];
+        }
+        var _command_units = _command_company.index_roles();
+
+        pane.line = array_join(pane.line,_command_units.create_plural_strings_array())
 
         // Coordinates declaration and text initiation
         var xx = 25, yy = 400 - 48, t;
@@ -64,347 +115,6 @@ function scr_management(argument0) {
 
         // Generates the company if there are more than 10 companites
         // TODO improve logic or add extra romanNumerals to array TBD
-        if (obj_ini.companies > 10) {
-            xx = 25;
-            yy = 400 - 48 + 258;
-            t = "";
-
-            for (var i = 11; i <= obj_ini.companies; i++) {
-                t = scr_convert_company_to_string(i);
-
-                var pane = instance_create(xx, yy, obj_managment_panel);
-                pane.company = i;
-                pane.manage = i + 100;
-                pane.header = 1;
-                pane.title = t;
-
-                xx += 156;
-            }
-        }
-
-        for (var i = 1; i <= 50; i++) {
-            num[i] = 0;
-            nam[i] = "";
-        }
-
-        //TODO update all this old shit to use UnitIndex
-        // ****** MAIN PANEL ******
-        q = 0;
-        company = 0;
-        obj_controller.temp[71] = 11;
-
-        for (var i = 0; i < 50; i++) {
-            num[i] = 0;
-            nam[i] = "";
-        }
-        nam[2] = role_names[eROLE.HONOURGUARD];
-
-        for (var i = 0; i < array_length(obj_ini.name[0]); i++) {
-            unit = fetch_unit([0, i]);
-            if (unit.role() == obj_ini.role[100][eROLE.CHAPTERMASTER]) {
-                num[1] += 1;
-                if (nam[1] == "") {
-                    nam[1] = unit.name();
-                }
-            }
-            if (unit.role() == role_names[eROLE.HONOURGUARD]) {
-                num[2] += 1;
-            }
-        }
-
-        // if (num[2]=0) then nam[2]="Strategic Staff";// reserved for co-master alien or something
-
-        // if (num[2]>0) {
-        // 	nam[2]=string(num)+"x "+string(role_names[eROLE.HONOURGUARD]);
-        // 	nam[3]="Strategic Staff";
-        // 	num[3]=1;
-        // }
-
-        with (obj_managment_panel) {
-            if (manage != obj_controller.temp[71]) {
-                instance_deactivate_object(id);
-            }
-        }
-
-        if (num[1] > 0) {
-            q++;
-            obj_managment_panel.line[q] = string(nam[1]);
-            // obj_managment_panel.italic[q]=1;
-            obj_managment_panel.bold[q] = 1;
-        }
-        if (num[2] > 0) {
-            q++;
-            obj_managment_panel.line[q] = string_plural_count(nam[2], num[2], false);
-        }
-
-        // obj_managment_panel.italic[1]=1;
-        obj_managment_panel.bold[q] = 1;
-        instance_activate_object(obj_managment_panel);
-
-        // ll=0;ll2=0;repeat(200){ll2++;if (obj_ini.role[company,ll2]=role_names[eROLE.HONOURGUARD]) then ll++;}
-        // if (ll>0) then temp[3]=string(ll)+"x "+string(role_names[eROLE.HONOURGUARD]);
-
-        // ** Apothecarium **
-        q = 0;
-        company = 0;
-        obj_controller.temp[71] = 12;
-        for (var i = 0; i < 50; i++) {
-            num[i] = 0;
-            nam[i] = "";
-        }
-        nam[2] = role_names[eROLE.APOTHECARY];
-
-        // Ranks
-        nam[3] = string(role_names[eROLE.APOTHECARY]) + " Aspirant"; // nam[4]="Sister Hospitaler";
-
-        for (var i = 1; i <= 200; i++) {
-            unit = fetch_unit([0, i]);
-            if (unit.role() == "Master of the Apothecarion") {
-                num[1] += 1;
-                if (nam[1] == "") {
-                    nam[1] = unit.name();
-                }
-            }
-
-            if (unit.role() == role_names[eROLE.APOTHECARY]) {
-                num[2] += 1;
-            }
-
-            if (unit.role() == string(role_names[eROLE.APOTHECARY]) + " Aspirant") {
-                num[3] += 1;
-            }
-            // if (unit.role() == "Sister Hospitaler") then num[4] += 1;
-        }
-
-        with (obj_managment_panel) {
-            if (manage != obj_controller.temp[71]) {
-                instance_deactivate_object(id);
-            }
-        }
-
-        if (num[1] > 0) {
-            q++;
-            obj_managment_panel.line[q] = string(nam[1]);
-            // obj_managment_panel.italic[q]=1;
-            obj_managment_panel.bold[q] = 1;
-        }
-        if (num[2] > 0) {
-            q++;
-            obj_managment_panel.line[q] = string_plural_count(nam[2], num[2], false);
-        }
-        if (num[3] > 0) {
-            q++;
-            obj_managment_panel.line[q] = string_plural_count(nam[3], num[3], false);
-        }
-        // if (num[4]>0){q++;obj_managment_panel.line[q]=string(num[4])+"x "+string(nam[4]);}
-        instance_activate_object(obj_managment_panel);
-
-        // ** Reclusium **
-        q = 0;
-        company = 0;
-        obj_controller.temp[71] = 14;
-
-        for (var i = 0; i < 50; i++) {
-            num[i] = 0;
-            nam[i] = "";
-        }
-
-        nam[2] = role_names[eROLE.CHAPLAIN];
-
-        // Ranks
-        nam[3] = string(role_names[eROLE.CHAPLAIN]) + " Aspirant";
-
-        for (var i = 1; i <= 200; i++) {
-            unit = fetch_unit([0, i]);
-            if (unit.role() == "Master of Sanctity") {
-                num[1] += 1;
-                if (nam[1] == "") {
-                    nam[1] = unit.name();
-                }
-            }
-
-            if (unit.role() == role_names[eROLE.CHAPLAIN]) {
-                num[2] += 1;
-            }
-
-            if (unit.role() == string(role_names[eROLE.CHAPLAIN]) + " Aspirant") {
-                num[3] += 1;
-            }
-        }
-
-        with (obj_managment_panel) {
-            if (manage != obj_controller.temp[71]) {
-                instance_deactivate_object(id);
-            }
-        }
-
-        if (num[1] > 0) {
-            q++;
-            obj_managment_panel.line[q] = string(nam[1]);
-            // obj_managment_panel.italic[q]=1;
-            obj_managment_panel.bold[q] = 1;
-        }
-
-        // TODO add specific Space Wolves and successor chapter logic for Master of Sanctity
-        // if (global.chapter_name!="Space Wolves")
-
-        // Specific Iron Hands chapter logic
-        if (chapter_name != "Iron Hands") {
-            if (num[2] > 0) {
-                q++;
-                obj_managment_panel.line[q] = string_plural_count(nam[2], num[2], false);
-            }
-            if (num[3] > 0) {
-                q++;
-                obj_managment_panel.line[q] = string_plural_count(nam[3], num[3], false);
-            }
-        }
-        instance_activate_object(obj_managment_panel);
-
-        // ** Armoury **
-        q = 0;
-        company = 0;
-        obj_controller.temp[71] = 15;
-
-        for (var i = 0; i < 50; i++) {
-            num[i] = 0;
-            nam[i] = "";
-        }
-
-        nam[2] = role_names[eROLE.TECHMARINE];
-
-        // Ranks
-        nam[3] = string(role_names[eROLE.TECHMARINE]) + " Aspirant";
-        nam[4] = "Techpriest";
-
-        for (var i = 1; i <= 200; i++) {
-            unit = fetch_unit([0, i]);
-            if (unit.role() == "Forge Master") {
-                num[1] += 1;
-                if (nam[1] == "") {
-                    nam[1] = unit.name();
-                }
-            }
-
-            if (unit.role() == role_names[eROLE.TECHMARINE]) {
-                num[2] += 1;
-            }
-
-            if (unit.role() == string(role_names[eROLE.TECHMARINE]) + " Aspirant") {
-                num[3] += 1;
-            }
-
-            if (unit.role() == "Techpriest") {
-                num[4] += 1;
-            }
-        }
-
-        with (obj_managment_panel) {
-            if (manage != obj_controller.temp[71]) {
-                instance_deactivate_object(id);
-            }
-        }
-
-        if (num[1] > 0) {
-            q++;
-            obj_managment_panel.line[q] = string(nam[1]);
-            // obj_managment_panel.italic[q]=1;
-            obj_managment_panel.bold[q] = 1;
-        }
-
-        if (num[2] > 0) {
-            q++;
-            obj_managment_panel.line[q] = string_plural_count(nam[2], num[2], false);
-        }
-
-        if (num[3] > 0) {
-            q++;
-            obj_managment_panel.line[q] = string_plural_count(nam[3], num[3], false);
-        }
-
-        if (num[4] > 0) {
-            q++;
-            obj_managment_panel.line[q] = string_plural_count(nam[4], num[4], false);
-        }
-
-        instance_activate_object(obj_managment_panel);
-
-        // ** Librarium **
-        q = 0;
-        company = 0;
-        obj_controller.temp[71] = 13;
-        for (var i = 0; i < 50; i++) {
-            num[i] = 0;
-            nam[i] = "";
-        }
-
-        nam[2] = role_names[eROLE.LIBRARIAN];
-
-        // Ranks
-        nam[3] = "Codiciery";
-        nam[4] = "Lexicanum";
-        nam[5] = string(role_names[eROLE.LIBRARIAN]) + " Aspirant";
-
-        for (var i = 1; i <= 200; i++) {
-            unit = fetch_unit([0, i]);
-            if (unit.role() == "Chief " + string(role_names[eROLE.LIBRARIAN])) {
-                num[1] += 1;
-                if (nam[1] == "") {
-                    nam[1] = unit.name();
-                }
-            }
-
-            if (unit.role() == role_names[eROLE.LIBRARIAN]) {
-                num[2] += 1;
-            }
-
-            if (unit.role() == "Codiciery") {
-                num[3] += 1;
-            }
-
-            if (unit.role() == "Lexicanum") {
-                num[4] += 1;
-            }
-
-            if (unit.role() == string(role_names[eROLE.LIBRARIAN]) + " Aspirant") {
-                num[5] += 1;
-            }
-        }
-
-        with (obj_managment_panel) {
-            if (manage != obj_controller.temp[71]) {
-                instance_deactivate_object(id);
-            }
-        }
-
-        if (num[1] > 0) {
-            q++;
-            obj_managment_panel.line[q] = string(nam[1]);
-            // obj_managment_panel.italic[q]=1;
-            obj_managment_panel.bold[q] = 1;
-        }
-
-        if (num[2] > 0) {
-            q++;
-            obj_managment_panel.line[q] = string_plural_count(nam[2], num[2], false);
-        }
-
-        if (num[3] > 0) {
-            q++;
-            obj_managment_panel.line[q] = string_plural_count(nam[3], num[3], false);
-        }
-
-        if (num[4] > 0) {
-            q++;
-            obj_managment_panel.line[q] = string_plural_count(nam[4], num[4], false);
-        }
-
-        if (num[5] > 0) {
-            q++;
-            obj_managment_panel.line[q] = string_plural_count(nam[5], num[5], false);
-        }
-
-        instance_activate_object(obj_managment_panel);
 
         // ** Marines and vehicles per company and HQ by ranks **
         for (company = 1; company <= obj_ini.companies; company++) {
@@ -416,7 +126,7 @@ function scr_management(argument0) {
                 nam[i] = "";
             }
             // Indexing the names to nam array
-            // nam[1] = role_names[eROLE.CAPTAIN];
+            nam[1] = role_names[eROLE.CAPTAIN];
             nam[2] = role_names[eROLE.CHAPLAIN];
             nam[3] = role_names[eROLE.APOTHECARY];
             nam[4] = role_names[eROLE.TECHMARINE];


### PR DESCRIPTION
<!--- YOU CAN DELETE ALL OF THIS AFTER READING. -->

<!--- Make use of markdown lists. They make stuff much easier to read through. -->
<!--- Explain why and what your changes do in simple terms. --->
<!--- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. --->

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->

<!--- "Inspired" by the CDDA PR template -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored `scr_management` to build management panels with `UnitIndex` and added auto-scrolling lists for long content. This simplifies the UI code and makes panels faster and easier to extend.

- **New Features**
  - Auto-scroll for long panel lists with delay and bounce; only visible lines are drawn.
  - New `draw_lines` on `obj_managment_panel` supports bold/italic and optional truncation.
  - Role summaries come from `UnitIndex.create_plural_strings_array()` with hierarchical ordering and singular names for heads.

- **Refactors**
  - Rewrote HQ, Reclusium, Apothecarium, Armoury, and Librarium panels to use `collect_company(...).get_from(...).index_roles()`.
  - Company panels generated in a loop; lines built from role indexes; vehicles aggregated in a compact pass.
  - Simplified `Draw_64` to call `draw_lines`, removing repeated font/line logic.
  - Added `UnitIndex.role_count` and `UnitIndex.hierarchy_keys` helpers to support the new data flow.

<sup>Written for commit 54422bed324027273da6927e7593087b5735fc97. Summary will update on new commits. <a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1195?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

