### PR TITLE
fix: Nuke unused/broken exemplary & artificer item qualities

### DIFF
--- a/docs/CHEATCODES.md
+++ b/docs/CHEATCODES.md
@@ -21,7 +21,7 @@ Arguments with stars `(argument*)` can be omitted.
 - `stcpopulate` - spawns an STC fragment on all planets.
 - `additem "(name)" (number*) (quality*)` - spawns an item(s) with specified parameters.
     - `"(name)"` - item name in quotes, as it's written in the game. Case sensitive. "Bolter", "Power Axe", etc.
-    - `(quality*)` - possible values: standard, master_crafted, artificer, artifact, exemplary. Case insensitive.
+    - `(quality*)` - possible values: `standard`, `master_crafted`, `artifact`. Case insensitive.
 - `newapoth` - spawns an Apothecary (40 points, Needs testing).
 - `newpsyk` - spawns a Librarian (70 points, Needs testing).
 - `newtech` - spawns a Techmarine (400 points, Needs testing).

--- a/scripts/scr_add_item/scr_add_item.gml
+++ b/scripts/scr_add_item/scr_add_item.gml
@@ -10,9 +10,7 @@ function scr_add_item(_item_name, _quantity = 1, _quality = "any") {
 
     static qualities = [
         "standard",
-        "exemplary",
         "master_crafted",
-        "artificer",
         "artifact"
     ];
 

--- a/scripts/scr_equipment_struct/scr_equipment_struct.gml
+++ b/scripts/scr_equipment_struct/scr_equipment_struct.gml
@@ -474,9 +474,7 @@ function quality_string_conversion(quality_request) {
     var quality_conversions = {
         standard: "Normal",
         master_crafted: "Master Crafted",
-        artificer: "Articifer",
         artifact: "Artifact",
-        exemplary: "Exemplary",
     };
     if (struct_exists(quality_conversions, quality_request)) {
         return quality_conversions[$ quality_request];
@@ -502,12 +500,8 @@ function quality_color(_item_quality) {
             return draw_get_color();
         case "master_crafted":
             return #bf9340;
-        case "artificer":
-            return #bf4040;
         case "artifact":
             return #40bfbf;
-        case "exemplary":
-            return #80bf40;
     }
 }
 

--- a/scripts/scr_reequip_units/scr_reequip_units.gml
+++ b/scripts/scr_reequip_units/scr_reequip_units.gml
@@ -169,11 +169,6 @@ function set_up_equip_popup() {
                         str1: "Master Crafted",
                         font: fnt_40k_14b,
                         val: 1,
-                    },
-                    {
-                        str1: "Artificer",
-                        font: fnt_40k_14b,
-                        val: 2,
                     }
                 ];
                 quality_radio = new RadioSet(_quality_options, "", {max_width: 500, x1: 1040, y1: 318});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the unused and broken `exemplary` and `artificer` item qualities across code and docs, leaving only `standard`, `master_crafted`, and `artifact`. This prevents invalid spawn options and cleans up the quality UI and mappings.

- **Bug Fixes**
  - Updated `additem` cheat docs to list only `standard`, `master_crafted`, `artifact`.
  - Pruned quality lists and removed name/color mappings for deleted qualities.
  - Removed the extra quality radio option from the equipment popup.

<sup>Written for commit 61d4979b56aff74d501ff897f0632a8ba2ba8485. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1198?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

