### PR TITLE
fix: crash from launching crusades

### DIFF
--- a/scripts/scr_crusade/scr_crusade.gml
+++ b/scripts/scr_crusade/scr_crusade.gml
@@ -231,7 +231,7 @@ function launch_crusade() {
         }
         var travel_leeway = 10;
         if (_nearest_player_fleet.action == "move") {
-            travel_leeway += _nearest_player_fleet.eta;
+            travel_leeway += _nearest_player_fleet.action_eta;
         }
         var _eta = get_viable_travel_time(travel_leeway, _nearest_player_fleet.x, _nearest_player_fleet.y, star_id.x, star_id.y, _nearest_player_fleet, false);
         scr_popup("Crusade", $"Fellow Astartes legions are preparing to embark on a Crusade to a nearby sector.  Your forces are expected at {star_id.name}; {_eta} months from now your ships there shall begin their journey.", "crusade", "");


### PR DESCRIPTION
<!--- YOU CAN DELETE ALL OF THIS AFTER READING. -->

<!--- Make use of markdown lists. They make stuff much easier to read through. -->
<!--- Explain why and what your changes do in simple terms. --->
<!--- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. --->

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->

<!--- "Inspired" by the CDDA PR template -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed a crash when launching a Crusade when the nearest player fleet is moving by using `_nearest_player_fleet.action_eta` instead of `eta` for travel leeway. This prevents invalid property access and keeps the crusade ETA calculation correct.

<sup>Written for commit e78f91b4f4a887be6487ed44a5958b617a9732df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1200?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

