### PR TITLE
fix: Unit transfer sanity refactors

### DIFF
--- a/scripts/is_specialist/is_specialist.gml
+++ b/scripts/is_specialist/is_specialist.gml
@@ -11,6 +11,7 @@
 #macro SPECIALISTS_DREADNOUGHTS "dreadnoughts"
 #macro SPECIALISTS_CAPTAIN_CANDIDATES "captain_candidates"
 #macro SPECIALISTS_TRAINEES "trainees"
+#macro SPECIALISTS_BRANCHES "branches"
 #macro SPECIALISTS_HEADS "heads"
 
 /// @description Retrieves the active roles from the game, either from the obj_creation or obj_ini object.
@@ -44,6 +45,23 @@ function role_groups(group, include_trainee = false, include_heads = true) {
                 "Codiciery",
                 "Lexicanum",
                 _roles[eROLE.HONOURGUARD]
+            ];
+            if (include_trainee) {
+                _role_list = array_concat(_role_list, role_groups(SPECIALISTS_TRAINEES));
+            }
+            if (include_heads) {
+                _role_list = array_concat(_role_list, role_groups(SPECIALISTS_HEADS));
+            }
+            break;
+
+        case SPECIALISTS_BRANCHES:
+            _role_list = [
+                _roles[eROLE.CHAPLAIN],
+                _roles[eROLE.APOTHECARY],
+                _roles[eROLE.TECHMARINE],
+                _roles[eROLE.LIBRARIAN],
+                "Codiciery",
+                "Lexicanum",
             ];
             if (include_trainee) {
                 _role_list = array_concat(_role_list, role_groups(SPECIALISTS_TRAINEES));

--- a/scripts/scr_transfer_marines/scr_transfer_marines.gml
+++ b/scripts/scr_transfer_marines/scr_transfer_marines.gml
@@ -151,81 +151,85 @@ function transfer_marines() {
 }
 
 function set_up_transfer_popup() {
-    if (instance_number(obj_popup) == 0) {
-        var pip = instance_create(0, 0, obj_popup);
-        pip.type = 5.1;
-        pip.company = managing;
+    with (obj_controller) {
+        if (instance_number(obj_popup) == 0) {
+            var pip = instance_create(0, 0, obj_popup);
+            pip.type = 5.1;
+            pip.company = managing;
+    
+            var god = 0, _marine_count = 0, _vehicle_count = 0, checky = 0, check_number = 0;
+            var _min_exp = 9999999999;
+    
+            for (var f = 0; f < array_length(display_unit); f++) {
+                if (!(man_sel[f] == 1)) {
+                    continue;
+                }
+            
+                // Set unit_role from the first selected unit only
+                if (god == 0) {
+                    if (man[f] == "man") {
+                        god = 1;
+                        pip.unit_role = ma_role[f];
+                    } else if (man[f] == "vehicle") {
+                        god = 1;
+                        pip.unit_role = ma_role[f];
+                    }
+                }
+            
+                // Accumulate across ALL selected units
+                if (man[f] == "man") {
+                    _min_exp = min(_min_exp, ma_exp[f]);
+                    _marine_count += 1;
+                    checky = 1;
 
-        var god = 0, _marine_count = 0, _vehicle_count = 0, checky = 0, check_number = 0;
-        var _min_exp = 9999999999;
-        for (var f = 0; f < array_length(display_unit); f++) {
-            if (!(man_sel[f] == 1)) {
-                continue;
+                    var _current_role = ma_role[f];
+                    var _target_roles = [
+                        obj_ini.role[100][eROLE.CHAMPION],
+                        obj_ini.role[100][eROLE.LIBRARIAN],
+                        obj_ini.role[100][eROLE.CHAPLAIN],
+                        obj_ini.role[100][eROLE.APOTHECARY],
+                        obj_ini.role[100][eROLE.TECHMARINE]
+                    ];
+                    
+                    if (array_contains(_target_roles, _current_role)) {
+                        checky = 0;
+                    }
+            
+                    if (checky == 1) {
+                        check_number += 1;
+                    }
+                } else if (man[f] == "vehicle") {
+                    _vehicle_count += 1;
+                }
             }
-            if (god == 1) {
-                break;
+    
+            if (_vehicle_count > 1) {
+                pip.unit_role = "Vehicles";
             }
-            if ((god == 0) && (man[f] == "man")) {
-                god = 1;
-                pip.unit_role = ma_role[f];
-                _min_exp = min(_min_exp, ma_exp[f]);
+            if (_marine_count > 1) {
+                pip.unit_role = "Marines";
             }
-            if ((god == 0) && (man[f] == "vehicle")) {
-                god = 1;
-                pip.unit_role = ma_role[f];
+            if ((_marine_count > 0) && (_vehicle_count > 0)) {
+                pip.unit_role = "Units";
             }
-
-            if (man[f] == "man") {
-                _marine_count += 1;
-                checky = 1;
-                if (ma_role[f] == obj_ini.role[100][7]) {
-                    checky = 0;
+            pip.units = _marine_count + _vehicle_count;
+            pip.min_exp = _min_exp;
+            if (_marine_count > 0 && check_number > 0 && !command_set[1]) {
+                cooldown = 8000;
+                with (pip) {
+                    instance_destroy();
                 }
-                if (ma_role[f] == obj_ini.role[100][14]) {
-                    checky = 0;
+            } else {
+                with (pip) {
+                    cancel_button = new UnitButtonObject({x1: 1061, y1: 491, style: "pixel", label: "Cancel"});
+                    main_slate = new DataSlate({style: "decorated", XX: 1006, YY: 143, set_width: true, width: 571, height: 350});
+                    // Inside with(pip), 'min_exp' refers to pip.min_exp
+                    if (unit_role == "Vehicles") {
+                        min_exp = -1; // sentinel to bypass gating only for vehicles
+                    }
+                    target_company_radio(min_exp);
+                    transfer_button = new UnitButtonObject({x1: 1450, y1: 491, style: "pixel", label: "Transfer"});
                 }
-                if (ma_role[f] == obj_ini.role[100][15]) {
-                    checky = 0;
-                }
-                if (ma_role[f] == obj_ini.role[100][16]) {
-                    checky = 0;
-                }
-                if (ma_role[f] == obj_ini.role[100][17]) {
-                    checky = 0;
-                }
-                if (checky == 1) {
-                    check_number += 1;
-                }
-            } else if (man[f] == "vehicle") {
-                _vehicle_count += 1;
-            }
-        }
-        if (_vehicle_count > 1) {
-            pip.unit_role = "Vehicles";
-        }
-        if (_marine_count > 1) {
-            pip.unit_role = "Marines";
-        }
-        if ((_marine_count > 0) && (_vehicle_count > 0)) {
-            pip.unit_role = "Units";
-        }
-        pip.units = _marine_count + _vehicle_count;
-        pip.min_exp = _min_exp;
-        if (_marine_count > 0 && check_number > 0 && !command_set[1]) {
-            cooldown = 8000;
-            with (pip) {
-                instance_destroy();
-            }
-        } else {
-            with (pip) {
-                cancel_button = new UnitButtonObject({x1: 1061, y1: 491, style: "pixel", label: "Cancel"});
-                main_slate = new DataSlate({style: "decorated", XX: 1006, YY: 143, set_width: true, width: 571, height: 350});
-                // Inside with(pip), 'min_exp' refers to pip.min_exp
-                if (unit_role == "Vehicles") {
-                    min_exp = -1; // sentinel to bypass gating only for vehicles
-                }
-                target_company_radio(min_exp);
-                transfer_button = new UnitButtonObject({x1: 1450, y1: 491, style: "pixel", label: "Transfer"});
             }
         }
     }

--- a/scripts/scr_transfer_marines/scr_transfer_marines.gml
+++ b/scripts/scr_transfer_marines/scr_transfer_marines.gml
@@ -2,14 +2,15 @@ function draw_popup_transfer() {
     main_slate.draw_with_dimensions();
     draw_set_color(CM_GREEN_COLOR);
     draw_text(1292, 145, "Transferring");
-
     draw_set_font(fnt_40k_12);
-    if (((unit_role != obj_ini.role[100][17]) || (obj_controller.command_set[1] != 0)) && (unit_role != "Lexicanum") && (unit_role != "Codiciery")) {
-        companies_select.draw();
-    }
+
+    companies_select.draw();
+    target_comp = 0;
+
     if (companies_select.changed) {
         target_comp = companies_select.selection_val("val");
     }
+
     if (cancel_button.draw()) {
         instance_destroy();
     }
@@ -160,15 +161,11 @@ function set_up_transfer_popup() {
         var _marine_count = 0;
         var _vehicle_count = 0;
         var _min_exp = 99999999;
-        var _disallowed = false;
+        var _allowed = true;
         var _selected_role = "None";
-        var _allowed_roles = [
-            obj_ini.role[100][eROLE.CHAMPION],
-            obj_ini.role[100][eROLE.LIBRARIAN],
-            obj_ini.role[100][eROLE.CHAPLAIN],
-            obj_ini.role[100][eROLE.APOTHECARY],
-            obj_ini.role[100][eROLE.TECHMARINE]
-        ];
+
+        // I think command_set[1] is Allow Astartes Transfer chapter option;
+        var _allow_transfers = command_set[1];
 
         for (var f = 0; f < array_length(display_unit); f++) {
             if (!(man_sel[f] == 1)) {
@@ -192,12 +189,16 @@ function set_up_transfer_popup() {
                 _min_exp = min(_min_exp, ma_exp[f]);
                 _marine_count += 1;
 
-                if (!_disallowed && !array_contains(_allowed_roles, _role)) {
-                    _disallowed = true;
+                if (!_allow_transfers && _allowed && !is_specialist(_role, SPECIALISTS_BRANCHES, true, false)) {
+                    _allowed = false;
                 }
             } else if (_type == "vehicle") {
                 _vehicle_count += 1;
             }
+        }
+
+        if (!_allowed) {
+            exit;
         }
 
         if ((_marine_count > 0) && (_vehicle_count > 0)) {
@@ -212,20 +213,17 @@ function set_up_transfer_popup() {
             _min_exp = -1;
         }
 
-        // I think command_set[1] is Allow Astartes Transfer chapter option;
-        if (!_disallowed || command_set[1]) {
-            var pip = instance_create(0, 0, obj_popup);
-            with (pip) {
-                type = 5.1;
-                company = managing;
-                unit_role = _selected_role;
-                units = _marine_count + _vehicle_count;
-                min_exp = _min_exp;
-                cancel_button = new UnitButtonObject({x1: 1061, y1: 491, style: "pixel", label: "Cancel"});
-                main_slate = new DataSlate({style: "decorated", XX: 1006, YY: 143, set_width: true, width: 571, height: 350});
-                target_company_radio(min_exp);
-                transfer_button = new UnitButtonObject({x1: 1450, y1: 491, style: "pixel", label: "Transfer"});
-            }
+        var pip = instance_create(0, 0, obj_popup);
+        with (pip) {
+            type = 5.1;
+            company = obj_controller.managing;
+            unit_role = _selected_role;
+            units = _marine_count + _vehicle_count;
+            min_exp = _min_exp;
+            cancel_button = new UnitButtonObject({x1: 1061, y1: 491, style: "pixel", label: "Cancel"});
+            main_slate = new DataSlate({style: "decorated", XX: 1006, YY: 143, set_width: true, width: 571, height: 350});
+            target_company_radio(min_exp);
+            transfer_button = new UnitButtonObject({x1: 1450, y1: 491, style: "pixel", label: "Transfer"});
         }
     }
 }

--- a/scripts/scr_transfer_marines/scr_transfer_marines.gml
+++ b/scripts/scr_transfer_marines/scr_transfer_marines.gml
@@ -5,7 +5,6 @@ function draw_popup_transfer() {
     draw_set_font(fnt_40k_12);
 
     companies_select.draw();
-    target_comp = 0;
 
     if (companies_select.changed) {
         target_comp = companies_select.selection_val("val");
@@ -222,6 +221,7 @@ function set_up_transfer_popup() {
             min_exp = _min_exp;
             cancel_button = new UnitButtonObject({x1: 1061, y1: 491, style: "pixel", label: "Cancel"});
             main_slate = new DataSlate({style: "decorated", XX: 1006, YY: 143, set_width: true, width: 571, height: 350});
+            target_comp = 0; // HQ button is selected from the start, this is needed so it actually works without deselection;
             target_company_radio(min_exp);
             transfer_button = new UnitButtonObject({x1: 1450, y1: 491, style: "pixel", label: "Transfer"});
         }

--- a/scripts/scr_transfer_marines/scr_transfer_marines.gml
+++ b/scripts/scr_transfer_marines/scr_transfer_marines.gml
@@ -151,85 +151,80 @@ function transfer_marines() {
 }
 
 function set_up_transfer_popup() {
-    with (obj_controller) {
-        if (instance_number(obj_popup) == 0) {
-            var pip = instance_create(0, 0, obj_popup);
-            pip.type = 5.1;
-            pip.company = managing;
-    
-            var god = 0, _marine_count = 0, _vehicle_count = 0, checky = 0, check_number = 0;
-            var _min_exp = 9999999999;
-    
-            for (var f = 0; f < array_length(display_unit); f++) {
-                if (!(man_sel[f] == 1)) {
-                    continue;
-                }
-            
-                // Set unit_role from the first selected unit only
-                if (god == 0) {
-                    if (man[f] == "man") {
-                        god = 1;
-                        pip.unit_role = ma_role[f];
-                    } else if (man[f] == "vehicle") {
-                        god = 1;
-                        pip.unit_role = ma_role[f];
-                    }
-                }
-            
-                // Accumulate across ALL selected units
-                if (man[f] == "man") {
-                    _min_exp = min(_min_exp, ma_exp[f]);
-                    _marine_count += 1;
-                    checky = 1;
+    if (instance_number(obj_popup) > 0) {
+        exit;
+    }
 
-                    var _current_role = ma_role[f];
-                    var _target_roles = [
-                        obj_ini.role[100][eROLE.CHAMPION],
-                        obj_ini.role[100][eROLE.LIBRARIAN],
-                        obj_ini.role[100][eROLE.CHAPLAIN],
-                        obj_ini.role[100][eROLE.APOTHECARY],
-                        obj_ini.role[100][eROLE.TECHMARINE]
-                    ];
-                    
-                    if (array_contains(_target_roles, _current_role)) {
-                        checky = 0;
-                    }
-            
-                    if (checky == 1) {
-                        check_number += 1;
-                    }
-                } else if (man[f] == "vehicle") {
-                    _vehicle_count += 1;
+    with (obj_controller) {
+        var _first = true;
+        var _marine_count = 0;
+        var _vehicle_count = 0;
+        var _min_exp = 99999999;
+        var _disallowed = false;
+        var _selected_role = "None";
+        var _allowed_roles = [
+            obj_ini.role[100][eROLE.CHAMPION],
+            obj_ini.role[100][eROLE.LIBRARIAN],
+            obj_ini.role[100][eROLE.CHAPLAIN],
+            obj_ini.role[100][eROLE.APOTHECARY],
+            obj_ini.role[100][eROLE.TECHMARINE]
+        ];
+
+        for (var f = 0; f < array_length(display_unit); f++) {
+            if (!(man_sel[f] == 1)) {
+                continue;
+            }
+
+            var _type = man[f];
+            var _role = ma_role[f];
+        
+            if (_first) {
+                if (_type == "man") {
+                    _first = false;
+                    _selected_role = _role;
+                } else if (_type == "vehicle") {
+                    _first = false;
+                    _selected_role = _role;
                 }
             }
-    
-            if (_vehicle_count > 1) {
-                pip.unit_role = "Vehicles";
-            }
-            if (_marine_count > 1) {
-                pip.unit_role = "Marines";
-            }
-            if ((_marine_count > 0) && (_vehicle_count > 0)) {
-                pip.unit_role = "Units";
-            }
-            pip.units = _marine_count + _vehicle_count;
-            pip.min_exp = _min_exp;
-            if (_marine_count > 0 && check_number > 0 && !command_set[1]) {
-                cooldown = 8000;
-                with (pip) {
-                    instance_destroy();
+        
+            if (_type == "man") {
+                _min_exp = min(_min_exp, ma_exp[f]);
+                _marine_count += 1;
+
+                if (!_disallowed && !array_contains(_allowed_roles, _role)) {
+                    _disallowed = true;
                 }
-            } else {
-                with (pip) {
-                    cancel_button = new UnitButtonObject({x1: 1061, y1: 491, style: "pixel", label: "Cancel"});
-                    main_slate = new DataSlate({style: "decorated", XX: 1006, YY: 143, set_width: true, width: 571, height: 350});
-                    // Inside with(pip), 'min_exp' refers to pip.min_exp
-                    if (unit_role == "Vehicles") {
-                        min_exp = -1; // sentinel to bypass gating only for vehicles
-                    }
-                    target_company_radio(min_exp);
-                    transfer_button = new UnitButtonObject({x1: 1450, y1: 491, style: "pixel", label: "Transfer"});
-                }
+            } else if (_type == "vehicle") {
+                _vehicle_count += 1;
+            }
+        }
+
+        if ((_marine_count > 0) && (_vehicle_count > 0)) {
+            _selected_role = "Units";
+        } else if (_vehicle_count > 1) {
+            _selected_role = "Vehicles";
+        } else if (_marine_count > 1) {
+            _selected_role = "Marines";
+        }
+
+        if (_marine_count == 0) {
+            _min_exp = -1;
+        }
+
+        // I think command_set[1] is Allow Astartes Transfer chapter option;
+        if (!_disallowed || command_set[1]) {
+            var pip = instance_create(0, 0, obj_popup);
+            with (pip) {
+                type = 5.1;
+                company = managing;
+                unit_role = _selected_role;
+                units = _marine_count + _vehicle_count;
+                min_exp = _min_exp;
+                cancel_button = new UnitButtonObject({x1: 1061, y1: 491, style: "pixel", label: "Cancel"});
+                main_slate = new DataSlate({style: "decorated", XX: 1006, YY: 143, set_width: true, width: 571, height: 350});
+                target_company_radio(min_exp);
+                transfer_button = new UnitButtonObject({x1: 1450, y1: 491, style: "pixel", label: "Transfer"});
             }
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes transfer popup grouping and gating for mixed marine/vehicle selections. Makes company selection stable and prevents duplicate popups.

- **Bug Fixes**
  - Accumulates marine/vehicle counts and min XP; labels use the first role or switch to "Marines", "Vehicles", or "Units"; pure vehicle selections set `min_exp = -1`; company selector is always visible.
  - Gating: exits early when transfers are disabled and the selection includes non-branch marines; allows Chaplain, Apothecary, Techmarine, Librarian (incl. Lexicanum/Codiciery, trainees) via `is_specialist(SPECIALISTS_BRANCHES, include_trainee=true)`.
  - Avoids duplicate popups by exiting if an `obj_popup` already exists.
  - Stabilizes company selection: initializes `target_comp = 0` (HQ) when the popup opens and updates it only when the selector changes.

<sup>Written for commit 441eeb0130fb25c6c841c43cf027c002ef9cc4fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1202?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

