### PR TITLE
Merge branch development into main

### DIFF
--- a/ChapterMaster.yyp
+++ b/ChapterMaster.yyp
@@ -792,6 +792,7 @@
     {"id":{"name":"scr_ChapterTraits","path":"scripts/scr_ChapterTraits/scr_ChapterTraits.yy",},},
     {"id":{"name":"scr_cheatcode","path":"scripts/scr_cheatcode/scr_cheatcode.yy",},},
     {"id":{"name":"scr_check_equip","path":"scripts/scr_check_equip/scr_check_equip.yy",},},
+    {"id":{"name":"UpdateChecker","path":"scripts/UpdateChecker/UpdateChecker.yy",},},
     {"id":{"name":"scr_choose_weighted","path":"scripts/scr_choose_weighted/scr_choose_weighted.yy",},},
     {"id":{"name":"scr_civil_roster","path":"scripts/scr_civil_roster/scr_civil_roster.yy",},},
     {"id":{"name":"scr_clean","path":"scripts/scr_clean/scr_clean.yy",},},

--- a/ChapterMaster.yyp
+++ b/ChapterMaster.yyp
@@ -2,9 +2,9 @@
   "$GMProject":"v1",
   "%Name":"ChapterMaster",
   "AudioGroups":[
-    {"$GMAudioGroup":"v1","%Name":"audiogroup_default","exportDir":"","name":"audiogroup_default","resourceType":"GMAudioGroup","resourceVersion":"2.0","targets":-1,},
-    {"$GMAudioGroup":"v1","%Name":"audiogroup_sfx","exportDir":"","name":"audiogroup_sfx","resourceType":"GMAudioGroup","resourceVersion":"2.0","targets":-1,},
-    {"$GMAudioGroup":"v1","%Name":"audiogroup_music","exportDir":"","name":"audiogroup_music","resourceType":"GMAudioGroup","resourceVersion":"2.0","targets":-1,},
+    {"$GMAudioGroup":"","%Name":"audiogroup_default","name":"audiogroup_default","resourceType":"GMAudioGroup","resourceVersion":"2.0","targets":-1,},
+    {"$GMAudioGroup":"","%Name":"audiogroup_sfx","name":"audiogroup_sfx","resourceType":"GMAudioGroup","resourceVersion":"2.0","targets":-1,},
+    {"$GMAudioGroup":"","%Name":"audiogroup_music","name":"audiogroup_music","resourceType":"GMAudioGroup","resourceVersion":"2.0","targets":-1,},
   ],
   "configs":{
     "children":[],
@@ -776,6 +776,7 @@
     {"id":{"name":"scr_apothecary_ship","path":"scripts/scr_apothecary_ship/scr_apothecary_ship.yy",},},
     {"id":{"name":"scr_array_functions","path":"scripts/scr_array_functions/scr_array_functions.yy",},},
     {"id":{"name":"scr_audience","path":"scripts/scr_audience/scr_audience.yy",},},
+    {"id":{"name":"scr_autosave","path":"scripts/scr_autosave/scr_autosave.yy",},},
     {"id":{"name":"scr_battle_allies","path":"scripts/scr_battle_allies/scr_battle_allies.yy",},},
     {"id":{"name":"scr_battle_sort","path":"scripts/scr_battle_sort/scr_battle_sort.yy",},},
     {"id":{"name":"scr_bionics_count","path":"scripts/scr_bionics_count/scr_bionics_count.yy",},},

--- a/objects/obj_controller/Alarm_1.gml
+++ b/objects/obj_controller/Alarm_1.gml
@@ -639,4 +639,7 @@ if (instance_exists(obj_temp7)) {
     scr_star_ownership(false);
 }*/
 
-// x=0;y=0; 
+// Save immediately after world gen
+if (global.load == -1 && global.settings.autosave == true) {
+    alarm[2] = 5;
+}

--- a/objects/obj_controller/Alarm_2.gml
+++ b/objects/obj_controller/Alarm_2.gml
@@ -1,6 +1,1 @@
-// initialize combat
-menu = 0;
-instance_create(0, 0, obj_ncombat);
-
-exit;
-//instance_create(0,0,obj_fleet); 
+scr_autosave();

--- a/objects/obj_main_menu/Create_0.gml
+++ b/objects/obj_main_menu/Create_0.gml
@@ -1,6 +1,7 @@
 fade_alpha = (global.returned > 0) ? 0 : 1.0;
 title_alpha = 0;
 cooldown = 0;
+update_blink_visible = false;
 
 audio_stop_all();
 global.current_music = audio_play_sound(snd_prologue, 10, true, 0.1);

--- a/objects/obj_main_menu/Draw_0.gml
+++ b/objects/obj_main_menu/Draw_0.gml
@@ -22,13 +22,25 @@ if (global.game_version != "unknown version") {
     draw_text(1598, 858, _version_line);
 }
 
-draw_set_halign(fa_left);
-draw_set_alpha(1);
-
 if (point_and_click([1400, 830, 1600, 900])) {
     clipboard_set_text($"{_build_date_line}\n{_version_line}");
     audio_play_sound(snd_click_small, 0, false);
 }
+
+// Update notification
+if (variable_global_exists("version_checker") && global.version_checker.update_available) {
+    draw_set_font(fnt_cul_14);
+    draw_set_color(update_blink_visible ? c_yellow : c_gray);
+    draw_text(1598, 790, $"Update: {global.version_checker.latest_version}\nClick to open download page");
+
+    if (point_and_click([1400, 780, 1600, 830])) {
+        url_open(global.version_checker.latest_release_url);
+        audio_play_sound(snd_click_small, 0, false);
+    }
+}
+
+draw_set_halign(fa_left);
+draw_set_alpha(1);
 
 if (fade_alpha > 0) {
     draw_set_alpha(fade_alpha);

--- a/objects/obj_main_menu/Step_0.gml
+++ b/objects/obj_main_menu/Step_0.gml
@@ -13,3 +13,6 @@ if (fade_alpha <= 0.5) {
         obj_cursor.image_alpha = title_alpha;
     }
 }
+
+// Blink update notification every 600ms
+update_blink_visible = floor(current_time / 600) % 2 == 0;

--- a/objects/obj_persistent/Other_62.gml
+++ b/objects/obj_persistent/Other_62.gml
@@ -1,0 +1,5 @@
+// Update check handler
+if (variable_global_exists("version_checker") && is_struct(global.version_checker)) {
+    global.version_checker.handle(async_load);
+    exit;
+}

--- a/objects/obj_persistent/obj_persistent.yy
+++ b/objects/obj_persistent/obj_persistent.yy
@@ -7,6 +7,7 @@
     {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":72,"eventType":7,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
     {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":63,"eventType":7,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
     {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":3,"eventType":7,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
+    {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":62,"eventType":7,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
   ],
   "managed":true,
   "name":"obj_persistent",

--- a/scripts/UpdateChecker/UpdateChecker.gml
+++ b/scripts/UpdateChecker/UpdateChecker.gml
@@ -1,0 +1,69 @@
+/// @desc Checks GitHub for newer game releases. Create with `new UpdateChecker()`.
+/// Encapsulates HTTP request lifecycle and update state.
+function UpdateChecker() constructor {
+    request_id = undefined;
+    repo = "Adeptus-Dominus/ChapterMaster";
+
+    /// Latest version tag from GitHub (e.g. "main/2026-05-28-2011")
+    latest_version = "";
+    /// URL to the release page on GitHub
+    latest_release_url = "";
+    /// Whether a newer version than current is available
+    update_available = false;
+
+    /// @desc Fires HTTP request to GitHub releases API.
+    /// Called once at startup after global.game_version is set.
+    static check = function() {
+        var _url = $"https://api.github.com/repos/{repo}/releases/latest";
+        var _headers = ds_map_create();
+        _headers[? "Accept"] = "application/json";
+        _headers[? "User-Agent"] = "ChapterMaster-UpdateChecker";
+        request_id = http_request(_url, "GET", _headers, "");
+        ds_map_destroy(_headers);
+    };
+
+    /// @desc Handles async HTTP response. Called from HTTP async event.
+    /// @param {Id.DsMap} _async_map async_load map
+    /// @return {Bool} true if update available, false otherwise
+    static handle = function(_async_map) {
+        if (ds_map_find_value(_async_map, "id") != request_id) {
+            return false;
+        }
+
+        var _http_status = ds_map_find_value(_async_map, "http_status");
+        if (_http_status != 200) {
+            LOGGER.error($"HTTP {_http_status}, skipping");
+            update_available = false;
+            return update_available;
+        }
+
+        var _result = ds_map_find_value(_async_map, "result");
+        if (_result == "") {
+            LOGGER.error("Empty response body, skipping");
+            update_available = false;
+            return update_available;
+        }
+
+        var _json;
+        try {
+            _json = json_parse(_result);
+        } catch (_e) {
+            LOGGER.error("json_parse failed, skipping", _e);
+            update_available = false;
+            return update_available;
+        }
+
+        var _latest_tag = _json[$ "tag_name"] ?? "";
+        if (_latest_tag == "") {
+            LOGGER.error("No tag_name in response, skipping");
+            update_available = false;
+            return update_available;
+        }
+
+        update_available = _latest_tag != $"{global.game_version}/{global.build_date}";
+        latest_version = _latest_tag;
+        latest_release_url = _json[$ "html_url"] ?? "";
+
+        return update_available;
+    };
+}

--- a/scripts/UpdateChecker/UpdateChecker.yy
+++ b/scripts/UpdateChecker/UpdateChecker.yy
@@ -1,0 +1,13 @@
+{
+  "$GMScript":"v1",
+  "%Name":"UpdateChecker",
+  "isCompatibility":false,
+  "isDnD":false,
+  "name":"UpdateChecker",
+  "parent":{
+    "name":"Constructors",
+    "path":"folders/Scripts/Constructors.yy",
+  },
+  "resourceType":"GMScript",
+  "resourceVersion":"2.0",
+}

--- a/scripts/__init_external/__init_external.gml
+++ b/scripts/__init_external/__init_external.gml
@@ -100,6 +100,11 @@ function __init_external() {
         global.commit_hash = _commit_hash;
     }
 
+    if (global.game_version != "compiled") {
+        global.version_checker = new UpdateChecker();
+        global.version_checker.check();
+    }
+
     global.weapons = json_to_gamemaker(working_directory + "\\data\\weapons.json", json_parse);
     global.gear = {
         "armour": json_to_gamemaker(working_directory + "\\data\\armour.json", json_parse),

--- a/scripts/scr_autosave/scr_autosave.gml
+++ b/scripts/scr_autosave/scr_autosave.gml
@@ -1,0 +1,17 @@
+/// @description Trigger an autosave using obj_saveload
+function scr_autosave() {
+    try {
+        if (!instance_exists(obj_saveload)) {
+            instance_create(0, 0, obj_saveload);
+        }
+
+        obj_saveload.autosaving = true;
+        scr_save(0, 0, true);
+    } catch (_e) {
+        handle_exception(_e);
+    } finally {
+        with (obj_saveload) {
+            instance_destroy();
+        }
+    }
+}

--- a/scripts/scr_autosave/scr_autosave.yy
+++ b/scripts/scr_autosave/scr_autosave.yy
@@ -1,0 +1,13 @@
+{
+  "$GMScript":"v1",
+  "%Name":"scr_autosave",
+  "isCompatibility":false,
+  "isDnD":false,
+  "name":"scr_autosave",
+  "parent":{
+    "name":"Scripts",
+    "path":"folders/Scripts.yy",
+  },
+  "resourceType":"GMScript",
+  "resourceVersion":"2.0",
+}

--- a/scripts/scr_controller_helpers/scr_controller_helpers.gml
+++ b/scripts/scr_controller_helpers/scr_controller_helpers.gml
@@ -437,21 +437,14 @@ function scr_end_turn() {
                 }*/
 
                 if (ok == 1) {
+                    obj_controller.menu = 0;
+                    obj_controller.zui = 0;
+                    obj_controller.invis = false;
+
                     if (global.settings.autosave == true) {
-                        // Autosave
+                        // Autosave every 10 turns
                         if (obj_controller.turn % 10 == 0) {
-                            // save every 10 turns
-                            if (!instance_exists(obj_saveload)) {
-                                instance_create(0, 0, obj_saveload);
-                            }
-                            obj_saveload.autosaving = true;
-                            scr_save(0, 0, true);
-                            obj_controller.menu = 0;
-                            obj_controller.zui = 0;
-                            obj_controller.invis = false;
-                            with (obj_saveload) {
-                                instance_destroy();
-                            }
+                            scr_autosave();
                         }
                     }
                     obj_controller.end_turn_insights = {};

--- a/scripts/scr_creation/scr_creation.gml
+++ b/scripts/scr_creation/scr_creation.gml
@@ -299,14 +299,19 @@ function scr_creation(slide_num) {
     if (slide_num == eCREATION_SLIDES.CHAPTERMASTER) {
         if (chapter_master_name != "" && chapter_master_melee != 0 && chapter_master_ranged != 0 && chapter_master_specialty != 0) {
             cooldown = 9999;
-            instance_create(0, 0, obj_ini);
-            audio_stop_all();
-            audio_play_sound(snd_royal, 0, true);
-            audio_sound_gain(snd_royal, 1, 5000);
 
             if (founding == ePROGENITOR.RANDOM) {
                 founding = irandom_range(ePROGENITOR.NONE, ePROGENITOR.RAVEN_GUARD);
             }
+
+            if (custom == eCHAPTER_TYPE.CUSTOM && global.chapter_id != eCHAPTERS.UNKNOWN) {
+                scr_save_chapter(global.chapter_id);
+            }
+
+            instance_create(0, 0, obj_ini);
+            audio_stop_all();
+            audio_play_sound(snd_royal, 0, true);
+            audio_sound_gain(snd_royal, 1, 5000);
 
             if (founding == eCHAPTERS.SALAMANDERS || global.chapter_id == eCHAPTERS.SALAMANDERS) {
                 obj_ini.skin_color = 1;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an update notice to the main menu and autosave at key moments to reduce lost progress. Centralizes autosave in a helper and hardens the update checker.

- **New Features**
  - Update check on startup (non-compiled builds): `UpdateChecker` queries GitHub releases, stores latest version and URL. Main menu shows a blinking “Update” banner; click opens the release page.
  - Autosave triggers:
    - Right after world generation/new game start.
    - Every 10 turns when `global.settings.autosave` is enabled.
    - After the last slide of custom chapter creation.

- **Refactors**
  - Added `scr_autosave()` with try/finally to manage `obj_saveload`, call `scr_save`, and clean up; replaced duplicated save code (world-gen alarm, end-turn).
  - `UpdateChecker` now handles HTTP async in `obj_persistent`, sets request headers, and includes basic error handling.

<sup>Written for commit 7ae60e72b843d722a71e4f60dcc72075e21fe531. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1203?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

