### PR TITLE
style: Undefined safety in fleets

### DIFF
--- a/scripts/scr_fleet_functions/scr_fleet_functions.gml
+++ b/scripts/scr_fleet_functions/scr_fleet_functions.gml
@@ -20,9 +20,7 @@ function random_sector_exit_point() {
 
 /// @self Asset.GMObject.obj_en_fleet|Asset.GMObject.obj_p_fleet
 function in_room(object = undefined) {
-    if (object == undefined) {
-        object = self;
-    }
+	object ??= self;
     return !(object.x < 0 || object.x > room_width || object.y < 0 || object.y > room_height);
 }
 

--- a/scripts/scr_player_fleet_functions/scr_player_fleet_functions.gml
+++ b/scripts/scr_player_fleet_functions/scr_player_fleet_functions.gml
@@ -20,9 +20,7 @@ function fleet_has_roles(fleet = "none", roles) {
 
 function fleet_engaged(fleet = undefined) {
     var _engaged = false;
-    if (fleet == undefined) {
-        fleet = self;
-    }
+	fleet ??= self;
     var _fleet_action = fleet.action;
     if (_fleet_action != "" && _fleet_action != "move") {
         //don't inspect if engaged in non negotiable actions


### PR DESCRIPTION
Just another quick code correction.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use nullish coalescing assignment in `in_room` and `fleet_engaged` to default to `self` when the argument is undefined. This simplifies the code with no behavior changes.

<sup>Written for commit 243befabb9c202cda895d29c4cc8ee8017e8659a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

