### PR TITLE
fix: Minor function call corrections

### DIFF
--- a/scripts/UpdateChecker/UpdateChecker.gml
+++ b/scripts/UpdateChecker/UpdateChecker.gml
@@ -52,7 +52,7 @@ function UpdateChecker() constructor {
         try {
             _json = json_parse(_result);
         } catch (_e) {
-            LOGGER.error("json_parse failed, skipping", _e);
+            LOGGER.error($"json_parse failed, skipping {_e}");
             update_available = false;
             return update_available;
         }

--- a/scripts/scr_Table/scr_Table.gml
+++ b/scripts/scr_Table/scr_Table.gml
@@ -22,8 +22,6 @@ function Table(data) constructor {
 
     move_data_to_current_scope(data);
 
-    update();
-
     static update = function(data) {
         move_data_to_current_scope(data);
         w = 0;
@@ -59,6 +57,8 @@ function Table(data) constructor {
         }
     };
 
+    update(data);
+	
     static row_method = function(_row, _row_entered) {
         if (!_row_entered) {
             return;

--- a/scripts/scr_buttons/scr_buttons.gml
+++ b/scripts/scr_buttons/scr_buttons.gml
@@ -1181,7 +1181,7 @@ function ToggleButton(data = {}) constructor {
     //make true to run clicked() within draw sequence
     clicked_check_default = false;
 
-    update = function(data) {
+    update = function(data = {}) {
         if (is_struct(data)) {
             move_data_to_current_scope(data, true);
         }

--- a/scripts/scr_dialogue/scr_dialogue.gml
+++ b/scripts/scr_dialogue/scr_dialogue.gml
@@ -1194,7 +1194,7 @@ function scr_dialogue(diplo_keyphrase, data = {}) {
             }
             if (diplo_keyphrase == "denounced") {
                 if (faction_justmet == 1) {
-                    alter_dispositions(diplomacy, -5);
+                    alter_dispositions([[eFACTION.IMPERIUM, -5]]);
                     faction_justmet = 0;
                 }
                 rando = choose(1, 2, 3);

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -1104,12 +1104,12 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
 
         if (scr_has_adv("Warp Touched")) {
             if (_psionics_roll < 170) {
-                var _second_roll = roll_dice(_dice_count, 100, "high");
+                var _second_roll = roll_dice_chapter(_dice_count, 100, "high");
                 _psionics_roll = _second_roll > _psionics_roll ? _second_roll : _psionics_roll;
             }
         } else if (scr_has_disadv("Psyker Intolerant")) {
             if (_psionics_roll >= 170) {
-                var _second_roll = roll_dice(_dice_count, 100, "low");
+                var _second_roll = roll_dice_chapter(_dice_count, 100, "low");
                 _psionics_roll = _second_roll < _psionics_roll ? _second_roll : _psionics_roll;
             }
         }


### PR DESCRIPTION
I loaded my save game and maybe i'm just tired but I think the button animations are smoother now? Besides that no noticeable regressions 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect parameters and call order so UI and rules behave correctly. Tables initialize with provided data, toggles handle empty updates, psionics rerolls use chapter dice, denouncement applies Imperium -5, and JSON parse errors log cleanly.

- **Bug Fixes**
  - Initialize tables with provided data: call update(data) once at the end of Table constructor; remove earlier call.
  - Default data = {} in ToggleButton.update() so empty calls work.
  - Use roll_dice_chapter(..., "high"/"low") for psionics rerolls.
  - Apply denouncement penalty via alter_dispositions([[eFACTION.IMPERIUM, -5]]).
  - Log JSON parse failures with a single interpolated message in LOGGER.error.

<sup>Written for commit b14358bc871d7b218ca952d0e7646b9bdf7a2d80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

