### PR TITLE
refactor: Init optional method properties as undefined

### DIFF
--- a/scripts/scr_buttons/scr_buttons.gml
+++ b/scripts/scr_buttons/scr_buttons.gml
@@ -356,7 +356,7 @@ function UnitButtonObject(data = false) constructor {
     keystroke = false;
     active = true;
     tooltip = "";
-    bind_method = "";
+    bind_method = undefined;
     bind_scope = false;
     set_width = false;
     style = "standard";
@@ -884,7 +884,7 @@ function MultiSelect(options_array, title, data = {}) constructor {
     x_gap = 10;
     y_gap = 5;
     standard_loc_data();
-    on_change = false;
+    on_change = undefined;
     active_col = CM_GREEN_COLOR;
     inactive_col = c_gray;
     max_width = 0;

--- a/scripts/scr_controller_helpers/scr_controller_helpers.gml
+++ b/scripts/scr_controller_helpers/scr_controller_helpers.gml
@@ -61,7 +61,7 @@ function scr_menu_clear_up(specific_area_function) {
     return false;
 }
 
-function scr_change_menu(wanted_menu, specific_area_function = false) {
+function scr_change_menu(wanted_menu, specific_area_function = undefined) {
     var continue_sequence = false;
     if (obj_controller.menu_lock) {
         return false;


### PR DESCRIPTION
Good practice to initialize variables to the Data Type you intend for them to be. My save game loads just fine, as expected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set callback defaults to undefined instead of false or empty strings to match expected types and avoid calling non-functions.

- **Refactors**
  - scr_buttons.gml: UnitButtonObject.bind_method and MultiSelect.on_change now default to undefined.
  - scr_controller_helpers.gml: scr_change_menu’s specific_area_function now defaults to undefined.

<sup>Written for commit 7ddc38f3d47d79aa74412acafa3f2499f960e0fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

