### PR TITLE
ci(builds): Only build on feat | fix commits

### DIFF
--- a/.github/workflows/release_dev.yml
+++ b/.github/workflows/release_dev.yml
@@ -76,18 +76,18 @@ jobs:
           # Use sed to indent messages for clarity in logs
           echo "$ALL_MSGS" | sed 's/^/  /'
 
-          # only build if at least one message does NOT match exclude pattern
+          # Only build if at least one message matches include pattern
           # The -v option inverts the match; -E enables extended regex; -q suppresses output.
           # The overall command exits successfully (0) if a non-matching line is found.
-          EXCLUDE="^(docs|chore|style|ci)"
-          if echo "$ALL_MSGS" | grep -vEq "$EXCLUDE"; then
-            echo "Found at least one commit message not matching the exclude pattern '$EXCLUDE'."
+
+          INCLUDE="^(feat|fix)"
+          if echo "$ALL_MSGS" | grep -vEq "$INCLUDE"; then
+            echo "Found at least one commit message matching the include pattern '$INCLUDE'."
             echo "Build needed."
             echo "needed=true" >> $GITHUB_OUTPUT
           else
-            echo "All new commit messages match the exclude pattern '$EXCLUDE'."
+            echo "None new commit messages match the include pattern '$INCLUDE'."
             echo "Skipping build."
-            # needed is already defaulted to false.
           fi
 
   prepare_release:

--- a/.github/workflows/release_dev.yml
+++ b/.github/workflows/release_dev.yml
@@ -81,12 +81,12 @@ jobs:
           # The overall command exits successfully (0) if a non-matching line is found.
 
           INCLUDE="^(feat|fix)"
-          if echo "$ALL_MSGS" | grep -vEq "$INCLUDE"; then
+          if echo "$ALL_MSGS" | grep -Eq "$INCLUDE"; then
             echo "Found at least one commit message matching the include pattern '$INCLUDE'."
             echo "Build needed."
             echo "needed=true" >> $GITHUB_OUTPUT
           else
-            echo "None new commit messages match the include pattern '$INCLUDE'."
+            echo "No new commit messages match the include pattern '$INCLUDE'."
             echo "Skipping build."
           fi
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update `release_dev` workflow to build only when at least one new commit message starts with "feat" or "fix". Switch to a positive include check (`^(feat|fix)`) with clearer logs to skip builds for non-feature/fix changes.

<sup>Written for commit 3742b858c91616897feea97a205f4351325e2f89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

