### PR TITLE
feat: Glorianas via jsons

### DIFF
--- a/ChapterMaster.yyp
+++ b/ChapterMaster.yyp
@@ -576,6 +576,7 @@
     {"$GMIncludedFile":"","%Name":"pauldron.png","CopyToMask":-1,"filePath":"datafiles/main/role_markings/ultramarines","name":"pauldron.png","resourceType":"GMIncludedFile","resourceVersion":"2.0",},
     {"$GMIncludedFile":"","%Name":"base_squads.json","CopyToMask":-1,"filePath":"datafiles/main/squads","name":"base_squads.json","resourceType":"GMIncludedFile","resourceVersion":"2.0",},
     {"$GMIncludedFile":"","%Name":"company_squad_builds.json","CopyToMask":-1,"filePath":"datafiles/main/squads","name":"company_squad_builds.json","resourceType":"GMIncludedFile","resourceVersion":"2.0",},
+    {"$GMIncludedFile":"","%Name":"lightning_warriors.json","CopyToMask":-1,"filePath":"datafiles/main/squads","name":"lightning_warriors.json","resourceType":"GMIncludedFile","resourceVersion":"2.0",},
     {"$GMIncludedFile":"","%Name":"version.json","CopyToMask":-1,"filePath":"datafiles/main","name":"version.json","resourceType":"GMIncludedFile","resourceVersion":"2.0",},
     {"$GMIncludedFile":"","%Name":"data.json","CopyToMask":-1,"filePath":"datafiles/main/visual_sets/Company_marks_roman_right_knee","name":"data.json","resourceType":"GMIncludedFile","resourceVersion":"2.0",},
     {"$GMIncludedFile":"","%Name":"12.png","CopyToMask":-1,"filePath":"datafiles/main/visual_sets/Company_marks_roman_right_knee/one","name":"12.png","resourceType":"GMIncludedFile","resourceVersion":"2.0",},

--- a/datafiles/data/armour.json
+++ b/datafiles/data/armour.json
@@ -86,7 +86,7 @@
             "master_crafted": 25,
             "standard": 20
         },
-        "description": "PLACEHOLDER",
+        "description": "Once the standard Dreadnought pattern when Primarchs walked the stars and Legions conquered worlds, now one of the closest-guarded secrets in Mechanicum tech enclaves. With an Atomantic arc-reactor at its heart that gave it superior speed, strength and even shielding capabilities, it was far superior to any other Dreadnought pattern save for its maintenance demands and the possible meltdown of the reactor.",
         "hp_mod": {
             "artifact": 50,
             "master_crafted": 35,

--- a/datafiles/data/mobility.json
+++ b/datafiles/data/mobility.json
@@ -9,13 +9,42 @@
         "description": "A robust bike that can propel an Astartes at very high speeds. Boasts highly responsive controls that allow for fluid movement on the battlefield and respectable Twin-Linked Bolters for offensive action.",
         "hp_mod": {
             "artifact": 35,
-            "master_crafted": 25,
+            "master_crafted": 30,
             "standard": 25
+        },
+        "melee_mod":{
+            "artifact": 30,
+            "master_crafted": 25,
+            "standard": 20
         },
         "second_profiles": [
             "Twin Linked Bolters"
         ],
         "value": 35,
+        "requires_to_forge": ["combi_1"]
+    },
+    "Attack Bike": {
+        "abbreviation": "At Bike",
+        "damage_resistance_mod": {
+            "artifact": 10,
+            "master_crafted": 10,
+            "standard": 5
+        },
+        "description": "A robust bike that can propel an Astartes at very high speeds. Boasts highly responsive controls that allow for fluid movement on the battlefield and respectable Twin-Linked Bolters for offensive action. Sports an additional sidecar with a heavy weapon of choice.",
+        "hp_mod": {
+            "artifact": 50,
+            "master_crafted": 40,
+            "standard": 35
+        },
+        "melee_mod":{
+            "artifact": 20,
+            "master_crafted": 15,
+            "standard": 10
+        },
+        "second_profiles": [
+            "Twin Linked Bolters"
+        ],
+        "value": 95,
         "requires_to_forge": ["combi_1"]
     },
     "Conversion Beamer Pack": {

--- a/datafiles/main/chapters/1.JSON
+++ b/datafiles/main/chapters/1.JSON
@@ -1815,7 +1815,7 @@
       "role": "Black Knight",
       "loadout": {
         "required": {
-          "wep1": ["Chainsword", 4],
+          "wep1": ["Power Sword", 4],
           "wep2": ["Bolt Pistol", 2],
           "mobi": ["Bike", 4]
         },

--- a/datafiles/main/chapters/10.JSON
+++ b/datafiles/main/chapters/10.JSON
@@ -158,6 +158,7 @@
         * use negative numbers to subtract ships
         */
         "extra_ships": {
+            "gloriana": 0,
             "battle_barges": 0,
             "gladius": 0,
             "strike_cruisers": 0,
@@ -184,9 +185,9 @@
             "codiciery": 0,
             "lexicanum": 0,
             "terminator": 0,
-            "assault": 10,
+            "assault": 0,
             "veteran": 0,
-            "devastator": -10
+            "devastator": 0
         },
         /**
         * * Default Marine strength

--- a/datafiles/main/chapters/11.JSON
+++ b/datafiles/main/chapters/11.JSON
@@ -156,6 +156,7 @@
         * * Stacks with advantages/disadvantages
         */
         "extra_ships": {
+            "gloriana": 0,
             "battle_barges": 0,
             "gladius": 0,
             "strike_cruisers": 0,

--- a/datafiles/main/chapters/12.JSON
+++ b/datafiles/main/chapters/12.JSON
@@ -143,6 +143,7 @@
         * * Stacks with advantages/disadvantages
         */
         "extra_ships": {
+            "gloriana": 0,
             "battle_barges": 0,
             "gladius": 0,
             "strike_cruisers": 0,

--- a/datafiles/main/chapters/13.JSON
+++ b/datafiles/main/chapters/13.JSON
@@ -144,6 +144,7 @@
         * * Stacks with advantages/disadvantages
         */
         "extra_ships": {
+            "gloriana": 0,
             "battle_barges": -1,
             "gladius": -3,
             "strike_cruisers": -4,

--- a/datafiles/main/chapters/14.JSON
+++ b/datafiles/main/chapters/14.JSON
@@ -147,6 +147,7 @@
         * * Stacks with advantages/disadvantages
         */
         "extra_ships": {
+            "gloriana": 0,
             "battle_barges": -3,
             "gladius": -5,
             "strike_cruisers": -1,

--- a/datafiles/main/chapters/15.JSON
+++ b/datafiles/main/chapters/15.JSON
@@ -161,6 +161,7 @@
         * * Stacks with advantages/disadvantages
         */
         "extra_ships": {
+            "gloriana": 0,
             "battle_barges": 0,
             "gladius": 0,
             "strike_cruisers": 0,

--- a/datafiles/main/chapters/16.JSON
+++ b/datafiles/main/chapters/16.JSON
@@ -143,6 +143,7 @@
         * * Stacks with advantages/disadvantages
         */
         "extra_ships": {
+            "gloriana": 0,
             "battle_barges": 0,
             "gladius": -4,
             "strike_cruisers": 0,

--- a/datafiles/main/chapters/17.JSON
+++ b/datafiles/main/chapters/17.JSON
@@ -188,6 +188,7 @@
         * * Stacks with advantages/disadvantages
         */
         "extra_ships": {
+            "gloriana": 0,
             "battle_barges": 0,
             "gladius": 0,
             "strike_cruisers": 0,

--- a/datafiles/main/chapters/2.JSON
+++ b/datafiles/main/chapters/2.JSON
@@ -147,6 +147,7 @@
         * use negative numbers to subtract ships
         */
         "extra_ships": {
+            "gloriana": 0,
             "battle_barges": 0,
             "gladius": 0,
             "strike_cruisers": 0,

--- a/datafiles/main/chapters/3.JSON
+++ b/datafiles/main/chapters/3.JSON
@@ -162,6 +162,7 @@
         * use negative numbers to subtract ships
         */
         "extra_ships": {
+            "gloriana": 0,
             "battle_barges": 0,
             "gladius": 0,
             "strike_cruisers": 0,

--- a/datafiles/main/chapters/31.JSON
+++ b/datafiles/main/chapters/31.JSON
@@ -137,6 +137,7 @@
         * use negative numbers to subtract ships
         */
         "extra_ships": {
+            "gloriana": 0,
             "battle_barges": 1,
             "gladius": 0,
             "strike_cruisers": 0,

--- a/datafiles/main/chapters/32.JSON
+++ b/datafiles/main/chapters/32.JSON
@@ -69,6 +69,13 @@
             ]
         },
         "flagship_name": "Legerin Heqite",
+        "extra_ships": {
+            "gloriana": 0,
+            "battle_barges": 1,
+            "gladius": 0,
+            "strike_cruisers": 0,
+            "hunters": 0
+        },
         "custom_roles": {
             "chaplain": {
                 "name": "Orator"

--- a/datafiles/main/chapters/33.json
+++ b/datafiles/main/chapters/33.json
@@ -182,6 +182,7 @@
         * * Stacks with advantages/disadvantages
         */
         "extra_ships": {
+            "gloriana": 0,
             "battle_barges": -1,
             "strike_cruisers": -4,
             "gladius": 0,

--- a/datafiles/main/chapters/34.json
+++ b/datafiles/main/chapters/34.json
@@ -49,6 +49,7 @@
     "fleet_type": 1.0,
     "strength": 5.0,
     "extra_ships": {
+      "gloriana": 0,
       "battle_barges": 0.0,
       "gladius": 0.0,
       "strike_cruisers": 0.0,

--- a/datafiles/main/chapters/34.json
+++ b/datafiles/main/chapters/34.json
@@ -139,7 +139,7 @@
     "culture_styles": [],
     "home_planets": 1.0,
     "flagship_name": "Victus",
-    "monastary_name": "",
+    "monastery_name": "",
     "advantages": [
       "",
       "Assault Doctrine",

--- a/datafiles/main/chapters/35.json
+++ b/datafiles/main/chapters/35.json
@@ -174,6 +174,7 @@
         * * Stacks with advantages/disadvantages
         */
         "extra_ships": {
+            "gloriana": 0,
             "battle_barges": 0,
             "gladius": 0,
             "strike_cruisers": 0,
@@ -243,9 +244,9 @@
             "captain": {
                 "name": "Warleader"
             },
-            "sergeant": {
+            /*"sergeant": {
                 "name": "Pride Leader"
-            },
+            },*/
             "chaplain": {
                 "name": "Deathspeaker"
             },

--- a/datafiles/main/chapters/36.json
+++ b/datafiles/main/chapters/36.json
@@ -181,6 +181,7 @@
         * * Stacks with advantages/disadvantages
         */
         "extra_ships": {
+            "gloriana": 0,
             "battle_barges": 0,
             "gladius": 0,
             "strike_cruisers": 0,

--- a/datafiles/main/chapters/37.json
+++ b/datafiles/main/chapters/37.json
@@ -190,6 +190,7 @@
         * * Stacks with advantages/disadvantages
         */
         "extra_ships": {
+            "gloriana": 0,
             "battle_barges": 0,
             "gladius": 0,
             "strike_cruisers": 0,

--- a/datafiles/main/chapters/4.JSON
+++ b/datafiles/main/chapters/4.JSON
@@ -145,6 +145,7 @@
         * use negative numbers to subtract ships
         */
         "extra_ships": {
+            "gloriana": 0,
             "battle_barges": 1,
             "gladius": 0,
             "strike_cruisers": 0,

--- a/datafiles/main/chapters/5.JSON
+++ b/datafiles/main/chapters/5.JSON
@@ -846,6 +846,7 @@
         * use negative numbers to subtract ships
         */
         "extra_ships": {
+            "gloriana": 0,
             "battle_barges": 0,
             "gladius": 0,
             "strike_cruisers": 0,

--- a/datafiles/main/chapters/6.JSON
+++ b/datafiles/main/chapters/6.JSON
@@ -149,6 +149,7 @@
         * use negative numbers to subtract ships
         */
         "extra_ships": {
+            "gloriana": 0,
             "battle_barges": 0,
             "gladius": 0,
             "strike_cruisers": 0,

--- a/datafiles/main/chapters/7.JSON
+++ b/datafiles/main/chapters/7.JSON
@@ -171,6 +171,7 @@
         * use negative numbers to subtract ships
         */
         "extra_ships": {
+            "gloriana": 0,
             "battle_barges": 0,
             "gladius": 0,
             "strike_cruisers": 0,

--- a/datafiles/main/chapters/8.JSON
+++ b/datafiles/main/chapters/8.JSON
@@ -154,6 +154,7 @@
         * use negative numbers to subtract ships
         */
         "extra_ships": {
+            "gloriana": 0,
             "battle_barges": 0,
             "gladius": 0,
             "strike_cruisers": 0,

--- a/datafiles/main/chapters/9.JSON
+++ b/datafiles/main/chapters/9.JSON
@@ -147,6 +147,7 @@
         * use negative numbers to subtract ships
         */
         "extra_ships": {
+            "gloriana": 0,
             "battle_barges": 0,
             "gladius": 0,
             "strike_cruisers": 0,

--- a/datafiles/main/chapters/template.JSON
+++ b/datafiles/main/chapters/template.JSON
@@ -1,309 +1,1489 @@
 {
-    "chapter": {
-        "id": 1,
-        "name": "Chapter Name",
-        "flavor": "Chapter Lore",
-        "origin": 3, // 1 - Founding, 2 - Successor, 3 - Other/non-canon/fanmade, 4 - Custom
-        "points": 150,
-        "founding": 0, // The id of the founding chapter, 0 for unknown or none, 10 for random
-        "splash": 1, // in \images\creation\chapters\splash folder, the img number, 1 being Dark Angels etc.
-        "icon_name": "unknown",
-        "fleet_type": 1, // 1= Homeworld, 2 = Fleet based, 3 = Penitent
-        "strength": 5, // 1-10
-        "purity": 5, // 1-10
-        "stability": 50, // 1-99
-        "cooperation": 5, // 1-10
-        "homeworld_exists": 1, // 1 = true
-        "recruiting_exists": 1, // 1 = true
-        "homeworld_rule": 1, // 1 = Govenor, 2 = Countries, 3 = Personal Rule
-        "homeworld": "Hive", // one of  "Lava" "Desert" "Forge" "Hive" "Death" "Agri" "Feudal" "Temperate" "Ice" "Dead" "Shrine"
-        "homeworld_name": "", // Homeworld Planet name, leave blank to autogenerate
-        "recruiting": "Death", // one of "Lava" "Desert" "Forge" "Hive" "Death" "Agri" "Feudal" "Temperate" "Ice" "Dead" "Shrine"
-        "recruiting_name": "", // Recruiting Planet name, leave blank to autogenerate
-        "discipline": "librarius", // one of 'default' 'biomancy' 'pyromancy' 'telekinesis' 'rune_magic'
-        "aspirant_trial": "SURVIVAL", // one of "BLOODDUEL" "HUNTING" "SURVIVAL" "EXPOSURE" "KNOWLEDGE" "CHALLENGE"  "APPRENTICESHIP" 
-        "advantages": [
-            "", // leave the first entry blank for now
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            ""
+  "chapter":
+  {
+    "id": 0, //number for your JSON file to be referenced in game files
+    "name": "", //name of the chapter
+    "flavor": "", //the short description that appears on popup when you hover over a chapter image
+    "battle_cry": "", //this is where you cry. I mean this is where you say what are you crying about. I mean... fuck it just type shit here to scream at people
+    "origin": "", //[1] Founding [2] Successor [3] Other [4] Custom
+    "points": 0, //creation points, feel free to cheat here for more wild stuff in custom if you don't like doing it via files
+    "founding": 0, //ID of the progenitor chapter, as per fiels in datafiles/main/chapters
+    "successors": 0, //write how many successors your chapter has. Go bonkers. Show them you got the seed to have 666 successors
+    "splash": 0, //the more artsy image on the left side of selection screen. Highly advised to use the same number as chapter ID
+    "icon_name": "", //name for the chapter icon you'll be using. Standing 
+    "fleet_type": 0, //[1] Homeworld [2] Fleetbased [3] Penitent
+    "strength": 0, //1-10
+    "purity": 0, //1-10
+    "stability": 0, //1-99
+    "cooperation": 0, //1-10
+    "homeworld_exists:": 1, //only is there for an obscure bit of code, but to avoid bugs and crashes keep it as is until we fix it
+    "recruiting_exists": 1, //same here
+    "home_warp": 1, //[0] low/no connections [1] connected [2] warp hub
+    "home_planets": 1, //how many planets in home system, [0]=1 [3]=4
+    "homeworld": "Forge", //Homeworld planet type "Lava" "Desert" "Forge" "Hive" "Death" "Agri" "Feudal" "Temperate" "Ice" "Dead" "Shrine"
+    "homeworld_rule": 1, //[1] Governor [2] Semi-independent [3] Direct Rule
+    "home_spawn_loc": 1, //unsure which is it, probably 0=fringe, 1=central
+    "homeworld_name": "", //name of the homeworld
+    "monastery_name": "", //name of the F-M structure on the homeplanet.
+    "recruiting": "", //Recruiting world planet type "Lava" "Desert" "Forge" "Hive" "Death" "Agri" "Feudal" "Temperate" "Ice" "Dead" "Shrine"
+    "recruiting_name": "", //recruiting world name
+    "recruit_home_relationship": 1, //[0] same planet [1] same system [2] different system
+    "discipline": "librarius", //one of 'default' 'biomancy' 'pyromancy' 'telekinesis' 'rune_magic'
+    "aspirant_trial": 5, //[0]"BLOODDUEL" [1]"HUNTING" [2]"SURVIVAL" [3]"EXPOSURE" [4]"KNOWLEDGE" [5]"CHALLENGE" [6]"APPRENTICESHIP"
+    "advantages": //Self-Explanatory
+      [
+        "", //first blank cause reasons
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+    "disadvantages": //S-E
+      [
+        "", //first blank cause reasons
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+    "mutations": //defines which mutations are present
+      {
+        "mucranoid":0,
+        "zygote":0,
+        "secretions":0,
+        "doomed":0,
+        "occulobe":0,
+        "membrane":0,
+        "lyman":0,
+        "betchers":0,
+        "ossmodula":0,
+        "omophagea":0,
+        "voice":0,
+        "catalepsean":0,
+        "preomnor":0
+      },
+    "disposition":
+      [
+        0,  //nothing, probably self
+        0,  //Progenitor
+        0,  //Imperium
+        0,  //Admech
+        0,  //=][=
+        0,  //Ecclesiarchy
+        0,  //Astartes
+        0   //Nothing
+      ],
+    "colors": //main or default colours for your chapter. Check a pasted table or scr_colors_initialize.gml for the color array
+      {
+        "special": 0, // 0 - normal, 1 - Breastplate, 2 - Vertical, 3 - Quadrant
+        "main": "Dark Red",
+        "weapon": "Dark Red",
+        "pauldron_l": "Dark Red",
+        "pauldron_r": "Dark Red",
+        "trim": "Dark Gold",
+        "secondary": "Dark Gold",
+        "lens": "Red"
+      },
+    "culture_styles":   //write in the styles you want
+      [
+        ""
+      ],
+    "chapter_master":
+      {
+        "name": "", //name for your chapter master, leave blank for random
+        "traits": //currently kinda not working, he's guaranteed to have Lead by Example though
+        [
+          ""
         ],
-        "disadvantages": [
-            "", // leave the first entry blank for now
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            ""
-        ],
-        "colors": {
-            "main": "Black",
-            "secondary": "Black",
-            "pauldron_r": "Black",
-            "pauldron_l": "Black",
-            "trim": "Silver",
-            "lens": "Red",
-            "weapon": "Dark Red",
-            "special": 0, // 0 - normal, 1 - Breastplate, 2 - Vertical, 3 - Quadrant
-            //"trim_on": 0 // 0 no, 1 yes for pauldron trim colours. Trim colour will still be used for certain complex livery items 
+        "specialty": 1, //1 Leader, 2 Champion, 3 Psyker
+        "melee": 1, //[1]twin power fists [2]twin lighting claws [3]Relic blade [4]Thunder Hammer [5]Power Sword [6]Power axe [7]Eviscerator [8]Force staff
+        "ranged": 1, //[1]boltstorm gauntlet [2]Infernus pistol [3]Plasma pistol [4]Plasma gun [5]MC Heavy Bolter [6]Mc Meltagun [7]Storm Shield
+        "armour": "", //default is Artificer, dont' need to put anything unless you want something different
+        "gear": "" //default is Iron Halo, same as above
+      },
+    "artifact": //copy and paste the template below as many times as you like
+      [
+        {
+          "name": "Artifact Name", //the most holy name of your long schlong weapon
+          "description": "Artefact Lore", //write fun stuff
+          "base_weapon_type": "Power Sword", //doesn't matter if it's armour, gear, mobi or anything else, you always use base_weapon_type to define it
+          "slot": "wep1" //leave empty if you want it to be stored in the Librarium without assignment
+        }
+      ],
+    "names":
+      {
+        //Chapter Staff
+        "hchaplain": "", // Head Chaplain
+        "clibrarian": "", // Chief Librarian
+        "fmaster": "", // Forge Master
+        "hapothecary": "", // Head Apothecary
+        //Company Captains 1 - 10
+        "honorcapt": "",
+        "watchmaster": "",
+        "arsenalmaster": "",
+        "admiral": "",
+        "marchmaster": "",
+        "ritesmaster": "",
+        "victualler": "",
+        "lordexec": "",
+        "relmaster": "",
+        "recruiter": ""
+      },
+    "company_titles":
+      [
+        "", //leave blank cause reasons
+        "", //1st Company
+        "", //2nd
+        "", //3rd
+        "", //4th
+        "", //5th
+        "", //6th
+        "", //7th
+        "", //8th
+        "", //9th
+        ""  //10th
+      ],
+    "equal_specialists": 0,// 0 if no, 1 if yes. If yes, will distribute specialist roles like Assaults and Devastators equally between companies. Otherwise all Assaults go in Company 8 and all Devastators in Company 9
+    "flagship_name":  "Flagship Name", // leave blank to autogenerate
+    "load_to_ships": 
+      {
+        "escort_load": 2, // 0 no, 2 yes, 1 doesnt do anything :)
+        "split_scouts": 0, // 0 no, 1 yes. If yes, splits scouts between ships equally. Otherwise all scouts are kept on the homeworld.
+        "split_vets": 0 // 0 no, 1 yes. If yes, all veterans are distrubuted equally between ships. Otherwise all veterans are kept in the flagship
+      },
+    "full_liveries":
+      [
+        {//[1] Chapter Master
+          "weapon_primary":11,
+          "metallic_trim":11,
+          "weapon_secondary":20,
+          "is_changed":true,
+          "left_arm":20,
+          "left_backpack":20,
+          "left_chest":20,
+          "right_arm":20,
+          "right_backpack":20,
+          "right_chest":20,
+          "left_hand":11,
+          "left_head":20,
+          "left_leg_knee":20,
+          "right_hand":11,
+          "eye_lense":9,
+          "right_head":20,
+          "left_leg_lower":20,
+          "left_leg_upper":20,
+          "left_muzzle":20,
+          "right_leg_knee":20,
+          "left_pauldron":11,
+          "right_leg_lower":20,
+          "right_leg_upper":20,
+          "right_muzzle":20,
+          "right_pauldron":11,
+          "left_thorax":20,
+          "left_trim":20,
+          "right_thorax":20,
+          "right_trim":20,
+          "company_marks":0,
+          "company_marks_loc":0
         },
-        "names": {
-            //Chapter Staff
-            "hchaplain": "", // Head Chaplain
-            "clibrarian": "", // Chief Librarian
-            "fmaster": "", // Forge Master
-            "hapothecary": "", // Head Apothecary
-            //Company Captains 1 - 10
-            "honorcapt": "",
-            "watchmaster": "",
-            "arsenalmaster": "",
-            "admiral": "",
-            "marchmaster": "",
-            "ritesmaster": "",
-            "victualler": "",
-            "lordexec": "",
-            "relmaster": "",
-            "recruiter": ""
+        {//[2] Brown dude, so far unknown what is this defining
+          "weapon_primary":11,
+          "metallic_trim":20,
+          "weapon_secondary":20,
+          "is_changed":true,
+          "left_arm":14,
+          "left_backpack":14,
+          "left_chest":14,
+          "right_arm":14,
+          "right_backpack":14,
+          "right_chest":14,
+          "left_hand":14,
+          "left_head":14,
+          "left_leg_knee":14,
+          "right_hand":14,
+          "eye_lense":22,
+          "right_head":14,
+          "left_leg_lower":14,
+          "left_leg_upper":14,
+          "left_muzzle":14,
+          "right_leg_knee":14,
+          "left_pauldron":14,
+          "right_leg_lower":14,
+          "right_leg_upper":14,
+          "right_muzzle":14,
+          "right_pauldron":14,
+          "left_thorax":0,
+          "left_trim":20,
+          "right_thorax":0,
+          "right_trim":20,
+          "company_marks":0,
+          "company_marks_loc":0
         },
-        "battle_cry": "For the Emperor!",
-        "equal_specialists": 0, // 0 if no, 1 if yes. If yes, will distribute specialist roles like Assaults and Devastators equally between companies. Otherwise all Assaults go in Company 8 and all Devastators in Company 9
-        "load_to_ships": {
-            "escort_load": 2, // 0 no, 2 yes, 1 doesnt do anything :)
-            "split_scouts": 0, // 0 no, 1 yes. If yes, splits scouts between ships equally. Otherwise all scouts are kept on the homeworld.
-            "split_vets": 0 // 0 no, 1 yes. If yes, all veterans are distrubuted equally between ships. Otherwise all veterans are kept in the flagship
+        {//[3] Honour Guard
+          "weapon_primary":11,
+          "metallic_trim":20,
+          "weapon_secondary":20,
+          "is_changed":true,
+          "left_arm":20,
+          "left_backpack":20,
+          "left_chest":20,
+          "right_arm":20,
+          "right_backpack":20,
+          "right_chest":20,
+          "left_hand":20,
+          "left_head":20,
+          "left_leg_knee":20,
+          "right_hand":20,
+          "eye_lense":9,
+          "right_head":20,
+          "left_leg_lower":20,
+          "left_leg_upper":20,
+          "left_muzzle":20,
+          "right_leg_knee":20,
+          "left_pauldron":20,
+          "right_leg_lower":20,
+          "right_leg_upper":20,
+          "right_muzzle":20,
+          "right_pauldron":20,
+          "left_thorax":0,
+          "left_trim":20,
+          "right_thorax":0,
+          "right_trim":20,
+          "company_marks":0,
+          "company_marks_loc":0
         },
-        "successors": 0, //total number of successor chapters
-        "mutations": {
-            "preomnor": 0,
-            "voice": 0,
-            "doomed": 0,
-            "lyman": 0,
-            "omophagea": 0,
-            "ossmodula": 0,
-            "membrane": 0,
-            "zygote": 0,
-            "betchers": 0,
-            "catalepsean": 0,
-            "secretions": 0,
-            "occulobe": 0,
-            "mucranoid": 0
+        {//[4] Veteran
+          "weapon_primary":11,
+          "metallic_trim":20,
+          "weapon_secondary":20,
+          "is_changed":true,
+          "left_arm":20,
+          "left_backpack":11,
+          "left_chest":8,
+          "right_arm":20,
+          "right_backpack":11,
+          "right_chest":8,
+          "left_hand":11,
+          "left_head":20,
+          "left_leg_knee":20,
+          "right_hand":11,
+          "eye_lense":9,
+          "right_head":20,
+          "left_leg_lower":11,
+          "left_leg_upper":11,
+          "left_muzzle":20,
+          "right_leg_knee":20,
+          "left_pauldron":11,
+          "right_leg_lower":11,
+          "right_leg_upper":11,
+          "right_muzzle":20,
+          "right_pauldron":11,
+          "left_thorax":0,
+          "left_trim":20,
+          "right_thorax":0,
+          "right_trim":20,
+          "company_marks":0,
+          "company_marks_loc":0
         },
-        "disposition": [
-            0, // nothing
-            0, // Progenitor faction
-            50, // Imperium
-            50, // Admech
-            50, //Inquisition
-            50, // Ecclesiarchy
-            50, // Astartes
-            0 // nothing
-        ],
-        "chapter_master": {
-            "name": "",
-            "specialty": 1, //1 Leader, 2 Champion, 3 Psyker,
-            "melee": 1, // 1 twin power fists ... 8 force staff
-            "ranged": 1, // 1 boltstorm gauntlets ... 7 storm shield
-            // All chapter masters have the trait `Lead by Example` by default
-            "traits": [
-                ""
-            ],
-            "gear": "",
-            "mobi": "",
-            "armour": "" // default is Artificer armour, only needed to set if changing to something else.
+        {//[5] Terminator
+          "weapon_primary":11,
+          "metallic_trim":20,
+          "weapon_secondary":20,
+          "is_changed":true,
+          "left_arm":11,
+          "left_backpack":11,
+          "left_chest":11,
+          "right_arm":11,
+          "right_backpack":11,
+          "right_chest":11,
+          "left_hand":20,
+          "left_head":8,
+          "left_leg_knee":11,
+          "right_hand":20,
+          "eye_lense":9,
+          "right_head":8,
+          "left_leg_lower":11,
+          "left_leg_upper":11,
+          "left_muzzle":20,
+          "right_leg_knee":20,
+          "left_pauldron":20,
+          "right_leg_lower":11,
+          "right_leg_upper":11,
+          "right_muzzle":20,
+          "right_pauldron":20,
+          "left_thorax":0,
+          "left_trim":20,
+          "right_thorax":0,
+          "right_trim":20,
+          "company_marks":0,
+          "company_marks_loc":0
         },
-        "artifact": [
+        {//[6] Captain
+          "weapon_primary":11,
+          "metallic_trim":11,
+          "weapon_secondary":20,
+          "is_changed":true,
+          "left_arm":20,
+          "left_backpack":20,
+          "left_chest":20,
+          "right_arm":20,
+          "right_backpack":20,
+          "right_chest":20,
+          "left_hand":20,
+          "left_head":20,
+          "left_leg_knee":11,
+          "right_hand":20,
+          "eye_lense":9,
+          "right_head":20,
+          "left_leg_lower":20,
+          "left_leg_upper":20,
+          "left_muzzle":20,
+          "right_leg_knee":11,
+          "left_pauldron":20,
+          "right_leg_lower":20,
+          "right_leg_upper":20,
+          "right_muzzle":20,
+          "right_pauldron":20,
+          "left_thorax":0,
+          "left_trim":11,
+          "right_thorax":0,
+          "right_trim":11,
+          "company_marks":0,
+          "company_marks_loc":0
+        },
+        {//[7] Dreadnought
+          "weapon_primary":11,
+          "metallic_trim":20,
+          "weapon_secondary":20,
+          "is_changed":true,
+          "left_arm":20,
+          "left_backpack":20,
+          "left_chest":20,
+          "right_arm":20,
+          "right_backpack":20,
+          "right_chest":20,
+          "left_hand":20,
+          "left_head":20,
+          "left_leg_knee":20,
+          "right_hand":20,
+          "eye_lense":9,
+          "right_head":20,
+          "left_leg_lower":20,
+          "left_leg_upper":20,
+          "left_muzzle":20,
+          "right_leg_knee":20,
+          "left_pauldron":20,
+          "right_leg_lower":20,
+          "right_leg_upper":20,
+          "right_muzzle":20,
+          "right_pauldron":20,
+          "left_thorax":20,
+          "left_trim":20,
+          "right_thorax":20,
+          "right_trim":20,
+          "company_marks":20,
+         "company_marks_loc":20
+        },
+        {//[8] Champion
+          "weapon_primary":11,
+          "metallic_trim":20,
+          "weapon_secondary":20,
+          "is_changed":true,
+          "left_arm":20,
+          "left_backpack":20,
+          "left_chest":11,
+          "right_arm":20,
+          "right_backpack":20,
+          "right_chest":11,
+          "left_hand":20,
+          "left_head":11,
+          "left_leg_knee":20,
+          "right_hand":20,
+          "eye_lense":22,
+          "right_head":11,
+          "left_leg_lower":11,
+          "left_leg_upper":11,
+          "left_muzzle":11,
+          "right_leg_knee":20,
+          "left_pauldron":20,
+          "right_leg_lower":11,
+          "right_leg_upper":11,
+          "right_muzzle":11,
+          "right_pauldron":20,
+          "left_thorax":0,
+          "left_trim":11,
+          "right_thorax":0,
+          "right_trim":11,
+          "company_marks":0,
+          "company_marks_loc":0
+        },
+        {//[9] Tactical
+          "weapon_primary":11,
+          "metallic_trim":20,
+          "weapon_secondary":20,
+          "is_changed":true,
+          "left_arm":11,
+          "left_backpack":11,
+          "left_chest":11,
+          "right_arm":11,
+          "right_backpack":11,
+          "right_chest":11,
+          "left_hand":11,
+          "left_head":11,
+          "left_leg_knee":11,
+          "right_hand":11,
+          "eye_lense":22,
+          "right_head":11,
+          "left_leg_lower":11,
+          "left_leg_upper":11,
+          "left_muzzle":11,
+          "right_leg_knee":11,
+          "left_pauldron":11,
+          "right_leg_lower":11,
+          "right_leg_upper":11,
+          "right_muzzle":11,
+          "right_pauldron":11,
+          "left_thorax":0,
+          "left_trim":20,
+          "right_thorax":0,
+          "right_trim":20,
+          "company_marks":0,
+          "company_marks_loc":0
+        },
+        {//[10] Devastator
+          "weapon_primary":11,
+          "metallic_trim":20,
+          "weapon_secondary":20,
+          "is_changed":true,
+          "left_arm":11,
+          "left_backpack":11,
+          "left_chest":11,
+          "right_arm":11,
+          "right_backpack":11,
+          "right_chest":11,
+          "left_hand":11,
+          "left_head":20,
+          "left_leg_knee":11,
+          "right_hand":11,
+          "eye_lense":22,
+          "right_head":20,
+          "left_leg_lower":11,
+          "left_leg_upper":11,
+          "left_muzzle":11,
+          "right_leg_knee":11,
+          "left_pauldron":11,
+          "right_leg_lower":11,
+          "right_leg_upper":11,
+          "right_muzzle":11,
+          "right_pauldron":11,
+          "left_thorax":0,
+          "left_trim":20,
+          "right_thorax":0,
+          "right_trim":20,
+          "company_marks":0,
+          "company_marks_loc":0
+        },
+        {//[11] Assault
+          "weapon_primary":11,
+          "metallic_trim":20,
+          "weapon_secondary":20,
+          "is_changed":true,
+          "left_arm":11,
+          "left_backpack":11,
+          "left_chest":11,
+          "right_arm":11,
+          "right_backpack":11,
+          "right_chest":11,
+          "left_hand":11,
+          "left_head":11,
+          "left_leg_knee":11,
+          "right_hand":11,
+          "eye_lense":22,
+          "right_head":11,
+          "left_leg_lower":11,
+          "left_leg_upper":11,
+          "left_muzzle":20,
+          "right_leg_knee":11,
+          "left_pauldron":11,
+          "right_leg_lower":11,
+          "right_leg_upper":11,
+          "right_muzzle":20,
+          "right_pauldron":11,
+          "left_thorax":0,
+          "left_trim":20,
+          "right_thorax":0,
+          "right_trim":20,
+          "company_marks":0,
+          "company_marks_loc":0
+        },
+        {//[12] Ancient
+          "weapon_primary":20,
+          "metallic_trim":20,
+          "weapon_secondary":20,
+          "is_changed":true,
+          "left_arm":11,
+          "left_backpack":20,
+          "left_chest":8,
+          "right_arm":11,
+          "right_backpack":20,
+          "right_chest":8,
+          "left_hand":20,
+          "left_head":11,
+          "left_leg_knee":20,
+          "right_hand":20,
+          "eye_lense":9,
+          "right_head":11,
+          "left_leg_lower":11,
+          "left_leg_upper":11,
+          "left_muzzle":8,
+          "right_leg_knee":20,
+          "left_pauldron":11,
+          "right_leg_lower":11,
+          "right_leg_upper":11,
+          "right_muzzle":8,
+          "right_pauldron":11,
+          "left_thorax":0,
+          "left_trim":8,
+          "right_thorax":0,
+          "right_trim":8,
+          "company_marks":0,
+          "company_marks_loc":0
+        },
+        {//[13] Scout
+          "weapon_primary":11,
+          "metallic_trim":20,
+          "weapon_secondary":20,
+          "is_changed":true,
+          "left_arm":11,
+          "left_backpack":11,
+          "left_chest":11,
+          "right_arm":11,
+          "right_backpack":11,
+          "right_chest":11,
+          "left_hand":11,
+          "left_head":11,
+          "left_leg_knee":11,
+          "right_hand":11,
+          "eye_lense":22,
+          "right_head":11,
+          "left_leg_lower":11,
+          "left_leg_upper":11,
+          "left_muzzle":11,
+          "right_leg_knee":11,
+          "left_pauldron":11,
+          "right_leg_lower":11,
+          "right_leg_upper":11,
+          "right_muzzle":11,
+          "right_pauldron":11,
+          "left_thorax":0,
+          "left_trim":20,
+          "right_thorax":0,
+          "right_trim":20,
+          "company_marks":0,
+          "company_marks_loc":0
+        },
+        {//[14] Green dude
+          "weapon_primary":11,
+          "metallic_trim":20,
+          "weapon_secondary":20,
+          "is_changed":true,
+          "left_arm":23,
+          "left_backpack":23,
+          "left_chest":23,
+          "right_arm":23,
+          "right_backpack":23,
+          "right_chest":23,
+          "left_hand":23,
+          "left_head":23,
+          "left_leg_knee":23,
+          "right_hand":23,
+          "eye_lense":22,
+          "right_head":23,
+          "left_leg_lower":23,
+          "left_leg_upper":23,
+          "left_muzzle":23,
+          "right_leg_knee":23,
+          "left_pauldron":23,
+          "right_leg_lower":23,
+          "right_leg_upper":23,
+          "right_muzzle":23,
+          "right_pauldron":23,
+          "left_thorax":0,
+          "left_trim":20,
+          "right_thorax":0,
+          "right_trim":20,
+          "company_marks":0,
+          "company_marks_loc":0
+        },
+        {//[15] Chaplain
+          "weapon_primary":8,
+          "metallic_trim":20,
+          "weapon_secondary":20,
+          "is_changed":true,
+          "left_arm":8,
+          "left_backpack":8,
+          "left_chest":8,
+          "right_arm":8,
+          "right_backpack":8,
+          "right_chest":8,
+          "left_hand":8,
+          "left_head":8,
+          "left_leg_knee":8,
+          "right_hand":8,
+          "eye_lense":9,
+          "right_head":8,
+          "left_leg_lower":8,
+          "left_leg_upper":8,
+          "left_muzzle":8,
+          "right_leg_knee":8,
+          "left_pauldron":11,
+          "right_leg_lower":8,
+          "right_leg_upper":8,
+          "right_muzzle":8,
+          "right_pauldron":8,
+          "left_thorax":0,
+          "left_trim":20,
+          "right_thorax":0,
+          "right_trim":20,
+          "company_marks":0,
+          "company_marks_loc":0
+        },
+        {//[16] Apothecary
+          "weapon_primary":11,
+          "metallic_trim":20,
+          "weapon_secondary":20,
+          "is_changed":true,
+          "left_arm":18,
+          "left_backpack":18,
+          "left_chest":18,
+          "right_arm":18,
+          "right_backpack":18,
+          "right_chest":18,
+          "left_hand":18,
+          "left_head":18,
+          "left_leg_knee":18,
+          "right_hand":18,
+          "eye_lense":9,
+          "right_head":18,
+          "left_leg_lower":18,
+          "left_leg_upper":18,
+          "left_muzzle":18,
+          "right_leg_knee":18,
+          "left_pauldron":11,
+          "right_leg_lower":18,
+          "right_leg_upper":18,
+          "right_muzzle":18,
+          "right_pauldron":18,
+          "left_thorax":0,
+          "left_trim":20,
+          "right_thorax":0,
+          "right_trim":20,
+          "company_marks":0,
+          "company_marks_loc":0
+        },
+        {//[17] Techmarine
+          "weapon_primary":11,
+          "metallic_trim":20,
+          "weapon_secondary":20,
+          "is_changed":true,
+          "left_arm":9,
+          "left_backpack":9,
+          "left_chest":9,
+          "right_arm":9,
+          "right_backpack":9,
+          "right_chest":9,
+          "left_hand":9,
+          "left_head":9,
+          "left_leg_knee":9,
+          "right_hand":9,
+          "eye_lense":22,
+          "right_head":9,
+          "left_leg_lower":9,
+          "left_leg_upper":9,
+          "left_muzzle":9,
+          "right_leg_knee":9,
+          "left_pauldron":11,
+          "right_leg_lower":9,
+          "right_leg_upper":9,
+          "right_muzzle":9,
+          "right_pauldron":9,
+          "left_thorax":0,
+          "left_trim":20,
+          "right_thorax":0,
+          "right_trim":20,
+          "company_marks":0,
+          "company_marks_loc":0
+        },
+        {//[18] Librarian
+          "weapon_primary":11,
+          "metallic_trim":20,
+          "weapon_secondary":20,
+          "is_changed":true,
+          "left_arm":34,
+          "left_backpack":34,
+          "left_chest":34,
+          "right_arm":34,
+          "right_backpack":34,
+          "right_chest":34,
+          "left_hand":34,
+          "left_head":34,
+          "left_leg_knee":34,
+          "right_hand":34,
+          "eye_lense":22,
+          "right_head":34,
+          "left_leg_lower":34,
+          "left_leg_upper":34,
+          "left_muzzle":34,
+          "right_leg_knee":34,
+          "left_pauldron":1,
+          "right_leg_lower":34,
+          "right_leg_upper":34,
+          "right_muzzle":34,
+          "right_pauldron":34,
+          "left_thorax":0,
+          "left_trim":0,
+          "right_thorax":0,
+          "right_trim":0,
+          "company_marks":0,
+          "company_marks_loc":0
+        },
+        {//[19] Sergeant
+          "weapon_primary":11,
+          "metallic_trim":20,
+          "weapon_secondary":20,
+          "is_changed":true,
+          "left_arm":11,
+          "left_backpack":11,
+          "left_chest":11,
+          "right_arm":11,
+          "right_backpack":11,
+          "right_chest":11,
+          "left_hand":11,
+          "left_head":11,
+          "left_leg_knee":11,
+          "right_hand":11,
+          "eye_lense":22,
+          "right_head":11,
+          "left_leg_lower":11,
+          "left_leg_upper":11,
+          "left_muzzle":11,
+          "right_leg_knee":20,
+          "left_pauldron":20,
+          "right_leg_lower":11,
+          "right_leg_upper":11,
+          "right_muzzle":11,
+          "right_pauldron":20,
+          "left_thorax":0,
+          "left_trim":11,
+          "right_thorax":0,
+          "right_trim":20,
+          "company_marks":0,
+          "company_marks_loc":0
+        },
+        {//[20] Veteran Sergeant
+          "weapon_primary":8,
+          "metallic_trim":20,
+          "weapon_secondary":11,
+          "is_changed":true,
+          "left_arm":20,
+          "left_backpack":8,
+          "left_chest":8,
+          "right_arm":20,
+          "right_backpack":8,
+          "right_chest":8,
+          "left_hand":20,
+          "left_head":11,
+          "left_leg_knee":20,
+          "right_hand":20,
+          "eye_lense":22,
+          "right_head":11,
+          "left_leg_lower":8,
+          "left_leg_upper":8,
+          "left_muzzle":11,
+          "right_leg_knee":20,
+          "left_pauldron":11,
+          "right_leg_lower":8,
+          "right_leg_upper":8,
+          "right_muzzle":11,
+          "right_pauldron":20,
+          "left_thorax":0,
+          "left_trim":11,
+          "right_thorax":0,
+          "right_trim":20,
+          "company_marks":0,
+          "company_marks_loc":0
+        },
+        {//[21] Blue Chest
+          "weapon_primary":11,
+          "metallic_trim":20,
+          "weapon_secondary":20,
+          "is_changed":true,
+          "left_arm":31,
+          "left_backpack":31,
+          "left_chest":31,
+          "right_arm":31,
+          "right_backpack":31,
+          "right_chest":31,
+          "left_hand":31,
+          "left_head":31,
+          "left_leg_knee":31,
+          "right_hand":31,
+          "eye_lense":22,
+          "right_head":31,
+          "left_leg_lower":31,
+          "left_leg_upper":31,
+          "left_muzzle":31,
+          "right_leg_knee":31,
+          "left_pauldron":31,
+          "right_leg_lower":31,
+          "right_leg_upper":31,
+          "right_muzzle":31,
+          "right_pauldron":31,
+          "left_thorax":0,
+          "left_trim":20,
+          "right_thorax":0,
+          "right_trim":20,
+          "company_marks":0,
+          "company_marks_loc":0
+        }
+      ],
+    "complex_livery_data": //helm_pattern - paint setup, [0] Full colour primary [1] Stripe in the middle secondary [2] Upper main lower second [3] same as 1 for some reason
+      {
+        "sgt":
+        {
+          "helm_detail":20,
+          "helm_lens":9,
+          "helm_pattern":0,
+          "helm_primary":20,
+          "helm_secondary":0
+        },
+        "veteran":
+        {
+          "helm_detail":20,
+          "helm_lens":22,
+          "helm_pattern":1,
+          "helm_primary":11,
+          "helm_secondary":8
+        },
+        "captain":
+        {
+          "helm_detail":20,
+          "helm_lens":9,
+          "helm_pattern":1,
+          "helm_primary":20,
+          "helm_secondary":11
+        },
+        "vet_sgt":
+        {
+          "helm_detail":20,
+          "helm_lens":9,
+          "helm_pattern":1,
+          "helm_primary":8,
+          "helm_secondary":11
+        }
+      },
+    "company_liveries"://if you put -1 as value that means there is no change from the base colour scheme. Beware that compnay markings overwrite specialists as well
+      [
+        {// HQ
+          "weapon_primary":-1,
+          "metallic_trim":-1,
+          "weapon_secondary":-1,
+          "is_changed":true,
+          "left_arm":-1,
+          "left_backpack":-1,
+          "left_chest":-1,
+          "right_arm":-1,
+          "right_backpack":-1,
+          "right_chest":-1,
+          "left_hand":-1,
+          "left_head":-1,
+          "left_leg_knee":-1,
+          "right_hand":-1,
+          "eye_lense":-1,
+          "right_head":-1,
+          "left_leg_lower":-1,
+          "left_leg_upper":-1,
+          "left_muzzle":-1,
+          "right_leg_knee":-1,
+          "left_pauldron":-1,
+          "right_leg_lower":-1,
+          "right_leg_upper":-1,
+          "right_muzzle":-1,
+          "right_pauldron":-1,
+          "left_thorax":-1,
+          "left_trim":-1,
+          "right_thorax":-1,
+          "right_trim":-1,
+          "company_marks":-1,
+          "company_marks_loc":-1
+        },
+        {// 1
+          "weapon_primary":-1,
+          "metallic_trim":-1,
+          "weapon_secondary":-1,
+          "is_changed":true,
+          "left_arm":-1,
+          "left_backpack":-1,
+          "left_chest":-1,
+          "right_arm":-1,
+          "right_backpack":-1,
+          "right_chest":-1,
+          "left_hand":-1,
+          "left_head":-1,
+          "left_leg_knee":-1,
+          "right_hand":-1,
+          "eye_lense":-1,
+          "right_head":-1,
+          "left_leg_lower":-1,
+          "left_leg_upper":-1,
+          "left_muzzle":-1,
+          "right_leg_knee":-1,
+          "left_pauldron":-1,
+          "right_leg_lower":-1,
+          "right_leg_upper":-1,
+          "right_muzzle":-1,
+          "right_pauldron":-1,
+          "left_thorax":-1,
+          "left_trim":-1,
+          "right_thorax":-1,
+          "right_trim":-1,
+          "company_marks":-1,
+          "company_marks_loc":-1
+        },
+        {// 2
+          "weapon_primary":-1,
+          "metallic_trim":-1,
+          "weapon_secondary":-1,
+          "is_changed":true,
+          "left_arm":-1,
+          "left_backpack":-1,
+          "left_chest":-1,
+          "right_arm":-1,
+          "right_backpack":-1,
+          "right_chest":-1,
+          "left_hand":-1,
+          "left_head":-1,
+          "left_leg_knee":-1,
+          "right_hand":-1,
+          "eye_lense":-1,
+          "right_head":-1,
+          "left_leg_lower":-1,
+          "left_leg_upper":-1,
+          "left_muzzle":-1,
+          "right_leg_knee":-1,
+          "left_pauldron":-1,
+          "right_leg_lower":-1,
+          "right_leg_upper":-1,
+          "right_muzzle":-1,
+          "right_pauldron":-1,
+          "left_thorax":-1,
+          "left_trim":-1,
+          "right_thorax":-1,
+          "right_trim":-1,
+          "company_marks":-1,
+          "company_marks_loc":-1
+        },
+        {// 3
+          "weapon_primary":-1,
+          "metallic_trim":-1,
+          "weapon_secondary":-1,
+          "is_changed":true,
+          "left_arm":-1,
+          "left_backpack":-1,
+          "left_chest":-1,
+          "right_arm":-1,
+          "right_backpack":-1,
+          "right_chest":-1,
+          "left_hand":-1,
+          "left_head":-1,
+          "left_leg_knee":-1,
+          "right_hand":-1,
+          "eye_lense":-1,
+          "right_head":-1,
+          "left_leg_lower":-1,
+          "left_leg_upper":-1,
+          "left_muzzle":-1,
+          "right_leg_knee":-1,
+          "left_pauldron":-1,
+          "right_leg_lower":-1,
+          "right_leg_upper":-1,
+          "right_muzzle":-1,
+          "right_pauldron":-1,
+          "left_thorax":-1,
+          "left_trim":-1,
+          "right_thorax":-1,
+          "right_trim":-1,
+          "company_marks":-1,
+          "company_marks_loc":-1
+        },
+        {// 4
+          "weapon_primary":-1,
+          "metallic_trim":-1,
+          "weapon_secondary":-1,
+          "is_changed":true,
+          "left_arm":-1,
+          "left_backpack":-1,
+          "left_chest":-1,
+          "right_arm":-1,
+          "right_backpack":-1,
+          "right_chest":-1,
+          "left_hand":-1,
+          "left_head":-1,
+          "left_leg_knee":-1,
+          "right_hand":-1,
+          "eye_lense":-1,
+          "right_head":-1,
+          "left_leg_lower":-1,
+          "left_leg_upper":-1,
+          "left_muzzle":-1,
+          "right_leg_knee":-1,
+          "left_pauldron":-1,
+          "right_leg_lower":-1,
+          "right_leg_upper":-1,
+          "right_muzzle":-1,
+          "right_pauldron":-1,
+          "left_thorax":-1,
+          "left_trim":-1,
+          "right_thorax":-1,
+          "right_trim":-1,
+          "company_marks":-1,
+          "company_marks_loc":-1
+        },
+        {// 5
+          "weapon_primary":-1,
+          "metallic_trim":-1,
+          "weapon_secondary":-1,
+          "is_changed":true,
+          "left_arm":-1,
+          "left_backpack":-1,
+          "left_chest":-1,
+          "right_arm":-1,
+          "right_backpack":-1,
+          "right_chest":-1,
+          "left_hand":-1,
+          "left_head":-1,
+          "left_leg_knee":-1,
+          "right_hand":-1,
+          "eye_lense":-1,
+          "right_head":-1,
+          "left_leg_lower":-1,
+          "left_leg_upper":-1,
+          "left_muzzle":-1,
+          "right_leg_knee":-1,
+          "left_pauldron":-1,
+          "right_leg_lower":-1,
+          "right_leg_upper":-1,
+          "right_muzzle":-1,
+          "right_pauldron":-1,
+          "left_thorax":-1,
+          "left_trim":-1,
+          "right_thorax":-1,
+          "right_trim":-1,
+          "company_marks":-1,
+          "company_marks_loc":-1
+        },
+        {// 6
+          "weapon_primary":-1,
+          "metallic_trim":-1,
+          "weapon_secondary":-1,
+          "is_changed":true,
+          "left_arm":-1,
+          "left_backpack":-1,
+          "left_chest":-1,
+          "right_arm":-1,
+          "right_backpack":-1,
+          "right_chest":-1,
+          "left_hand":-1,
+          "left_head":-1,
+          "left_leg_knee":-1,
+          "right_hand":-1,
+          "eye_lense":-1,
+          "right_head":-1,
+          "left_leg_lower":-1,
+          "left_leg_upper":-1,
+          "left_muzzle":-1,
+          "right_leg_knee":-1,
+          "left_pauldron":-1,
+          "right_leg_lower":-1,
+          "right_leg_upper":-1,
+          "right_muzzle":-1,
+          "right_pauldron":-1,
+          "left_thorax":-1,
+          "left_trim":-1,
+          "right_thorax":-1,
+          "right_trim":-1,
+          "company_marks":-1,
+          "company_marks_loc":-1
+        },
+        {// 7
+          "weapon_primary":-1,
+          "metallic_trim":-1,
+          "weapon_secondary":-1,
+          "is_changed":true,
+          "left_arm":-1,
+          "left_backpack":-1,
+          "left_chest":-1,
+          "right_arm":-1,
+          "right_backpack":-1,
+          "right_chest":-1,
+          "left_hand":-1,
+          "left_head":-1,
+          "left_leg_knee":-1,
+          "right_hand":-1,
+          "eye_lense":-1,
+          "right_head":-1,
+          "left_leg_lower":-1,
+          "left_leg_upper":-1,
+          "left_muzzle":-1,
+          "right_leg_knee":-1,
+          "left_pauldron":-1,
+          "right_leg_lower":-1,
+          "right_leg_upper":-1,
+          "right_muzzle":-1,
+          "right_pauldron":-1,
+          "left_thorax":-1,
+          "left_trim":-1,
+          "right_thorax":-1,
+          "right_trim":-1,
+          "company_marks":-1,
+          "company_marks_loc":-1
+        },
+        {// 8
+          "weapon_primary":-1,
+          "metallic_trim":-1,
+          "weapon_secondary":-1,
+          "is_changed":true,
+          "left_arm":-1,
+          "left_backpack":-1,
+          "left_chest":-1,
+          "right_arm":-1,
+          "right_backpack":-1,
+          "right_chest":-1,
+          "left_hand":-1,
+          "left_head":-1,
+          "left_leg_knee":-1,
+          "right_hand":-1,
+          "eye_lense":-1,
+          "right_head":-1,
+          "left_leg_lower":-1,
+          "left_leg_upper":-1,
+          "left_muzzle":-1,
+          "right_leg_knee":-1,
+          "left_pauldron":-1,
+          "right_leg_lower":-1,
+          "right_leg_upper":-1,
+          "right_muzzle":-1,
+          "right_pauldron":-1,
+          "left_thorax":-1,
+          "left_trim":-1,
+          "right_thorax":-1,
+          "right_trim":-1,
+          "company_marks":-1,
+          "company_marks_loc":-1
+        },
+        {// 9
+          "weapon_primary":-1,
+          "metallic_trim":-1,
+          "weapon_secondary":-1,
+          "is_changed":true,
+          "left_arm":-1,
+          "left_backpack":-1,
+          "left_chest":-1,
+          "right_arm":-1,
+          "right_backpack":-1,
+          "right_chest":-1,
+          "left_hand":-1,
+          "left_head":-1,
+          "left_leg_knee":-1,
+          "right_hand":-1,
+          "eye_lense":-1,
+          "right_head":-1,
+          "left_leg_lower":-1,
+          "left_leg_upper":-1,
+          "left_muzzle":-1,
+          "right_leg_knee":-1,
+          "left_pauldron":-1,
+          "right_leg_lower":-1,
+          "right_leg_upper":-1,
+          "right_muzzle":-1,
+          "right_pauldron":-1,
+          "left_thorax":-1,
+          "left_trim":-1,
+          "right_thorax":-1,
+          "right_trim":-1,
+          "company_marks":-1,
+          "company_marks_loc":-1
+        },
+        {// 10
+          "weapon_primary":-1,
+          "metallic_trim":-1,
+          "weapon_secondary":-1,
+          "is_changed":true,
+          "left_arm":-1,
+          "left_backpack":-1,
+          "left_chest":-1,
+          "right_arm":-1,
+          "right_backpack":-1,
+          "right_chest":-1,
+          "left_hand":-1,
+          "left_head":-1,
+          "left_leg_knee":-1,
+          "right_hand":-1,
+          "eye_lense":-1,
+          "right_head":-1,
+          "left_leg_lower":-1,
+          "left_leg_upper":-1,
+          "left_muzzle":-1,
+          "right_leg_knee":-1,
+          "left_pauldron":-1,
+          "right_leg_lower":-1,
+          "right_leg_upper":-1,
+          "right_muzzle":-1,
+          "right_pauldron":-1,
+          "left_thorax":-1,
+          "left_trim":-1,
+          "right_thorax":-1,
+          "right_trim":-1,
+          "company_marks":-1,
+          "company_marks_loc":-1
+        }
+    ],
+    "custom_roles":
+    {
+      "chapter_master"://feel free to add specific equipment, name and whatnot
+      {
+        "name": ""
+      }
+      /*"template":
+      {
+        "wep1":"",
+        "wep2":"",
+        "gear":"",
+        "armour":"",
+        "name":"template",
+        "mobi":""
+      },*/
+    },
+    "extra_equipment": 
+    [
+      // ["Bolter", 10] is an example of how this is called
+    ],
+    "extra_marines": //default is 100 marines per company, the first company works via adding veterans or terminators
+    {//beware, only adds Tacticals
+      "second": 0,
+      "third": 0,
+      "fourth": 0,
+      "fifth": 0,
+      "sixth": 0,
+      "seventh": 0,
+      "eighth": 0,
+      "ninth": 0,
+      "tenth": 0
+    },
+    "extra_ships": 
+    /**
+    * * Default fleet composition
+    * * Homeworld 
+    * - 2 Battle Barges, 8 Strike cruisers, 7 Gladius, 3 Hunters
+    * * Fleet based and Penitent 
+    * - 4 Battle Barges, 3 Strike Cruisers, 7 Gladius, 3 Hunters
+    * 
+    * use negative numbers to subtract ships
+    * * Stacks with advantages/disadvantages
+    */
+    {
+      "gloriana": 0,
+      "battle_barges": 0,
+      "strike_cruisers": 0,
+      "gladius": 0,
+      "hunters": 0
+    },
+    /**
+      * * Default HQ Layout (Does not include company specialists)
+      * - 8 Chaplains, 8 Techmarines, 8 Apothecary, 2 Epistolary (librarian), 
+      * - 2 Codiciery, 4 Lexicanum
+      * * Default Company specialists (divided based on `load_to_ships.split_vets` setting)
+      * - 20 Terminators, 85 Veterans, 20 Devastators, 20 Assault
+      * Use negative numbers to subtract
+      * Stacks with advantages/disadvantages
+    */
+    "extra_specialists": 
+    {
+      "chaplains": 0,//adds them to the Reclusiam
+      "chaplains_per_company": 0,//adds them to company, X per company
+      "techmarines": 0,
+      "techmarines_per_company": 0,
+      "apothecary": 0,
+      "apothecary_per_company": 0,
+      "epistolary": 0,
+      "epistolary_per_company": 0,
+      "codiciery": 0,
+      "lexicanum": 0,
+      "terminator": 0,
+      "assault": 0,
+      "veteran": 0,
+      "devastator": 0,
+      "dreadnought": 0
+    },
+    "extra_vehicles":
+    {
+      "rhino": 0,
+      "predator": 0,
+      "land_speeder": 0,
+      "whirlwind": 0,
+      "land_raider": 0
+    },
+    "companies":// you may use this to override default company manpower and vehicles on start.
+    {
+      "first": "",
+      "second":"",
+      "third":"",
+      "fourth":"",
+      "fifth":"",
+      "sixth":"",
+      "seventh":"",
+      "eighth":"",
+      "ninth":"",
+      "tenth":""
+    },
+    "custom_advisors"://here you define what image [by typing the png name] are your custom advisors using. If you add nothing here, the game uses defaults
+    {/*
+      "forge_master": ,
+      "apothecary": ,
+      "librarian": , 
+      "chaplain": ,
+      "admiral": ,
+      "recruiter": 
+    */},
+    "squad_name": "Squad", //how will any squad be referenced
+    "custom_squads":
+    {/*Example how this works, showcasing the Deathwing Terminator Squads
+      "deathwing_squad":
+      [
+        // Terminator Sergeant
+        [
+          "Veteran Sergeant",
+          {
+            "max": 1,
+            "min": 1,
+            "role": "Deathwing Sergeant",
+            "loadout": 
             {
-                "name": "Artifact Name",
-                "description": "Artefact Lore",
-                "base_weapon_type": "Power Sword",
-                "slot": "wep1"
+              "required": 
+              {
+                "wep1":
+                [
+                  "Power Sword",
+                  1
+                ]
+              }
+            }
+          }
+        ],
+        // Terminator
+        [
+          "Terminator",
+            {
+              "max": 4,
+              "min": 2,
+              "role": "Deathwing Terminator",
+              "loadout":
+              {
+                "required":
+                {
+                  "wep1":
+                  [
+                    "",
+                    0
+                  ],
+                  "wep2":
+                  [
+                    "Storm Bolter",
+                    3
+                  ]
+                },
+                "option":
+                {
+                  "wep1":
+                  [
+                    [
+                      [
+                        "Power Fist",
+                        "Chainfist"
+                      ],
+                      4
+                    ]
+                  ],
+                  "wep2":
+                  [
+                    [
+                      [
+                        "Heavy Flamer",
+                        "Heavy Flamer",
+                        "Heavy Flamer",
+                        "Assault Cannon",
+                        "Assault Cannon",
+                        "Plasma Cannon"
+                      ],
+                      1
+                    ]
+                  ]
+                }
+              }
             }
         ],
-        "company_titles": [
-            "",
-            "1st Company",
-            "2nd Company",
-            "3rd Company",
-            "4th Company",
-            "5th Company",
-            "6th Company",
-            "7th Company",
-            "8th Company",
-            "9th Company",
-            "10th Company"
-        ],
-        "flagship_name": "Flagship Name", // leave blank to autogenerate
-        /**
-        * * Default fleet composition
-        * * Homeworld 
-        * - 2 Battle Barges, 8 Strike cruisers, 7 Gladius, 3 Hunters
-        * * Fleet based and Penitent 
-        * - 4 Battle Barges, 3 Strike Cruisers, 7 Gladius, 3 Hunters
-        * 
-        * use negative numbers to subtract ships
-        * * Stacks with advantages/disadvantages
-        */
-        "extra_ships": {
-            "battle_barges": 0,
-            "gladius": 0,
-            "strike_cruisers": 0,
-            "hunters": 0
-        },
-        /**
-        * * Default HQ Layout (Does not include company specialists)
-        * - 8 Chaplains, 8 Techmarines, 8 Apothecary, 2 Epistolary (librarian), 
-        * - 2 Codiciery, 4 Lexicanum
-        * * Default Company specialists (divided based on `load_to_ships.split_vets` setting)
-        * - 20 Terminators, 85 Veterans, 20 Devastators, 20 Assault
-        * Use negative numbers to subtract
-        * * Stacks with advantages/disadvantages
-        */
-        "extra_specialists": {
-            "chaplains": 0,
-            "chaplains_per_company": 0,
-            "techmarines": 0,
-            "techmarines_per_company": 0,
-            "apothecary": 0,
-            "apothecary_per_company": 0,
-            "epistolary": 0,
-            "epistolary_per_company": 0,
-            "codiciery": 0,
-            "lexicanum": 0,
-            "terminator": 0,
-            "assault": 0,
-            "veteran": 0,
-            "devastator": 0,
-            "dreadnought": 0
-        },
-        /**
-        * * Default Marine strength
-        * - 100 marines per company
-        * use negative numbers to subtract
-        * * Stacks with strength for non-founding chapters only
-        */
-        "extra_marines": {
-            "second": 0,
-            "third": 0,
-            "fourth": 0,
-            "fifth": 0,
-            "sixth": 0,
-            "seventh": 0,
-            "eighth": 0,
-            "ninth": 0,
-            "tenth": 0
-        },
-        /**
-        * All vehicles are added to the 10th company at the start of the game
-        */
-        "extra_vehicles": {
-            "rhino": 0,
-            "whirlwind": 0,
-            "predator": 0,
-            "land_raider": 0,
-            "land_speeder": 0
-        },
-        /** Add extra starting items ["Item Name", Number to add] */
-        "extra_equipment": [
-            // [
-            //     "Bolter",
-            //     20
-            // ]
-        ],
-        /** 
-        * Provide a place to change the default name and equipment preferences of roles for this chapter
-        * `custom_roles` should be used for specialist/leadership type roles, 
-        * To affect an entire squad, see `custom_squads` below
-        */
-        "custom_roles": {
-            // "honour_guard": {
-            //     "name": "Honour Guard",
-            //     "wep1": "Power Sword",
-            //     "wep2": "Bolter"
-            // },
-            // "veteran": {
-            //     "name": "Veteran",
-            //     "wep1": "Chainaxe"
-            // },
-            // "captain": {
-            //     "name": "Captain",
-            //     "wep1": "Power Sword"
-            // },
-            // "tactical": {
-            //     "name": "Tactical"
-            // },
-            // "devastator": {
-            //     "name": "Devastator"
-            // },
-            // "assault": {
-            //     "name": "Assault",
-            //     "wep1": "Chainsword"
-            // },
-            // "scout": {
-            //     "name": "Scout",
-            //     "wep1": "Sniper Rifle"
-            // },
-            // "chaplain": {
-            //     "name": "Chaplain",
-            // },
-            // "techmarine": {
-            //     "name": "Techmarine",
-            //     "wep1": "Power Axe"
-            // },
-            // "apothecary": {
-            //     "name": "Apothecary",
-            //     "wep1": "Power Axe"
-            // },
-            // "librarian": {
-            //     "name": "Librarian",
-            //     "wep1": "Force Staff"
-            // },
-            // "sergeant": {
-            //     "name": "Sergeant",
-            //     "wep1": "Chainaxe"
-            // },
-            // "veteran_sergeant": {
-            //     "name": "Veteran Sergeant",
-            //     "wep1": "Chainaxe"
-            // }
-        },
-        /**
-        * * Custom squad roles, loadouts and formations
-        * When companies are made, squads are formed based on these rules: 
-        * - squad name: one of captain, terminator, terminator_assault, sternguard_veteran,
-                vanguard_veteran, devastator, tactical, assault, scout, scout_sniper
-        * - squad array layout [Role, Role, ...Role, type_data]
-        * - each element of the array is a default Role, and their settings.
-            - if you changed the role using `custom_roles` you need to reference the role with this new name
-            - for non-leader roles it is better to change the name of the role in the squad layout instead
-        * - unit layout [Role Name, Settings Struct]
-        * - settings struct: 
-        *   - max: The most amount of this unit is allowed per squad
-        *   - min: The squad can't be formed unless at least 1 of this unit is in it
-        *   - role: The name of the unit when it is a member of the squad. This is where you rename roles e.g. 
-                "Terminator" > "Deathwing Terminator" 
-        **  - loadout: Struct containing Required and Optional weaponry this unit can equip 
-                a required loadout always follows this syntax <loadout_slot>:[<loadout_item>,<required number>]
-				so "wep1":["Bolter",4], will mean four marines are always equipped with 4 bolters in the wep1 slot
-        *       option loadouts follow the following syntax <loudout_slot>:[[<loadout_item_list>],<allowed_number>]
-				for example [["Flamer", "Meltagun"],1], means the role can have a max of one flamer or meltagun
-					[["Plasma Pistol","Bolt Pistol"], 4] means the role can have a mix of 4 plasma pistols and bolt pistols on top
-						of all required loadout options
-                - wep1: right hand weapon
-                - wep2: left hand weapon
-                - mobi: Mobility item, e.g. Jump Packs. 
-                - armour: required armour 
-                - gear: special equipment needed for certain roles, like a Roasrius or Narthecium
-        *   - type_data: names the squad, allows certain formations 
-        */
-        "squad_name": "Squad",
-        "custom_squads": {}
+        [
+          "type_data",
+            {
+              "display_data": "Deathwing Terminator Squad",
+              "formation_options":
+              [
+                "terminator",
+                "veteran",
+                "assault",
+                "devastator",
+                "scout",
+                "tactical"
+              ],
+              "allowed_companies": [1] //this is specifically for when squads are supposed to spawn only in specific companies. Ignore for chapter-wide changes
+            }
+        ]
+      ]*/
     }
+/*  * Custom squad roles, loadouts and formations
+    * When companies are made, squads are formed based on these rules: 
+    * - squad name: one of captain, terminator, terminator_assault, sternguard_veteran,
+      vanguard_veteran, devastator, tactical, assault, scout, scout_sniper
+    * - squad array layout [Role, Role, ...Role, type_data]
+    * - each element of the array is a default Role, and their settings.
+      - if you changed the role using `custom_roles` you need to reference the role with this new name
+      - for non-leader roles it is better to change the name of the role in the squad layout instead
+    * - unit layout [Role Name, Settings Struct]
+    * - settings struct: 
+    *   - max: The most amount of this unit is allowed per squad
+    *   - min: The squad can't be formed unless at least 1 of this unit is in it
+    *   - role: The name of the unit when it is a member of the squad. This is where you rename roles e.g. 
+      "Terminator" > "Deathwing Terminator" 
+    **  - loadout: Struct containing Required and Optional weaponry this unit can equip 
+      a required loadout always follows this syntax <loadout_slot>:[<loadout_item>,<required number>]
+		so "wep1":["Bolter",4], will mean four marines are always equipped with 4 bolters in the wep1 slot
+    *       option loadouts follow the following syntax <loudout_slot>:[[<loadout_item_list>],<allowed_number>]
+		for example [["Flamer", "Meltagun"],1], means the role can have a max of one flamer or meltagun
+		[["Plasma Pistol","Bolt Pistol"], 4] means the role can have a mix of 4 plasma pistols and bolt pistols on top
+		of all required loadout options
+      - wep1: right hand weapon
+      - wep2: left hand weapon
+      - mobi: Mobility item, e.g. Jump Packs. 
+      - armour: required armour 
+      - gear: special equipment needed for certain roles, like a Roasrius or Narthecium
+    *   - type_data: names the squad, allows certain formations ? idk what that does yet*/
+  }
 }

--- a/datafiles/main/squads/base_squads.json
+++ b/datafiles/main/squads/base_squads.json
@@ -7,27 +7,32 @@
     "Champion": {
       "max": 1,
       "min": 0,
-      "role": "Company Champion"
+      "role": "Company Champion",
+      "alternative_roles": ["Champion"]
     },
     "Apothecary": {
       "max": 1,
       "min": 0,
-      "role": "Company Apothecary"
+      "role": "Company Apothecary",
+      "alternative_roles": ["Apothecary"]
     },
     "Chaplain": {
       "max": 1,
       "min": 0,
-      "role": "Company Chaplain"
+      "role": "Company Chaplain",
+      "alternative_roles": ["Chaplain"]
     },
     "Ancient": {
       "max": 1,
       "min": 1,
-      "role": "Company Ancient"
+      "role": "Company Ancient",
+      "alternative_roles": ["Ancient"]
     },
     "Veteran": {
       "max": 5,
       "min": 0,
       "role": "Company Veteran",
+      "alternative_roles": ["Veteran"],
       "loadout": {
         "required": {
           "wep1": ["", 0],
@@ -43,12 +48,14 @@
     "Techmarine": {
       "max": 2,
       "min": 0,
-      "role": "Company Techmarine"
+      "role": "Company Techmarine",
+      "alternative_roles": ["Techmarine"]
     },
     "Librarian": {
       "max": 1,
       "min": 0,
-      "role": "Company Librarian"
+      "role": "Company Librarian",
+      "alternative_roles": ["Librarian"]
     },
     "type_data": {
       "display_data": "Command {squad_name}",
@@ -213,11 +220,11 @@
     "Devastator": {
       "max": 9,
       "min": 4,
+      "role": "Devastator",
       "loadout": {
         "required": {
           "wep1": ["Bolter", 5],
-          "wep2": ["Combat Knife", 9],
-          "mobi": ["", 5]
+          "wep2": ["Combat Knife", 9]
         },
         "option": {
           "wep1": [
@@ -258,6 +265,7 @@
     "Tactical": {
       "max": 9,
       "min": 4,
+      "role": "Tactical",
       "loadout": {
         "required": {
           "wep1": ["wep1[8]", 7],
@@ -307,6 +315,7 @@
     "Assault": {
       "max": 9,
       "min": 4,
+      "role": "Assault",
       "loadout": {
         "required": {
           "wep1": ["wep1[10]", 5],
@@ -358,6 +367,7 @@
     "Scout": {
       "max": 9,
       "min": 4,
+      "role": "Scout",
       "loadout": {
         "required": {
           "wep1": ["", 0],
@@ -398,42 +408,7 @@
       ]
     }
   },
-  "bike_squad": {
-      "Biker": {
-        "max": 7,
-        "min": 2,
-        "role": "Biker",
-        "alternative_roles": ["Tactical", "Assault"],
-        "loadout": {
-          "required": {
-            "armour": ["",0],
-            "wep1": ["", 0],
-            "wep2": ["Bolt Pistol", 2],
-            "mobi": ["Bike", "max"]
-          },
-          "option": {
-            "wep1": [[["","Chainsword","Chainaxe"],5,{"wep2":"Bolt Pistol"}]]
-          }
-        }
-      },
-      "Sergeant": {
-          "max": 1,
-          "min": 1,
-          "role": "Biker Sergeant",
-          "loadout": {
-              "required": {
-                  "wep1": ["", "max"],
-                  "wep2": ["Chainsword", "max"],
-                  "mobi": ["Bike", 1]
-              }
-          }
-      },
-      "type_data": {
-          "display_data": "Bike {squad_name}",
-          "class": ["bike"],
-          "formation_options": ["assault", "tactical"]
-      }
-  },
+
   "breacher_squad": {
       "Tactical": {
           "max": 9,
@@ -476,5 +451,91 @@
           "display_data": "Breacher {squad_name}",
           "formation_options": ["tactical", "assault", "devastator", "scout"]
       }
-  }
+  },
+  
+  "bike_squad": {
+      "Tactical": {
+        "max": 7,
+        "min": 2,
+        "role": "Biker",
+        "alternative_roles": ["Assault","Devastator","Tactical"],
+        "loadout": {
+          "required": {
+            "armour": ["", 0],
+            "wep1": ["", 0],
+            "wep2": ["", 0],
+            "mobi": ["Bike", 7]
+          },
+          "option": {
+            "wep1": [[["Chainsword","Chainaxe"],7,{"wep2":"Bolt Pistol"}]]
+          }
+        }
+      },
+      "Sergeant": {
+          "max": 1,
+          "min": 1,
+          "role": "Biker Sergeant",
+          "loadout": {
+              "required": {
+                "wep1": ["", 0],
+                "wep2": ["", 0],
+                "mobi": ["Bike", 1]
+              },
+              "option": {
+                "wep1": [
+                  [["Power Sword", "Power Spear", "Power Axe", "Power Fist", "Chainaxe", "Chainsword"],1],
+                  [["Lightning Claw"],1,{"wep2":"Lightning Claw"}]
+                ],
+                "wep2": [[["Volkite Serpenta", "Plasma Pistol", "Bolt Pistol", "Phobos Bolt Pistol", "Grav-Pistol", "Hand Flamer", "Infernus Pistol", "RyzPlsmPis"],1]]
+              }
+          }
+      },
+      "type_data": {
+          "display_data": "Bike {squad_name}",
+          "class": ["bike"],
+          "formation_options": ["assault", "tactical","devastator","scout"]
+      }
+  },
+
+  
+  "attack_bike_squad": {
+    "Tactical": {
+        "max": 2,
+        "min": 1,
+        "role": "Attack Biker",
+        "alternative_roles": ["Devastator", "Assault", "Tactical"],
+        "loadout": {
+            "required": {
+                "wep1": ["", 0],
+                "wep2": ["", 0],
+                "mobi": ["Attack Bike", "max"]
+            },
+            "option": {
+                "wep1": [[["Multi-Melta", "Heavy Bolter"], 2]],
+                "wep2": [[["Chainsword", "Chainaxe", "Combat Knife"],2]]
+            }
+        }
+    },
+    "Sergeant": {
+        "max": 1,
+        "min": 1,
+        "role": "Attack Bike Sergeant",
+        "loadout": {
+            "required": {
+                "wep1": ["", 0],
+                "wep2": ["", 0],
+                "mobi": ["Attack Bike", 1]
+            },
+            "option": {
+              "wep1": [[["Multi-Melta", "Heavy Bolter", "Plasma Cannon", "Lascannon"],1]],
+              "wep2": [[["Chainsword", "Chainaxe", "Power Sword", "Power Spear", "Power Axe"],1]]
+            }
+        }
+    },
+    "type_data": {
+        "display_data": "Attack Bike {squad_name}",
+        "class": ["bike"],
+        "formation_options": ["assault", "tactical", "devastator", "scout"]
+    }
+}
 }

--- a/datafiles/main/squads/base_squads.json
+++ b/datafiles/main/squads/base_squads.json
@@ -217,7 +217,7 @@
   },
 
   "devastator_squad": {
-    "Devastator": {
+    "Devastator Marine": {
       "max": 9,
       "min": 4,
       "role": "Devastator",
@@ -262,7 +262,7 @@
   },
 
   "tactical_squad": {
-    "Tactical": {
+    "Tactical Marine": {
       "max": 9,
       "min": 4,
       "role": "Tactical",
@@ -312,7 +312,7 @@
   },
 
   "assault_squad": {
-    "Assault": {
+    "Assault Marine": {
       "max": 9,
       "min": 4,
       "role": "Assault",
@@ -410,7 +410,7 @@
   },
 
   "breacher_squad": {
-      "Tactical": {
+      "Tactical Marine": {
           "max": 9,
           "min": 4,
           "role": "Breacher",

--- a/datafiles/main/squads/base_squads.json
+++ b/datafiles/main/squads/base_squads.json
@@ -399,17 +399,22 @@
     }
   },
   "bike_squad": {
-      "Assault": {
-          "max": 9,
-          "min": 4,
-          "role": "Biker",
-          "loadout": {
-              "required": {
-                  "wep1": ["", "max"],
-                  "wep2": ["Chainsword", "max"],
-                  "mobi": ["Bike", "max"]
-              }
+      "Biker": {
+        "max": 7,
+        "min": 2,
+        "role": "Biker",
+        "alternative_roles": ["Tactical", "Assault"],
+        "loadout": {
+          "required": {
+            "armour": ["",0],
+            "wep1": ["", 0],
+            "wep2": ["Bolt Pistol", 2],
+            "mobi": ["Bike", "max"]
+          },
+          "option": {
+            "wep1": [[["","Chainsword","Chainaxe"],5,{"wep2":"Bolt Pistol"}]]
           }
+        }
       },
       "Sergeant": {
           "max": 1,

--- a/datafiles/main/squads/base_squads.json
+++ b/datafiles/main/squads/base_squads.json
@@ -481,13 +481,16 @@
                 "wep2": ["", 0],
                 "mobi": ["Bike", 1]
               },
-              "option": {
-                "wep1": [
-                  [["Power Sword", "Power Spear", "Power Axe", "Power Fist", "Chainaxe", "Chainsword"],1],
-                  [["Lightning Claw"],1,{"wep2":"Lightning Claw"}]
-                ],
-                "wep2": [[["Volkite Serpenta", "Plasma Pistol", "Bolt Pistol", "Phobos Bolt Pistol", "Grav-Pistol", "Hand Flamer", "Infernus Pistol", "RyzPlsmPis"],1]]
-              }
+              "random_pick": [
+                {
+                  "wep1": ["Power Sword", "Power Spear", "Power Axe", "Power Fist", "Chainaxe", "Chainsword"],
+                  "wep2": ["Volkite Serpenta", "Plasma Pistol", "Bolt Pistol", "Phobos Bolt Pistol", "Grav-Pistol", "Hand Flamer", "Infernus Pistol", "RyzPlsmPis"]
+                },
+                {
+                  "wep1": "Lightning Claw",
+                  "wep2": "Lightning Claw"
+                }
+              ]
           }
       },
       "type_data": {

--- a/datafiles/main/squads/company_squad_builds.json
+++ b/datafiles/main/squads/company_squad_builds.json
@@ -34,7 +34,7 @@
         },
         {
           "squad": "tactical_squad",
-          "proportion": 5
+          "proportion": 6
         },
         {
           "squad": "breacher_squad",
@@ -61,7 +61,7 @@
         },
         {
           "squad": "tactical_squad",
-          "proportion": 5
+          "proportion": 6
         },
         {
           "squad": "breacher_squad",
@@ -88,7 +88,7 @@
         },
         {
           "squad": "tactical_squad",
-          "proportion": 5
+          "proportion": 6
         },
         {
           "squad": "breacher_squad",
@@ -115,7 +115,7 @@
         },
         {
           "squad": "tactical_squad",
-          "proportion": 5
+          "proportion": 6
         },
         {
           "squad": "breacher_squad",
@@ -142,7 +142,7 @@
         },
         {
           "squad": "tactical_squad",
-          "proportion": 5
+          "proportion": 6
         },
         {
           "squad": "breacher_squad",

--- a/datafiles/main/squads/lightning_warriors.json
+++ b/datafiles/main/squads/lightning_warriors.json
@@ -1,0 +1,242 @@
+{
+  "companies": [
+    {
+      "company": 1,
+      "squads": [
+        {
+          "squad": "command_squad",
+          "max_count": 1,
+          "min_count": 1,
+          "require": true
+        },
+        {
+          "squad": "terminator_squad",
+          "proportion": 2
+        },
+        {
+          "squad": "terminator_assault_squad",
+          "proportion": 2
+        },
+        {
+          "squad": "veteran_squad",
+          "proportion": 1
+        }
+      ]
+    },
+    {
+      "company": 2,
+      "squads": [
+        {
+          "squad": "command_squad",
+          "max_count": 1,
+          "min_count": 1,
+          "require": true
+        },
+        {
+          "squad": "tactical_squad",
+          "proportion": 0
+        },
+        {
+          "squad": "bike_squad",
+          "proportion": 7
+        },
+        {
+          "squad": "attack_bike_squad",
+          "proportion": 3
+        },
+        {
+          "squad": "devastator_squad",
+          "proportion": 0
+        },
+        {
+          "squad": "assault_squad",
+          "proportion": 0
+        }
+      ]
+    },
+    {
+      "company": 3,
+      "squads": [
+        {
+          "squad": "command_squad",
+          "max_count": 1,
+          "min_count": 1,
+          "require": true
+        },
+        {
+          "squad": "tactical_squad",
+          "proportion": 0
+        },
+        {
+          "squad": "bike_squad",
+          "proportion": 7
+        },
+        {
+          "squad": "attack_bike_squad",
+          "proportion": 3
+        },
+        {
+          "squad": "devastator_squad",
+          "proportion": 0
+        },
+        {
+          "squad": "assault_squad",
+          "proportion": 0
+        }
+      ]
+    },
+    {
+      "company": 4,
+      "squads": [
+        {
+          "squad": "command_squad",
+          "max_count": 1,
+          "min_count": 1,
+          "require": true
+        },
+        {
+          "squad": "tactical_squad",
+          "proportion": 0
+        },
+        {
+          "squad": "bike_squad",
+          "proportion": 7
+        },
+        {
+          "squad": "attack_bike_squad",
+          "proportion": 3
+        },
+        {
+          "squad": "devastator_squad",
+          "proportion": 0
+        },
+        {
+          "squad": "assault_squad",
+          "proportion": 0
+        }
+      ]
+    },
+    {
+      "company": 5,
+      "squads": [
+        {
+          "squad": "command_squad",
+          "max_count": 1,
+          "min_count": 1,
+          "require": true
+        },
+        {
+          "squad": "tactical_squad",
+          "proportion": 0
+        },
+        {
+          "squad": "bike_squad",
+          "proportion": 7
+        },
+        {
+          "squad": "attack_bike_squad",
+          "proportion": 3
+        },
+        {
+          "squad": "devastator_squad",
+          "proportion": 0
+        },
+        {
+          "squad": "assault_squad",
+          "proportion": 0
+        }
+      ]
+    },
+    {
+      "company": 6,
+      "squads": [
+        {
+          "squad": "command_squad",
+          "max_count": 1,
+          "min_count": 1,
+          "require": true
+        },
+        {
+          "squad": "tactical_squad",
+          "proportion": 0
+        },
+        {
+          "squad": "bike_squad",
+          "proportion": 7
+        },
+        {
+          "squad": "attack_bike_squad",
+          "proportion": 3
+        },
+        {
+          "squad": "devastator_squad",
+          "proportion": 0
+        },
+        {
+          "squad": "assault_squad",
+          "proportion": 0
+        }
+      ]
+    },
+    {
+      "company": 7,
+      "squads": [
+        {
+          "squad": "command_squad",
+          "max_count": 1,
+          "min_count": 1,
+          "require": true
+        },
+        {
+          "squad": "tactical_squad",
+          "proportion": 1
+        }
+      ]
+    },
+    {
+      "company": 8,
+      "squads": [
+        {
+          "squad": "command_squad",
+          "max_count": 1,
+          "min_count": 1,
+          "require": true
+        },
+        {
+          "squad": "assault_squad",
+          "proportion": 1
+        }
+      ]
+    },
+    {
+      "company": 9,
+      "squads": [
+        {
+          "squad": "command_squad",
+          "max_count": 1,
+          "min_count": 1,
+          "require": true
+        },
+        {
+          "squad": "devastator_squad",
+          "proportion": 1
+        }
+      ]
+    },
+    {
+      "company": 10,
+      "squads": [
+        {
+          "squad": "command_squad",
+          "max_count": 1,
+          "min_count": 1,
+          "require": true
+        },
+        {
+          "squad": "scout_squad",
+          "proportion": 1
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/scr_UnitGroup/scr_UnitGroup.gml
+++ b/scripts/scr_UnitGroup/scr_UnitGroup.gml
@@ -199,11 +199,11 @@ function UnitGroup(units) constructor {
 
     var _roles = active_roles();
 
-    static sgt_types = role_groups(SPECIALISTS_SQUAD_LEADERS);
+    static sgt_types = [];
 
     static create_squad = function(squad_type, squad_loadout = true, squad_uid = "", game_start = false) {
         //LOGGER.info($"sgts : ${sgt_types}");
-        
+        sgt_types  = role_groups(SPECIALISTS_SQUAD_LEADERS);
 
         var roles = active_roles();
 
@@ -229,9 +229,13 @@ function UnitGroup(units) constructor {
             var _primary_role = squad_unit_types[r];
             var _primary_role_def = _fill_squad[$ _primary_role];
             var _primary_role_name = struct_exists(_primary_role_def, "role") ? _primary_role_def.role : _primary_role;
-            LOGGER.info($"Squad type: {squad_type}, Looking for roles: {_all_roles_to_fetch}");
             if (!array_contains(_all_roles_to_fetch, _primary_role_name)) {
                 array_push(_all_roles_to_fetch, _primary_role_name);
+            }
+            // Always include the JSON key itself as a source — units carry their base role
+            // (e.g. "Terminator") before being renamed to the squad-specific role ("Deathwing Terminator")
+            if (!array_contains(_all_roles_to_fetch, _primary_role)) {
+                array_push(_all_roles_to_fetch, _primary_role);
             }
 
             //add alternative source roles to fetch list if this squad role defines them
@@ -244,10 +248,15 @@ function UnitGroup(units) constructor {
                 }
             }
         }
-
+        //ensure generic sergeant role names are always included in the pool
+        //JSON overrides with specific names "Tactical Sergeant"
+        for (var s = 0; s < 2; s++) {
+            if (!array_contains(_all_roles_to_fetch, sgt_types[s])) {
+                array_push(_all_roles_to_fetch, sgt_types[s]);
+            }
+        }
 
         var _squadless = get_from({squadless: true, roles: _all_roles_to_fetch});
-        LOGGER.info($"Squadless count before: {_squadless.number()}");
 
         for (var s = 0; s < 2; s++) {
             var _sgt_type = sgt_types[s];
@@ -264,13 +273,19 @@ function UnitGroup(units) constructor {
                 var _role_name = squad_unit_types[r];
                 var _role_def = _fill_squad[$ _role_name];
                 var _primary_role_name = struct_exists(_role_def, "role") ? _role_def.role : _role_name;
-                if (_primary_role_name == _sgt_type) {
+                if (_primary_role_name == _sgt_type || (_role_name == "Sergeant" && _sgt_type == sgt_types[0]) || (_role_name == "Veteran Sergeant" && _sgt_type == sgt_types[1])) {
                     _sgt_group = _role_name;
                     break;
                 }
             }
             if (_sgt_group != "") {
                 squad_fulfilment[$ _sgt_group]++;
+                // Rename pre-existing sergeant to squad-specific role if needed
+                var _sgt_slot_def = _fill_squad[$ _sgt_group];
+                var _target_sgt_role = struct_exists(_sgt_slot_def, "role") ? _sgt_slot_def.role : _sgt_type;
+                if (_target_sgt_role != _sgt.role()) {
+                    _sgt.update_role(_target_sgt_role);
+                }
             }
             sergeant_found = true;
         }
@@ -292,7 +307,7 @@ function UnitGroup(units) constructor {
                     var _role_name = squad_unit_types[r];
                     var _role_def = _fill_squad[$ _role_name];
                     var _primary_role_name = struct_exists(_role_def, "role") ? _role_def.role : _role_name;
-                    if (_sgt_type == _primary_role_name) {
+                    if (_primary_role_name == _sgt_type || _role_name == "Sergeant" && _sgt_type == sgt_types[0] || _role_name == "Veteran Sergeant" && _sgt_type == sgt_types[1]) {
                         _has_sgt_requirements = true;
                         break;
                     }
@@ -318,12 +333,17 @@ function UnitGroup(units) constructor {
                 var _primary_role_name = struct_exists(_role_def, "role") ? _role_def.role : _role_name;
 
                 
-                // Check if marine matches this primary role
+                // Check if marine matches this primary role (squad-specific rename target)
                 if (_target_role == _primary_role_name) {
                     _role_group = _role_name;
                     break;
                 }
-                
+                // Check if marine matches the JSON key itself (base role before squad rename)
+                if (_target_role == _role_name) {
+                    _role_group = _role_name;
+                    break;
+                }
+
                 // Check if marine matches any alternative roles for this group
                 if (struct_exists(_role_def, "alternative_roles")) {
                     var _alts = _role_def.alternative_roles;
@@ -349,6 +369,14 @@ function UnitGroup(units) constructor {
                 //if sergeants not required
                 squad_fulfilment[$ _role_group]++;
                 squad.add_member(_unit.company, _unit.marine_number);
+                // Rename unit to the squad-specific role only for rank-and-file marines
+                // (Tactical/Assault/Devastator/Scout → Biker, Breacher, etc.)
+                // Specialists (Chaplain, Ancient, Champion, Veteran, etc.) keep their existing role
+                var _slot_def = _fill_squad[$ _role_group];
+                if (struct_exists(_slot_def, "role") && _slot_def.role != _unit.role()
+                    && _unit.IsSpecialist(SPECIALISTS_RANK_AND_FILE)) {
+                    _unit.update_role(_slot_def.role);
+                }
             }
         }
 
@@ -363,18 +391,21 @@ function UnitGroup(units) constructor {
         for (var s = 0; s < 2; s++) {
             var _sgt_type = sgt_types[s];
             var _sgt_group = "";
+            var _exp_unit = undefined;
             for (var r = 0; r < array_length(squad_unit_types); r++) {
                 var _role_name = squad_unit_types[r];
                 var _role_def = _fill_squad[$ _role_name];
                 var _primary_role_name = struct_exists(_role_def, "role") ? _role_def.role : _role_name;
-                if (_primary_role_name == _sgt_type) {
+                if (_primary_role_name == _sgt_type || (_role_name == "Sergeant" && _sgt_type == sgt_types[0]) || (_role_name == "Veteran Sergeant" && _sgt_type == sgt_types[1])) {
                     _sgt_group = _role_name;
                     break;
                 }
-            }            if (_sgt_group != "" && struct_exists(squad_fulfilment, _sgt_group) && (!sergeant_found)) {
-                var _exp_unit = _members.highest_exp();
-
-                _exp_unit.update_role(_sgt_type);
+            }            
+                if (_sgt_group != "" && struct_exists(squad_fulfilment, _sgt_group) && (!sergeant_found)) {
+                _exp_unit = _members.highest_exp();
+                var _sgt_role_def = _fill_squad[$ _sgt_group];
+                var _actual_sgt_role = struct_exists(_sgt_role_def, "role") ? _sgt_role_def.role : _sgt_type;
+                _exp_unit.update_role(_actual_sgt_role);
                 squad_fulfilment[$ _sgt_group]++;
                 if (game_start && irandom(1) == 0) {
                     _exp_unit.add_trait("lead_example");
@@ -394,7 +425,7 @@ function UnitGroup(units) constructor {
         }
         if (_fulfilled) {
             for (var s = 0; s < 2; s++) {
-                if (struct_exists(squad_fulfilment, sgt_types[s]) && (sergeant_found == false)) {
+                if (struct_exists(squad_fulfilment, sgt_types[s]) && (sergeant_found == false) && (_exp_unit != undefined)) {
                     _exp_unit.update_role(sgt_types[s]); //if squad is viable promote marine to sergeant
                     if (game_start && irandom(1) == 0) {
                         _exp_unit.add_trait("lead_example");

--- a/scripts/scr_UnitGroup/scr_UnitGroup.gml
+++ b/scripts/scr_UnitGroup/scr_UnitGroup.gml
@@ -202,7 +202,8 @@ function UnitGroup(units) constructor {
     static sgt_types = role_groups(SPECIALISTS_SQUAD_LEADERS);
 
     static create_squad = function(squad_type, squad_loadout = true, squad_uid = "", game_start = false) {
-        // LOGGER.info($"sgts : ${sgt_types}");
+        //LOGGER.info($"sgts : ${sgt_types}");
+        
 
         var roles = active_roles();
 
@@ -222,20 +223,55 @@ function UnitGroup(units) constructor {
         var _fill_squad = obj_ini.squad_types[$ squad_type];
 
         var _fulfilled = false;
+        //adding multiple role sources on gen within a single squad
+        var _all_roles_to_fetch = array_create(0);
+            for (var r = 0; r < array_length(squad_unit_types); r++) {
+            var _primary_role = squad_unit_types[r];
+            var _primary_role_def = _fill_squad[$ _primary_role];
+            var _primary_role_name = struct_exists(_primary_role_def, "role") ? _primary_role_def.role : _primary_role;
+            LOGGER.info($"Squad type: {squad_type}, Looking for roles: {_all_roles_to_fetch}");
+            if (!array_contains(_all_roles_to_fetch, _primary_role_name)) {
+                array_push(_all_roles_to_fetch, _primary_role_name);
+            }
 
-        var _squadless = get_from({squadless: true, roles: squad_unit_types});
+            //add alternative source roles to fetch list if this squad role defines them
+            if (struct_exists(_primary_role_def, "alternative_roles")) {
+                var _alternatives = _primary_role_def.alternative_roles;
+                for (var a = 0; a < array_length(_alternatives); a++) {
+                    if (!array_contains(_all_roles_to_fetch, _alternatives[a])) {
+                        array_push(_all_roles_to_fetch, _alternatives[a]);
+                    }
+                }
+            }
+        }
+
+
+        var _squadless = get_from({squadless: true, roles: _all_roles_to_fetch});
+        LOGGER.info($"Squadless count before: {_squadless.number()}");
 
         for (var s = 0; s < 2; s++) {
             var _sgt_type = sgt_types[s];
-            var _available_sgt = _squadless.get_from({role: _sgt_type, max_wanted: 1});
+            var _available_sgt = _squadless.get_from({role: _sgt_type, max_wanted: 1}, true, true);
 
             if (_available_sgt.number() == 0) {
                 continue;
             }
 
             var _sgt = _available_sgt.units[0];
-            squad.add_member(_sgt);
-            squad_fulfilment[$ _sgt_type]++;
+            squad.add_member(_sgt.company, _sgt.marine_number);
+            var _sgt_group = "";
+            for (var r = 0; r < array_length(squad_unit_types); r++) {
+                var _role_name = squad_unit_types[r];
+                var _role_def = _fill_squad[$ _role_name];
+                var _primary_role_name = struct_exists(_role_def, "role") ? _role_def.role : _role_name;
+                if (_primary_role_name == _sgt_type) {
+                    _sgt_group = _role_name;
+                    break;
+                }
+            }
+            if (_sgt_group != "") {
+                squad_fulfilment[$ _sgt_group]++;
+            }
             sergeant_found = true;
         }
 
@@ -252,8 +288,17 @@ function UnitGroup(units) constructor {
             var _has_sgt_requirements = false;
             for (var s = 0; s < 2; s++) {
                 var _sgt_type = sgt_types[s];
-                if (array_contains(squad_unit_types, _sgt_type)) {
-                    _has_sgt_requirements = true;
+                for (var r = 0; r < array_length(squad_unit_types); r++) {
+                    var _role_name = squad_unit_types[r];
+                    var _role_def = _fill_squad[$ _role_name];
+                    var _primary_role_name = struct_exists(_role_def, "role") ? _role_def.role : _role_name;
+                    if (_sgt_type == _primary_role_name) {
+                        _has_sgt_requirements = true;
+                        break;
+                    }
+                }
+                if (_has_sgt_requirements) {
+                    break;
                 }
             }
 
@@ -262,14 +307,47 @@ function UnitGroup(units) constructor {
             }
 
             //clone or else keeps pushing up number
-            var _max = variable_clone(_fill_squad[$ _unit.role()][$ "max"]);
+            //EXPERIMENTAL Determine which role GROUP this marine belongs to
+            var _target_role = _unit.role();
+            var _role_group = "";  // default to the marine's own role
+            
+            // Search through defined role groups to find which one this marine belongs to
+            for (var r = 0; r < array_length(squad_unit_types); r++) {
+                var _role_name = squad_unit_types[r];
+                var _role_def = _fill_squad[$ _role_name];
+                var _primary_role_name = struct_exists(_role_def, "role") ? _role_def.role : _role_name;
+
+                
+                // Check if marine matches this primary role
+                if (_target_role == _primary_role_name) {
+                    _role_group = _role_name;
+                    break;
+                }
+                
+                // Check if marine matches any alternative roles for this group
+                if (struct_exists(_role_def, "alternative_roles")) {
+                    var _alts = _role_def.alternative_roles;
+                    if (array_contains(_alts, _target_role)) {
+                        _role_group = _role_name;
+                        break;
+                    }
+                }
+            }
+
+            if (_role_group == "") {
+                continue;
+            }
+            
+            // NEW: Check max capacity for the ROLE GROUP (not the source role)
+            var _max = variable_clone(_fill_squad[$ _role_group][$ "max"]);
             if (_has_sgt_requirements) {
                 _max += 1;
             }
 
-            if (squad_fulfilment[$ _unit.role()] < _max) {
+            // NEW: Track fulfillment by role GROUP, allowing alternatives to fill the same slot
+            if (squad_fulfilment[$ _role_group] < _max) {
                 //if sergeants not required
-                squad_fulfilment[$ _unit.role()]++;
+                squad_fulfilment[$ _role_group]++;
                 squad.add_member(_unit.company, _unit.marine_number);
             }
         }
@@ -284,10 +362,23 @@ function UnitGroup(units) constructor {
         }
         for (var s = 0; s < 2; s++) {
             var _sgt_type = sgt_types[s];
-            if (struct_exists(squad_fulfilment, _sgt_type) && (!sergeant_found)) {
+            var _sgt_group = "";
+            for (var r = 0; r < array_length(squad_unit_types); r++) {
+                var _role_name = squad_unit_types[r];
+                var _role_def = _fill_squad[$ _role_name];
+                var _primary_role_name = struct_exists(_role_def, "role") ? _role_def.role : _role_name;
+                if (_primary_role_name == _sgt_type) {
+                    _sgt_group = _role_name;
+                    break;
+                }
+            }            if (_sgt_group != "" && struct_exists(squad_fulfilment, _sgt_group) && (!sergeant_found)) {
                 var _exp_unit = _members.highest_exp();
 
-                squad_fulfilment[$ _sgt_type]++;
+                _exp_unit.update_role(_sgt_type);
+                squad_fulfilment[$ _sgt_group]++;
+                if (game_start && irandom(1) == 0) {
+                    _exp_unit.add_trait("lead_example");
+                }
             }
         }
 

--- a/scripts/scr_chapter_new/scr_chapter_new.gml
+++ b/scripts/scr_chapter_new/scr_chapter_new.gml
@@ -104,6 +104,7 @@ function ChapterData() constructor {
         armour: "",
     };
     extra_ships = {
+        glorianas: 0,
         battle_barges: 0,
         gladius: 0,
         strike_cruisers: 0,

--- a/scripts/scr_chapter_new/scr_chapter_new.gml
+++ b/scripts/scr_chapter_new/scr_chapter_new.gml
@@ -30,7 +30,7 @@ function ChapterData() constructor {
     home_planets = 1;
 
     flagship_name = global.name_generator.GenerateFromSet("imperial_ship");
-    monastary_name = "";
+    monastery_name = "";
     advantages = array_create(9);
     disadvantages = array_create(9);
     discipline = "librarius"; // todo convert to enum

--- a/scripts/scr_company_order/scr_company_order.gml
+++ b/scripts/scr_company_order/scr_company_order.gml
@@ -204,6 +204,76 @@ function role_hierarchy() {
         "Death Company",
         _roles[eROLE.VETERANSERGEANT],
         _roles[eROLE.SERGEANT],
+    ];
+
+    // Dynamically collect squad-specific sergeant role variants (e.g. "Biker Sergeant", "Tactical Sergeant")
+    // so they sort immediately after the generic sergeant, keeping them at the top of their squads
+    var _sgt_base  = _roles[eROLE.SERGEANT];
+    var _vsgt_base = _roles[eROLE.VETERANSERGEANT];
+    var _squad_type_names = struct_get_names(obj_ini.squad_types);
+    for (var _si = 0; _si < array_length(_squad_type_names); _si++) {
+        var _sq_data = obj_ini.squad_types[$ _squad_type_names[_si]];
+        var _sq_keys = struct_get_names(_sq_data);
+        for (var _ki = 0; _ki < array_length(_sq_keys); _ki++) {
+            var _k = _sq_keys[_ki];
+            if (_k == "type_data") continue;
+            var _role_def = _sq_data[$ _k];
+            if (!struct_exists(_role_def, "role")) continue;
+            var _specific_role = _role_def.role;
+            if (!array_contains(hierarchy, _specific_role)) {
+                if (string_count(_vsgt_base, _specific_role) > 0) {
+                    // Veteran-sergeant variant — insert just before _vsgt_base position
+                    var _vpos = array_get_index(hierarchy, _vsgt_base);
+                    array_insert(hierarchy, max(0, _vpos), _specific_role);
+                } else if (string_count(_sgt_base, _specific_role) > 0) {
+                    // Regular sergeant variant — insert just after _sgt_base position
+                    var _spos = array_get_index(hierarchy, _sgt_base);
+                    array_insert(hierarchy, _spos + 1, _specific_role);
+                }
+            }
+        }
+    }
+
+    // Also add non-sergeant squad-specific role variants so they appear after their base role
+    var _base_roles = [
+        _roles[eROLE.TERMINATOR], _roles[eROLE.VETERAN],
+        _roles[eROLE.TACTICAL], _roles[eROLE.ASSAULT],
+        _roles[eROLE.DEVASTATOR], _roles[eROLE.SCOUT],
+        _roles[eROLE.ANCIENT], _roles[eROLE.CHAMPION],
+        _roles[eROLE.CHAPLAIN], _roles[eROLE.APOTHECARY],
+        _roles[eROLE.TECHMARINE], _roles[eROLE.LIBRARIAN]
+    ];
+    for (var _si = 0; _si < array_length(_squad_type_names); _si++) {
+        var _sq_data = obj_ini.squad_types[$ _squad_type_names[_si]];
+        var _sq_keys = struct_get_names(_sq_data);
+        for (var _ki = 0; _ki < array_length(_sq_keys); _ki++) {
+            var _k = _sq_keys[_ki];
+            if (_k == "type_data") continue;
+            var _role_def = _sq_data[$ _k];
+            if (!struct_exists(_role_def, "role")) continue;
+            var _specific_role = _role_def.role;
+            if (array_contains(hierarchy, _specific_role)) continue;
+            // Skip sergeant variants (already handled above)
+            if (string_count(_sgt_base, _specific_role) > 0) continue;
+            // Find the closest matching base role and insert after it
+            for (var _bi = 0; _bi < array_length(_base_roles); _bi++) {
+                if (struct_exists(_role_def, "alternative_roles") &&
+                    array_contains(_role_def.alternative_roles, _base_roles[_bi])) {
+                    var _bpos = array_get_index(hierarchy, _base_roles[_bi]);
+                    if (_bpos >= 0) {
+                        array_insert(hierarchy, _bpos + 1, _specific_role);
+                        break;
+                    }
+                }
+            }
+            // If not inserted via alternative_roles, just append before rank-and-file
+            if (!array_contains(hierarchy, _specific_role)) {
+                array_push(hierarchy, _specific_role);
+            }
+        }
+    }
+
+    array_push(hierarchy,
         _roles[eROLE.TERMINATOR],
         _roles[eROLE.VETERAN],
         _roles[eROLE.TACTICAL],
@@ -218,7 +288,7 @@ function role_hierarchy() {
         "Sister of Battle",
         "Flash Git",
         "Ork Sniper"
-    ];
+    );
 
     return hierarchy;
 }

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -3098,7 +3098,7 @@ function add_unit_to_company(ttrpg_name, company, slot, role_name, role_id, wep1
         spawn_unit.add_trait("champion");
     }
     if (role_id == eROLE.APOTHECARY) {
-        spawn_unit.add_trait("soft_target");
+        spawn_unit.add_trait("scholar");
     }
     if (role_id == eROLE.LIBRARIAN) {
         if (scr_has_adv("Favoured By The Warp") && (roll_dice_unit(1, 6, "high", spawn_unit) >= 4)) {

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -3002,6 +3002,11 @@ function scr_initialize_custom() {
     LOGGER.info("set up the starting squads");
     obj_ini.squads = {};
     game_start_squads();
+
+    // Populate TTRPG display arrays immediately so the management screen
+    // shows unit data before any fleet event fires sort_all_companies
+    LOGGER.info("initial company sort");
+    sort_all_companies();
 }
 
 /// @description helper function to streamline code inside of scr_initialize_custom, should only be used as part of

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -3002,11 +3002,6 @@ function scr_initialize_custom() {
     LOGGER.info("set up the starting squads");
     obj_ini.squads = {};
     game_start_squads();
-
-    // Populate TTRPG display arrays immediately so the management screen
-    // shows unit data before any fleet event fires sort_all_companies
-    LOGGER.info("initial company sort");
-    sort_all_companies();
 }
 
 /// @description helper function to streamline code inside of scr_initialize_custom, should only be used as part of

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -881,6 +881,7 @@ function scr_initialize_custom() {
     fleet_type = obj_creation.fleet_type;
 
     #region Ship Setup
+    glorianas = 0;
     battle_barges = 0;
     strike_cruisers = 0;
     gladius = 0;
@@ -939,6 +940,7 @@ function scr_initialize_custom() {
         strike_cruisers += 2;
     }
     if (struct_exists(obj_creation, "extra_ships")) {
+        glorianas = glorianas + obj_creation.extra_ships.gloriana;
         battle_barges = battle_barges + obj_creation.extra_ships.battle_barges;
         strike_cruisers = strike_cruisers + obj_creation.extra_ships.strike_cruisers;
         gladius = gladius + obj_creation.extra_ships.gladius;
@@ -949,14 +951,20 @@ function scr_initialize_custom() {
     // LOGGER.info(ship_summary_str);
     // LOGGER.debug(ship_summary_str);
 
-    if (battle_barges >= 1) {
-        for (v = 0; v < battle_barges; v++) {
-            var new_ship = new_player_ship("Battle Barge", "home");
-            if ((flagship_name != "") && (v == 0)) {
-                ship[new_ship] = flagship_name;
-            }
-        }
-    }
+    if (glorianas>=1)
+	{
+	for (v=0;v<glorianas;v++){
+		var new_ship = new_player_ship("Gloriana", "home");
+		if (flagship_name!="") and (v=0) then ship[new_ship]=flagship_name;
+	}
+	}
+	if (battle_barges>=1)
+	{
+	 	for (v=0;v<battle_barges;v++){
+	 		var new_ship = new_player_ship("Battle Barge", "home");
+		    if (flagship_name=="") && (v=0) then ship[new_ship]=flagship_name;
+		}
+	}
 
     for (var i = 0; i < strike_cruisers; i++) {
         new_player_ship("Strike Cruiser");

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -1685,7 +1685,17 @@ function scr_initialize_custom() {
     #endregion
 
     #region Squad Loadouts
-    obj_ini.chapter_squad_arrangement = json_to_gamemaker(working_directory + $"main\\squads\\company_squad_builds.json", json_parse);
+    if (scr_has_adv("Lightning Warriors")) {
+        obj_ini.chapter_squad_arrangement = json_to_gamemaker(
+            working_directory + $"main\\squads\\lightning_warriors.json",
+            json_parse
+        );
+    } else {
+        obj_ini.chapter_squad_arrangement = json_to_gamemaker(
+            working_directory + $"main\\squads\\company_squad_builds.json",
+            json_parse
+        );
+    }
 
     var _squad_name = "Squad";
     if (obj_creation.custom != eCHAPTER_TYPE.PREMADE) {
@@ -1866,40 +1876,7 @@ function scr_initialize_custom() {
         };
     }
 
-    /*if (scr_has_adv("Lightning Warriors")) {
-        variable_struct_set(
-            custom_squads,
-            "bikers",
-            [
-                [
-                    roles.assault,
-                    {
-                        "max": 9,
-                        "min": 4,
-                        "loadout": {
-                            //tactical marine
-                            "required": {"wep1": ["", "max"], "wep2": ["Chainsword", "max"], "mobi": ["Bike", "max"]},
-                        },
-                        "role": $"Biker",
-                    }
-                ],
-                [
-                    roles.sergeant,
-                    {
-                        "max": 1,
-                        "min": 1,
-                        "loadout": {
-                            //sergeant
-                            "required": {"wep1": ["", "max"], "wep2": ["Chainsword", "max"], "mobi": ["Bike", 1]},
-                        },
-                        "role": $"Biker {roles.sergeant}",
-                    }
-                ],
-                ["type_data", {"display_data": $"Bike {_squad_name}", "class": ["bike"], "formation_options": ["assault", "tactical"]}]
-            ]
-        );
-    }
-
+    /*
     if (scr_has_adv("Boarders")) {
         variable_struct_set(
             custom_squads,

--- a/scripts/scr_management/scr_management.gml
+++ b/scripts/scr_management/scr_management.gml
@@ -88,18 +88,454 @@ function scr_management(argument0) {
             pane.header = 1;
             pane.title = t;
 
-            var _company_group = collect_company(company).index_roles();
+            xx += 156;
+        }
 
-            pane.line = array_join(pane.line, _company_group.create_plural_strings_array());
+        // Generates the company if there are more than 10 companites
+        // TODO improve logic or add extra romanNumerals to array TBD
+        if (obj_ini.companies > 10) {
+            xx = 25;
+            yy = 400 - 48 + 258;
+            t = "";
 
-            var num = array_create(5, 0);
-            var nam = [
-                "Land Raider",
-                "Predator",
-                "Rhino",
-                "Land Speeder",
-                "Whirlwind"
-            ];
+            for (var i = 11; i <= obj_ini.companies; i++) {
+                t = scr_convert_company_to_string(i);
+
+                var pane = instance_create(xx, yy, obj_managment_panel);
+                pane.company = i;
+                pane.manage = i + 100;
+                pane.header = 1;
+                pane.title = t;
+
+                xx += 156;
+            }
+        }
+
+        for (var i = 1; i <= 50; i++) {
+            num[i] = 0;
+            nam[i] = "";
+        }
+
+        // ****** MAIN PANEL ******
+        q = 0;
+        company = 0;
+        obj_controller.temp[71] = 11;
+
+        for (var i = 0; i < 50; i++) {
+            num[i] = 0;
+            nam[i] = "";
+        }
+        nam[2] = role_names[eROLE.HONOURGUARD];
+
+        for (var i = 0; i < array_length(obj_ini.name[0]); i++) {
+            unit = fetch_unit([0, i]);
+            if (unit.role() == obj_ini.role[100][eROLE.CHAPTERMASTER]) {
+                num[1] += 1;
+                if (nam[1] == "") {
+                    nam[1] = unit.name();
+                }
+            }
+            if (unit.role() == role_names[eROLE.HONOURGUARD]) {
+                num[2] += 1;
+            }
+        }
+
+        // if (num[2]=0) then nam[2]="Strategic Staff";// reserved for co-master alien or something
+
+        // if (num[2]>0) {
+        // 	nam[2]=string(num)+"x "+string(role_names[eROLE.HONOURGUARD]);
+        // 	nam[3]="Strategic Staff";
+        // 	num[3]=1;
+        // }
+
+        with (obj_managment_panel) {
+            if (manage != obj_controller.temp[71]) {
+                instance_deactivate_object(id);
+            }
+        }
+
+        if (num[1] > 0) {
+            q++;
+            obj_managment_panel.line[q] = string(nam[1]);
+            // obj_managment_panel.italic[q]=1;
+            obj_managment_panel.bold[q] = 1;
+        }
+        if (num[2] > 0) {
+            q++;
+            obj_managment_panel.line[q] = string_plural_count(nam[2], num[2], false);
+        }
+
+        // obj_managment_panel.italic[1]=1;
+        obj_managment_panel.bold[q] = 1;
+        instance_activate_object(obj_managment_panel);
+
+        // ll=0;ll2=0;repeat(200){ll2++;if (obj_ini.role[company,ll2]=role_names[eROLE.HONOURGUARD]) then ll++;}
+        // if (ll>0) then temp[3]=string(ll)+"x "+string(role_names[eROLE.HONOURGUARD]);
+
+        // ** Apothecarium **
+        q = 0;
+        company = 0;
+        obj_controller.temp[71] = 12;
+        for (var i = 0; i < 50; i++) {
+            num[i] = 0;
+            nam[i] = "";
+        }
+        nam[2] = role_names[eROLE.APOTHECARY];
+
+        // Ranks
+        nam[3] = string(role_names[eROLE.APOTHECARY]) + " Aspirant"; // nam[4]="Sister Hospitaler";
+
+        for (var i = 1; i <= 200; i++) {
+            unit = fetch_unit([0, i]);
+            if (unit.role() == "Master of the Apothecarion") {
+                num[1] += 1;
+                if (nam[1] == "") {
+                    nam[1] = unit.name();
+                }
+            }
+
+            if (unit.role() == role_names[eROLE.APOTHECARY]) {
+                num[2] += 1;
+            }
+
+            if (unit.role() == string(role_names[eROLE.APOTHECARY]) + " Aspirant") {
+                num[3] += 1;
+            }
+            // if (unit.role() == "Sister Hospitaler") then num[4] += 1;
+        }
+
+        with (obj_managment_panel) {
+            if (manage != obj_controller.temp[71]) {
+                instance_deactivate_object(id);
+            }
+        }
+
+        if (num[1] > 0) {
+            q++;
+            obj_managment_panel.line[q] = string(nam[1]);
+            // obj_managment_panel.italic[q]=1;
+            obj_managment_panel.bold[q] = 1;
+        }
+        if (num[2] > 0) {
+            q++;
+            obj_managment_panel.line[q] = string_plural_count(nam[2], num[2], false);
+        }
+        if (num[3] > 0) {
+            q++;
+            obj_managment_panel.line[q] = string_plural_count(nam[3], num[3], false);
+        }
+        // if (num[4]>0){q++;obj_managment_panel.line[q]=string(num[4])+"x "+string(nam[4]);}
+        instance_activate_object(obj_managment_panel);
+
+        // ** Reclusium **
+        q = 0;
+        company = 0;
+        obj_controller.temp[71] = 14;
+
+        for (var i = 0; i < 50; i++) {
+            num[i] = 0;
+            nam[i] = "";
+        }
+
+        nam[2] = role_names[eROLE.CHAPLAIN];
+
+        // Ranks
+        nam[3] = string(role_names[eROLE.CHAPLAIN]) + " Aspirant";
+
+        for (var i = 1; i <= 200; i++) {
+            unit = fetch_unit([0, i]);
+            if (unit.role() == "Master of Sanctity") {
+                num[1] += 1;
+                if (nam[1] == "") {
+                    nam[1] = unit.name();
+                }
+            }
+
+            if (unit.role() == role_names[eROLE.CHAPLAIN]) {
+                num[2] += 1;
+            }
+
+            if (unit.role() == string(role_names[eROLE.CHAPLAIN]) + " Aspirant") {
+                num[3] += 1;
+            }
+        }
+
+        with (obj_managment_panel) {
+            if (manage != obj_controller.temp[71]) {
+                instance_deactivate_object(id);
+            }
+        }
+
+        if (num[1] > 0) {
+            q++;
+            obj_managment_panel.line[q] = string(nam[1]);
+            // obj_managment_panel.italic[q]=1;
+            obj_managment_panel.bold[q] = 1;
+        }
+
+        // TODO add specific Space Wolves and successor chapter logic for Master of Sanctity
+        // if (global.chapter_name!="Space Wolves")
+
+        // Specific Iron Hands chapter logic
+        if (chapter_name != "Iron Hands") {
+            if (num[2] > 0) {
+                q++;
+                obj_managment_panel.line[q] = string_plural_count(nam[2], num[2], false);
+            }
+            if (num[3] > 0) {
+                q++;
+                obj_managment_panel.line[q] = string_plural_count(nam[3], num[3], false);
+            }
+        }
+        instance_activate_object(obj_managment_panel);
+
+        // ** Armoury **
+        q = 0;
+        company = 0;
+        obj_controller.temp[71] = 15;
+
+        for (var i = 0; i < 50; i++) {
+            num[i] = 0;
+            nam[i] = "";
+        }
+
+        nam[2] = role_names[eROLE.TECHMARINE];
+
+        // Ranks
+        nam[3] = string(role_names[eROLE.TECHMARINE]) + " Aspirant";
+        nam[4] = "Techpriest";
+
+        for (var i = 1; i <= 200; i++) {
+            unit = fetch_unit([0, i]);
+            if (unit.role() == "Forge Master") {
+                num[1] += 1;
+                if (nam[1] == "") {
+                    nam[1] = unit.name();
+                }
+            }
+
+            if (unit.role() == role_names[eROLE.TECHMARINE]) {
+                num[2] += 1;
+            }
+
+            if (unit.role() == string(role_names[eROLE.TECHMARINE]) + " Aspirant") {
+                num[3] += 1;
+            }
+
+            if (unit.role() == "Techpriest") {
+                num[4] += 1;
+            }
+        }
+
+        with (obj_managment_panel) {
+            if (manage != obj_controller.temp[71]) {
+                instance_deactivate_object(id);
+            }
+        }
+
+        if (num[1] > 0) {
+            q++;
+            obj_managment_panel.line[q] = string(nam[1]);
+            // obj_managment_panel.italic[q]=1;
+            obj_managment_panel.bold[q] = 1;
+        }
+
+        if (num[2] > 0) {
+            q++;
+            obj_managment_panel.line[q] = string_plural_count(nam[2], num[2], false);
+        }
+
+        if (num[3] > 0) {
+            q++;
+            obj_managment_panel.line[q] = string_plural_count(nam[3], num[3], false);
+        }
+
+        if (num[4] > 0) {
+            q++;
+            obj_managment_panel.line[q] = string_plural_count(nam[4], num[4], false);
+        }
+
+        instance_activate_object(obj_managment_panel);
+
+        // ** Librarium **
+        q = 0;
+        company = 0;
+        obj_controller.temp[71] = 13;
+        for (var i = 0; i < 50; i++) {
+            num[i] = 0;
+            nam[i] = "";
+        }
+
+        nam[2] = role_names[eROLE.LIBRARIAN];
+
+        // Ranks
+        nam[3] = "Codiciery";
+        nam[4] = "Lexicanum";
+        nam[5] = string(role_names[eROLE.LIBRARIAN]) + " Aspirant";
+
+        for (var i = 1; i <= 200; i++) {
+            unit = fetch_unit([0, i]);
+            if (unit.role() == "Chief " + string(role_names[eROLE.LIBRARIAN])) {
+                num[1] += 1;
+                if (nam[1] == "") {
+                    nam[1] = unit.name();
+                }
+            }
+
+            if (unit.role() == role_names[eROLE.LIBRARIAN]) {
+                num[2] += 1;
+            }
+
+            if (unit.role() == "Codiciery") {
+                num[3] += 1;
+            }
+
+            if (unit.role() == "Lexicanum") {
+                num[4] += 1;
+            }
+
+            if (unit.role() == string(role_names[eROLE.LIBRARIAN]) + " Aspirant") {
+                num[5] += 1;
+            }
+        }
+
+        with (obj_managment_panel) {
+            if (manage != obj_controller.temp[71]) {
+                instance_deactivate_object(id);
+            }
+        }
+
+        if (num[1] > 0) {
+            q++;
+            obj_managment_panel.line[q] = string(nam[1]);
+            // obj_managment_panel.italic[q]=1;
+            obj_managment_panel.bold[q] = 1;
+        }
+
+        if (num[2] > 0) {
+            q++;
+            obj_managment_panel.line[q] = string_plural_count(nam[2], num[2], false);
+        }
+
+        if (num[3] > 0) {
+            q++;
+            obj_managment_panel.line[q] = string_plural_count(nam[3], num[3], false);
+        }
+
+        if (num[4] > 0) {
+            q++;
+            obj_managment_panel.line[q] = string_plural_count(nam[4], num[4], false);
+        }
+
+        if (num[5] > 0) {
+            q++;
+            obj_managment_panel.line[q] = string_plural_count(nam[5], num[5], false);
+        }
+
+        instance_activate_object(obj_managment_panel);
+
+        // ** Marines and vehicles per company and HQ by ranks **
+        for (company = 1; company <= obj_ini.companies; company++) {
+            q = 0;
+            obj_controller.temp[71] = company;
+
+            for (var i = 0; i < 50; i++) {
+                num[i] = 0;
+                nam[i] = "";
+            }
+            // Indexing the names to nam array
+            // nam[1] = role_names[eROLE.CAPTAIN];
+            nam[2] = role_names[eROLE.CHAPLAIN];
+            nam[3] = role_names[eROLE.APOTHECARY];
+            nam[4] = role_names[eROLE.TECHMARINE];
+            nam[5] = role_names[eROLE.LIBRARIAN];
+            nam[6] = "Codiciery";
+            nam[7] = "Lexicanum";
+            nam[8] = "Company" + role_names[eROLE.ANCIENT];
+            nam[9] = (role_names[eROLE.CHAMPION] == "Champion") ? "Champion" : role_names[eROLE.CHAMPION];
+            nam[10] = role_names[eROLE.TERMINATOR];
+            nam[11] = role_names[eROLE.SERGEANT];
+            nam[12] = (role_names[eROLE.VETERANSERGEANT] == "Veteran Sergeant") ? "Sergeant" : role_names[eROLE.VETERANSERGEANT];
+            nam[13] = role_names[eROLE.VETERAN];
+            nam[14] = role_names[eROLE.TACTICAL];
+            nam[15] = role_names[eROLE.ASSAULT];
+            nam[16] = role_names[eROLE.DEVASTATOR];
+            nam[17] = role_names[eROLE.SCOUT];
+            nam[18] = role_names[eROLE.DREADNOUGHT]; // Venerable Dreadnought, just the role name is too long for the company box
+            nam[19] = role_names[eROLE.DREADNOUGHT];
+            nam[20] = "Land Raider";
+            nam[21] = "Predator";
+            nam[22] = "Rhino";
+            nam[23] = "Land Speeder";
+            nam[24] = "Whirlwind";
+            for (var i = 0; i < array_length(obj_ini.TTRPG[company]); i++) {
+                unit = obj_ini.TTRPG[company][i];
+                if (unit.name() == "") {
+                    continue;
+                }
+                if (unit.role() == role_names[eROLE.CAPTAIN]) {
+                    num[1]++;
+                    nam[1] = unit.name();
+                }
+                // Space Wolves exception
+                if (chapter_name != "Iron Hands" && unit.role() == role_names[eROLE.CHAPLAIN]) {
+                    num[2]++;
+                }
+                if (chapter_name != "Space Wolves" && unit.role() == role_names[eROLE.APOTHECARY]) {
+                    num[3]++;
+                }
+                if (unit.role() == role_names[eROLE.TECHMARINE]) {
+                    num[4]++;
+                }
+                if (unit.role() == role_names[eROLE.LIBRARIAN]) {
+                    num[5]++;
+                }
+                if (unit.role() == "Codiciery") {
+                    num[6]++;
+                }
+                if (unit.role() == "Lexicanum") {
+                    num[7]++;
+                }
+                if (unit.role() == role_names[eROLE.ANCIENT]) {
+                    num[8]++;
+                }
+                if (unit.role() == role_names[eROLE.CHAMPION]) {
+                    num[9]++;
+                }
+                if (unit.role() == role_names[eROLE.TERMINATOR]) {
+                    num[10]++;
+                }
+                // Count all "X Sergeant" variants (Tactical Sergeant, Biker Sergeant, etc.) but not Veteran Sergeant
+                if (string_count(role_names[eROLE.SERGEANT], unit.role()) > 0 && unit.role() != role_names[eROLE.VETERANSERGEANT]) {
+                    num[11]++;
+                }
+                // Count all "Veteran Sergeant" variants (Terminator Sergeant, Veteran Sergeant, etc.)
+                if (string_count(role_names[eROLE.VETERANSERGEANT], unit.role()) > 0) {
+                    num[12]++;
+                }
+                if (unit.role() == role_names[eROLE.VETERAN]) {
+                    num[13]++;
+                }
+                if (unit.role() == role_names[eROLE.TACTICAL]) {
+                    num[14]++;
+                }
+                if (unit.role() == role_names[eROLE.ASSAULT]) {
+                    num[15]++;
+                }
+                if (unit.role() == role_names[eROLE.DEVASTATOR]) {
+                    num[16]++;
+                }
+                if (unit.role() == role_names[eROLE.SCOUT]) {
+                    num[17]++;
+                }
+                if (unit.role() == "Venerable " + string(role_names[eROLE.DREADNOUGHT])) {
+                    num[18]++;
+                }
+                if (unit.role() == role_names[eROLE.DREADNOUGHT]) {
+                    num[19]++;
+                }
+            }
+
             // Vehicles
             for (var i = 0; i < array_length(obj_ini.veh_role[company]); i++) {
                 for (var s = 0; s < array_length(nam); s++) {

--- a/scripts/scr_management/scr_management.gml
+++ b/scripts/scr_management/scr_management.gml
@@ -10,6 +10,11 @@ function scr_management(argument0) {
     var unit;
 
     if (argument0 == 1) {
+        // Ensure TTRPG display data is up to date before drawing the overview
+        with (obj_ini) {
+            sort_all_companies();
+        }
+
         with (obj_managment_panel) {
             instance_destroy();
         }
@@ -87,6 +92,10 @@ function scr_management(argument0) {
             pane.manage = company;
             pane.header = 1;
             pane.title = t;
+
+            // Populate company panel — same pattern as the HQ specialty panels above
+            var _co_units = collect_company(company).index_roles();
+            pane.line = array_join(pane.line, _co_units.create_plural_strings_array());
 
             xx += 156;
         }
@@ -545,17 +554,7 @@ function scr_management(argument0) {
                 }
             }
 
-            for (var d = 0; d < 5; d++) {
-                if (num[d] > 0) {
-                    if (d == 1) {
-                        array_push(pane.line, {str1: nam[d], bold: true, italic: false});
-                        // obj_managment_panel.italic[q] = 1;
-                    } else {
-                        array_push(pane.line, nam[d], string_plural_count(nam[d], num[d], false));
-                    }
-                }
-            }
-            xx += 156;
+            // company panels are now populated at creation time above — nothing to do here
         }
     }
 }

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -228,16 +228,18 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
                     stat_boosts({strength: 4, constitution: 4, dexterity: 4}); //will decide on if these are needed
                 }
             }
-            if (!is_specialist(role())) {
-                //logs changes too and from specialist status
-                if (is_specialist(new_role)) {
-                    obj_controller.marines -= 1;
-                    obj_controller.command += 1;
-                }
-            } else {
-                if (!is_specialist(new_role)) {
-                    obj_controller.marines += 1;
-                    obj_controller.command -= 1;
+            if (instance_exists(obj_controller)) {
+                if (!is_specialist(role())) {
+                    //logs changes too and from specialist status
+                    if (is_specialist(new_role)) {
+                        obj_controller.marines -= 1;
+                        obj_controller.command += 1;
+                    }
+                } else {
+                    if (!is_specialist(new_role)) {
+                        obj_controller.marines += 1;
+                        obj_controller.command -= 1;
+                    }
                 }
             }
         }

--- a/scripts/scr_planetary_feature/scr_planetary_feature.gml
+++ b/scripts/scr_planetary_feature/scr_planetary_feature.gml
@@ -152,7 +152,7 @@ function NewPlanetFeature(feature_type, other_data = {}) constructor {
             tier = 1;
             break;
         case eP_FEATURES.MONASTERY:
-            planet_display = "Fortress Monastary";
+            planet_display = "Fortress Monastery";
             player_hidden = 0;
             forge = 0;
             name = global.name_generator.GenerateFromSet("imperial_ship");

--- a/scripts/scr_save_chapter/scr_save_chapter.gml
+++ b/scripts/scr_save_chapter/scr_save_chapter.gml
@@ -104,7 +104,7 @@ function scr_save_chapter(chapter_id) {
 
     chap.disposition = disposition;
     if (variable_instance_exists(self.id, "monastery_name")) {
-        chap.monastary_name = monastery_name;
+        chap.monastery_name = monastery_name;
     }
     chap.chapter_master = {
         name: chapter_master_name,

--- a/scripts/scr_squads/scr_squads.gml
+++ b/scripts/scr_squads/scr_squads.gml
@@ -216,6 +216,38 @@ function SquadEquipmentSorting(squad, from_armoury = true, to_armoury = true) co
         }
     };
 
+    // Picks ONE entry (loadout category) at random, then resolves each slot:
+    // string values are used directly; array values get one item picked at random.
+    // Any slot omitted from an entry is left unchanged on the unit.
+    //
+    // JSON example:
+    //   "random_pick": [
+    //     { "wep1": ["Sword","Axe","Mace"], "wep2": ["Pistol","Plasma","Volkite"] },
+    //     { "wep1": "Lightning Claw", "wep2": "Lightning Claw" }
+    //   ]
+    static equip_random_pick_for_role = function(pick_options) {
+        var _actual_role = role_key_to_actual[$ unit_role];
+        var _members_with_role = members_UnitGroup.get_from({role: _actual_role});
+        while (_members_with_role.number() > 0) {
+            var _unit = _members_with_role.pop();
+            if (array_contains(ignore_units, _unit.uid)) continue;
+            if (_unit.role() != _actual_role) continue;
+
+            // Pick a random loadout category
+            var _chosen = pick_options[irandom(array_length(pick_options) - 1)];
+
+            // Resolve slots: array values → random element; strings → used as-is
+            var _resolved = {};
+            var _slots = struct_get_names(_chosen);
+            for (var _s = 0; _s < array_length(_slots); _s++) {
+                var _slot  = _slots[_s];
+                var _value = _chosen[$ _slot];
+                _resolved[$ _slot] = is_array(_value) ? array_random_element(_value) : _value;
+            }
+            _unit.alter_equipment(_resolved, from_armoury, to_armoury);
+        }
+    };
+
     static role_squad_loadout = function() {
         required_load = undefined;
         optional_load = undefined;
@@ -240,6 +272,11 @@ function SquadEquipmentSorting(squad, from_armoury = true, to_armoury = true) co
         for (var i = 0; i < array_length(load_out_areas); i++) {
             current_load_slot = load_out_areas[i];
             equip_loudouts_specific_equip_slot();
+        }
+
+        // random_pick runs after required/option — picks one complete loadout at random
+        if (struct_exists(_loudout_data, "random_pick")) {
+            equip_random_pick_for_role(_loudout_data[$ "random_pick"]);
         }
     };
 }

--- a/scripts/scr_squads/scr_squads.gml
+++ b/scripts/scr_squads/scr_squads.gml
@@ -302,6 +302,16 @@ function UnitSquad(squad_type = undefined, company = 0) constructor {
             }
             squad_fulfilment[$ _wanted_unit_role] = 0; //create a fulfilment structure to log members of squad
         }
+        //Mapping for role groups in alternative source; 
+        squad_role_alternatives = {};
+            for (var i =0; i < array_length(squad_unit_types); i++) {
+                var _role_name = squad_unit_types[i];
+                var _role_def = fill_squad[$ _role_name];
+                //alternative source presence check
+                if (struct_exists(_role_def, "alternative_roles")) {
+                    squad_role_alternatives[$ _role_name] = _role_def.alternative_roles;
+                }
+            }
         return squad_unit_types;
     };
 

--- a/scripts/scr_squads/scr_squads.gml
+++ b/scripts/scr_squads/scr_squads.gml
@@ -45,10 +45,19 @@ function SquadEquipmentSorting(squad, from_armoury = true, to_armoury = true) co
     squad_type = target_squad.type;
     squad_unit_types = squad.find_squad_unit_types();
     full_squad_data = obj_ini.squad_types[$ squad_type];
+    //build a map from JSON key
+    role_key_to_actual = {};
+    for (var _i = 0; _i < array_length(squad_unit_types); _i++) {
+    var _key = squad_unit_types[_i];
+    var _def = full_squad_data[$ _key];
+    var _actual = struct_exists(_def, "role") ? _def.role : _key;
+    role_key_to_actual[$ _key] = _actual;
+    }
     unit_role = "";
     members_UnitGroup = squad.get_members(true);
     members_UnitGroup.shuffle();
     optional_load = undefined;
+    optional_fill_counts = {};   // flat struct: "slot_groupIndex" -> filled count
     required_load = undefined;
 
     target_squad.update_fulfilment();
@@ -70,14 +79,19 @@ function SquadEquipmentSorting(squad, from_armoury = true, to_armoury = true) co
     ];
 
     static structure_role_optional_loadout = function(optional_data) {
-        optional_load = variable_clone(optional_data); //create a fulfillment object for optional loadouts
+        // Use the original data directly — no clone needed since optional_load is now read-only
+        // (all mutable state lives in optional_fill_counts). variable_clone can incorrectly
+        // flatten doubly-nested arrays in this GML version, corrupting the group structure.
+        optional_load = optional_data;
 
+        // Initialise fill-count tracking in a flat struct (struct field writes are always
+        // in-place in GML — no copy-on-write issues unlike nested array element writes)
+        optional_fill_counts = {};
         var _optional_loadout_slots = struct_get_names(optional_load);
-
         for (var slot = 0; slot < array_length(_optional_loadout_slots); slot++) {
             var _load_out_slot = _optional_loadout_slots[slot];
             for (var i = 0; i < array_length(optional_load[$ _load_out_slot]); i++) {
-                array_insert(optional_load[$ _load_out_slot][i], 2, 0);
+                optional_fill_counts[$ _load_out_slot + "_" + string(i)] = 0;
             }
         }
     };
@@ -117,13 +131,13 @@ function SquadEquipmentSorting(squad, from_armoury = true, to_armoury = true) co
 
         var _optional_groups = optional_load[$ current_load_slot];
         for (var i = 0; i < array_length(_optional_groups); i++) {
-            var _optional_load_data = _optional_groups[i];
-            var _optionals_filled = _optional_load_data[2];
-            var _optionals_max_allowed = _optional_load_data[1];
-            var _optionals_equipment = _optional_load_data[0];
+            var _count_key             = current_load_slot + "_" + string(i);
+            var _optionals_filled      = optional_fill_counts[$ _count_key];   // read from flat struct
+            var _optionals_max_allowed = _optional_groups[i][1];
+            var _optionals_equipment   = _optional_groups[i][0];
             var _item_to_add;
             if (_optionals_filled < _optionals_max_allowed) {
-                var _is_equipment_set = array_length(_optional_load_data) > 3;
+                var _is_equipment_set = array_length(_optional_groups[i]) > 2;
 
                 if (is_array(_optionals_equipment)) {
                     //if the array items are varibale e.g a struct
@@ -155,9 +169,10 @@ function SquadEquipmentSorting(squad, from_armoury = true, to_armoury = true) co
                 var _opt_load_out = {};
                 _opt_load_out[$ current_load_slot] = _item_to_add;
                 _unit.alter_equipment(_opt_load_out, from_armoury, to_armoury);
-                _optional_load_data[1]++;
+                // Struct field write — guaranteed in-place, no copy-on-write in GML
+                optional_fill_counts[$ _count_key]++;
                 if (_is_equipment_set) {
-                    var _equip_set_data = _optional_load_data[3];
+                    var _equip_set_data = _optional_groups[i][2];
                     if (is_struct(_equip_set_data)) {
                         _unit.alter_equipment(_equip_set_data, from_armoury, to_armoury);
                         array_push(ignore_units, _unit.uid);
@@ -169,7 +184,8 @@ function SquadEquipmentSorting(squad, from_armoury = true, to_armoury = true) co
     };
 
     static equip_loudouts_specific_equip_slot = function() {
-        var _members_with_role = members_UnitGroup.get_from({role: unit_role});
+        var _actual_role = role_key_to_actual[$ unit_role];
+        var _members_with_role = members_UnitGroup.get_from({role:  _actual_role});
         if (!struct_exists(current_unit_squad_data, "loadout")) {
             return;
         }
@@ -177,18 +193,21 @@ function SquadEquipmentSorting(squad, from_armoury = true, to_armoury = true) co
         var _loudouts = current_unit_squad_data[$ "loadout"];
         while (_members_with_role.number() > 0) {
             _unit = _members_with_role.pop();
-            if (array_contains(ignore_units, _unit.uid)) {
-                continue;
-            }
-            if (_unit.role() != unit_role) {
+            if (_unit.role() != _actual_role) {
                 continue;
             }
 
+            // Required loadout is always applied — ignore_units only gates optional extras
             if (required_load != undefined && struct_exists(required_load, current_load_slot)) {
                 var _needed_required = equip_required_for_role(_unit);
                 if (_needed_required) {
                     continue;
                 }
+            }
+
+            // Optional loadout respects ignore_units (units that already got a full equipment set)
+            if (array_contains(ignore_units, _unit.uid)) {
+                continue;
             }
 
             if (optional_load != undefined && struct_exists(optional_load, current_load_slot)) {
@@ -330,10 +349,10 @@ function UnitSquad(squad_type = undefined, company = 0) constructor {
     };
 
     // for creating a new sergeant from existing squad members
-    static new_sergeant = function(veteran = false) {
+    static new_sergeant = function(veteran = false, target_role = undefined) {
         var exp_unit = "";
         var _unit;
-        var highest_exp = 0;
+        var highest_exp = -1;
         var member_length = array_length(members);
         for (var i = 0; i < member_length; i++) {
             _unit = fetch_unit(members[i]);
@@ -343,7 +362,7 @@ function UnitSquad(squad_type = undefined, company = 0) constructor {
                 i--;
                 continue;
             }
-            if (_unit.experience > highest_exp) {
+            if (exp_unit == "" || _unit.experience > highest_exp) {
                 highest_exp = _unit.experience;
                 exp_unit = _unit;
             }
@@ -351,7 +370,9 @@ function UnitSquad(squad_type = undefined, company = 0) constructor {
         if ((array_length(members) > 0) && is_struct(exp_unit)) {
             if (exp_unit.name() != "") {
                 var new_role;
-                if (veteran == true) {
+                if (target_role != undefined) {
+                    new_role = target_role;
+                } else if (veteran == true) {
                     new_role = obj_ini.role[100][19];
                 } else {
                     new_role = obj_ini.role[100][18];
@@ -384,6 +405,8 @@ function UnitSquad(squad_type = undefined, company = 0) constructor {
 
         var squad_unit_types = struct_get_names(fill_squad); //find out what type of units squad consists of
         var unit_type_count = array_length(squad_unit_types);
+        // build actual_role → json_key map to handle slots with a "role" override
+        var _actual_to_key = {};
         for (var i = unit_type_count - 1; i >= 0; i--) {
             var _wanted_unit_role = squad_unit_types[i];
             if (_wanted_unit_role == "type_data") {
@@ -391,6 +414,9 @@ function UnitSquad(squad_type = undefined, company = 0) constructor {
                 continue;
             }
             squad_fulfilment[$ _wanted_unit_role] = 0; //create a fulfilment structure to log members of squad
+            var _role_def = fill_squad[$ _wanted_unit_role];
+            var _mapped = struct_exists(_role_def, "role") ? _role_def.role : _wanted_unit_role;
+            _actual_to_key[$ _mapped] = _wanted_unit_role;
         }
         var member_length = array_length(members);
         for (var i = member_length - 1; i >= 0; i--) {
@@ -400,10 +426,13 @@ function UnitSquad(squad_type = undefined, company = 0) constructor {
                 array_delete(members, i, 1);
                 continue;
             }
-            if (struct_exists(squad_fulfilment, _unit.role())) {
-                squad_fulfilment[$ _unit.role()]++;
+            // map actual role to json key so role-overridden slots are counted correctly
+            var _unit_role = _unit.role();
+            var _slot_key = struct_exists(_actual_to_key, _unit_role) ? _actual_to_key[$ _unit_role] : _unit_role;
+            if (struct_exists(squad_fulfilment, _slot_key)) {
+                squad_fulfilment[$ _slot_key]++;
             } else {
-                squad_fulfilment[$ _unit.role()] = 1;
+                squad_fulfilment[$ _slot_key] = 1;
             }
         }
         fulfilled = true;
@@ -418,8 +447,15 @@ function UnitSquad(squad_type = undefined, company = 0) constructor {
             var _min_role_allowed = fill_squad[$ _wanted_unit_role][$ "min"];
 
             if (fill_from != undefined) {
-                while (fill_from.has_role(_wanted_unit_role) && _squad_role_current < _max_role_count) {
-                    var _new_member = fill_from.pop_role_member(_wanted_unit_role);
+                var _fill_role = struct_exists(fill_squad[$ _wanted_unit_role], "role")
+                    ? fill_squad[$ _wanted_unit_role].role : _wanted_unit_role;
+                // Also try the JSON key itself as a source role (base role before squad rename)
+                var _fill_role_base = _wanted_unit_role;
+                while (_squad_role_current < _max_role_count) {
+                    var _pick_role = fill_from.has_role(_fill_role) ? _fill_role
+                        : (fill_from.has_role(_fill_role_base) ? _fill_role_base : "");
+                    if (_pick_role == "") break;
+                    var _new_member = fill_from.pop_role_member(_pick_role);
                     add_member(_new_member.company, _new_member.marine_number);
                     squad_fulfilment[$ _wanted_unit_role]++;
                     _squad_role_current = squad_fulfilment[$ _wanted_unit_role];
@@ -437,19 +473,23 @@ function UnitSquad(squad_type = undefined, company = 0) constructor {
                 required[$ _wanted_unit_role] = _min_role_allowed - _squad_role_current;
             }
         }
-        var _sarge = obj_ini.role[100][eROLE.SERGEANT];
-        if (struct_exists(required, _sarge)) {
-            if (required[$ _sarge] > 0) {
-                new_sergeant();
-                required[$ _sarge]--;
-            }
-        }
-        //find a new veteran sergeant
-        var _vet_sarge = obj_ini.role[100][eROLE.VETERANSERGEANT];
-        if (struct_exists(required, _vet_sarge)) {
-            if (required[$ _vet_sarge] > 0) {
-                new_sergeant(true);
-                required[$ _vet_sarge]--;
+        var _default_sarge = obj_ini.role[100][eROLE.SERGEANT];
+        var _default_vet_sarge = obj_ini.role[100][eROLE.VETERANSERGEANT];
+        var _required_keys = struct_get_names(required);
+        for (var _ri = 0; _ri < array_length(_required_keys); _ri++) {
+            var _req_key = _required_keys[_ri];
+            if (required[$ _req_key] <= 0) continue;
+            var _role_def = fill_squad[$ _req_key];
+            if (_role_def == undefined) continue;
+            var _actual_role = struct_exists(_role_def, "role") ? _role_def.role : _req_key;
+            if (_req_key == _default_sarge || _actual_role == _default_sarge
+                || string_lower(_req_key) == "sergeant") {
+                new_sergeant(false, _actual_role);
+                required[$ _req_key]--;
+            } else if (_req_key == _default_vet_sarge || _actual_role == _default_vet_sarge
+                || string_lower(_req_key) == "veteran sergeant") {
+                new_sergeant(true, _actual_role);
+                required[$ _req_key]--;
             }
         }
     };

--- a/scripts/scr_start_load/scr_start_load.gml
+++ b/scripts/scr_start_load/scr_start_load.gml
@@ -43,7 +43,7 @@ function scr_start_load(fleet, load_from_star, load_options) {
             if (comp_split > 7 || !comp_has_units[comp_split + 2]) {
                 comp_split = 0;
             }
-            var _squad = fetch_squad(_squad_ids[i]);
+            var _squad = fetch_squad(_squad_ids[squads]);
             if (_squad.base_company == 1) {
                 array_push(total_distribute_squads[comp_split], _squad);
                 comp_split++;
@@ -57,7 +57,7 @@ function scr_start_load(fleet, load_from_star, load_options) {
             if (comp_split > 7 || !comp_has_units[comp_split + 2]) {
                 comp_split = 0;
             }
-            var _squad = fetch_squad(_squad_ids[i]);
+            var _squad = fetch_squad(_squad_ids[squads]);
             if (_squad.base_company == 10) {
                 array_push(total_distribute_squads[comp_split], _squad);
                 comp_split++;

--- a/scripts/scr_start_load/scr_start_load.gml
+++ b/scripts/scr_start_load/scr_start_load.gml
@@ -43,7 +43,7 @@ function scr_start_load(fleet, load_from_star, load_options) {
             if (comp_split > 7 || !comp_has_units[comp_split + 2]) {
                 comp_split = 0;
             }
-            var _squad = fetch_squad(_squad_ids[squads]);
+            var _squad = fetch_squad(_squad_ids[i]);
             if (_squad.base_company == 1) {
                 array_push(total_distribute_squads[comp_split], _squad);
                 comp_split++;
@@ -57,7 +57,7 @@ function scr_start_load(fleet, load_from_star, load_options) {
             if (comp_split > 7 || !comp_has_units[comp_split + 2]) {
                 comp_split = 0;
             }
-            var _squad = fetch_squad(_squad_ids[squads]);
+            var _squad = fetch_squad(_squad_ids[i]);
             if (_squad.base_company == 10) {
                 array_push(total_distribute_squads[comp_split], _squad);
                 comp_split++;


### PR DESCRIPTION
##Contents
- Glorianas counter in chapter jsons, script to support them as flahships and not doubling with BB
- Apothecaries now no longer start with marked for death, replaced by scholar
- Celestial Lions custom Sergeant name removed cause it bugged the vet sergeants, will address post white scars update
##Notes
DA now actually generate the Invincible Reason as their gloriana and flagship

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Gloriana support to chapter JSONs with automatic flagship spawning. Expands squad generation with bikes/attack bikes, multi-role roles, random equipment, and a cleaner company management view.

- **New Features**
  - Chapters can set `extra_ships.gloriana`; the engine creates a `Gloriana` and uses `flagship_name` when present. Dark Angels now generate the Invincible Reason.
  - Adds Attack Bike mobility and buffs Bike melee; introduces Bike and Attack Bike squads; includes Lightning Warriors squad presets; equips Dark Angels Black Knights with Power Swords.
  - Supports multi-origin squads via `alternative_roles`, randomizes equipment loadouts, refactors company panels to sort and summarize roles, and adds an expanded custom chapter template.

- **Bug Fixes**
  - Prevents double-counting battle barges when a Gloriana exists; flagship assignment prefers the Gloriana.
  - Fixes squad generation edge cases and company view rendering for large chapters; orders squad-specific sergeant variants correctly; corrects Lightning Warriors squad data.
  - Apothecaries now start with `scholar` instead of marked for death/`soft_target`; removes Celestial Lions custom `sergeant` title.
  - Corrects “Monastery” naming and save path; updates Contemptor Dreadnought description.

<sup>Written for commit 664420062e882c98a5613a0afc769a59f64171d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

