### PR TITLE
fix: Correctly check for SpriteButton sprite existence

### DIFF
--- a/scripts/scr_buttons/scr_buttons.gml
+++ b/scripts/scr_buttons/scr_buttons.gml
@@ -370,12 +370,12 @@ function SpriteButton(_sprite, _hover_sprite = undefined) constructor {
                 tooltip_draw(tooltip_text, tooltip_w);
             }
 
-            if (is_clicked && sound_click != -1) {
+            if (is_clicked && sound_click != undefined) {
                 audio_play_sound(sound_click, 10, false);
             }
         }
 
-        var _draw_sprite = (_enabled && is_hovered && hover_sprite != -1) ? hover_sprite : sprite;
+        var _draw_sprite = (_enabled && is_hovered && hover_sprite != undefined) ? hover_sprite : sprite;
         var _draw_alpha = _enabled ? (is_hovered ? alpha_hover : alpha_idle) : alpha_disabled;
 
         draw_sprite_ext(_draw_sprite, 0, _x, _y, scale_x, scale_y, 0, c_white, _draw_alpha);


### PR DESCRIPTION
This was causing a crash when hovering over a SpriteButton (noteably in the Armamentarium window).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash when hovering a SpriteButton by correctly checking for missing hover sprite and click sound. We now test against undefined instead of -1, preventing invalid asset access (e.g., in the Armamentarium window).

<sup>Written for commit 8830148b0965b5eba9263f5d8fb7473bf58c4d2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

