### PR TITLE
fix(scr_zoom): Proper positioning during map zooming

### DIFF
--- a/scripts/scr_zoom/scr_zoom.gml
+++ b/scripts/scr_zoom/scr_zoom.gml
@@ -39,12 +39,12 @@ function scr_zoom_keys() {
 
     //this is changes the zoom based on scolling but you can set it how ever you like
     var zoom_delta = 0;
-    if (keyboard_check(vk_add) || keyboard_check(187) || keyboard_check(24) || mouse_wheel_down()) {
+    if (keyboard_check(vk_subtract) || keyboard_check(187) || keyboard_check(24) || mouse_wheel_down()) {
         if (obj_controller.map_scale > 0.1) {
             zoom_delta = -1;
         }
     }
-    if (keyboard_check(vk_subtract) || mouse_wheel_up()) {
+    if (keyboard_check(vk_add) || mouse_wheel_up()) {
         if (obj_controller.map_scale < 3) {
             zoom_delta = +1
         }

--- a/scripts/scr_zoom/scr_zoom.gml
+++ b/scripts/scr_zoom/scr_zoom.gml
@@ -31,7 +31,6 @@ function set_zoom_to_default() {
 /// @description This script will zoom in and out of the game view based on the keys pressed.
 /// @self obj_controller
 function scr_zoom_keys() {
-    var change = 0;
     var zoom_speed = 0.1;
 
     if (keyboard_check(vk_shift)) {
@@ -39,40 +38,42 @@ function scr_zoom_keys() {
     }
 
     //this is changes the zoom based on scolling but you can set it how ever you like
+    var zoom_delta = 0;
     if (keyboard_check(vk_add) || keyboard_check(187) || keyboard_check(24) || mouse_wheel_down()) {
-        if (obj_controller.map_scale < 3) {
-            var view_w = camera_get_view_width(view_camera[0]);
-            var view_h = camera_get_view_height(view_camera[0]);
-            if (view_w > (0.5 * global.default_view_width)) {
-                camera_set_view_size(view_camera[0], view_w * (1 - zoom_speed), view_h * (1 - zoom_speed));
-                change = true;
-            }
+        if (obj_controller.map_scale > 0.1) {
+            zoom_delta = -1;
         }
     }
     if (keyboard_check(vk_subtract) || mouse_wheel_up()) {
-        if (obj_controller.map_scale > 0.1) {
-            var view_w = camera_get_view_width(view_camera[0]);
-            var view_h = camera_get_view_height(view_camera[0]);
-            if (view_w < (5 * global.default_view_width)) {
-                camera_set_view_size(view_camera[0], view_w * (1 + zoom_speed), view_h * (1 + zoom_speed));
-                change = true;
-            }
+        if (obj_controller.map_scale < 3) {
+            zoom_delta = +1
         }
     }
-    if (change != 0) {
-        var view_w = camera_get_view_width(view_camera[0]);
-        var view_h = camera_get_view_height(view_camera[0]);
-        // @stitch-ignore-next-line: undeclared-global
-        x = clamp(x, 0, room_width);
-        // @stitch-ignore-next-line: undeclared-global
-        y = clamp(y, 0, room_height);
+    if (zoom_delta != 0) {
+        // temporarily disable the view from automatically moving towards obj_controller
+        var old_target = camera_get_view_target(view_camera[0]);
+        camera_set_view_target(view_camera[0], noone);
+
+        var mouse_pos = return_mouse_consts();
+        var mouse_x_ = mouse_pos[0];
+        var mouse_y_ = mouse_pos[1];
+        var old_x = camera_get_view_x(view_camera[0]);
+        var old_y = camera_get_view_y(view_camera[0]);
+        var old_w = camera_get_view_width(view_camera[0]);
+        var old_h = camera_get_view_height(view_camera[0]);
+        var zoom_factor = 1 - zoom_speed * zoom_delta;
+        var new_w = old_w * zoom_factor;
+        var new_h = old_h * zoom_factor;
+        camera_set_view_size(view_camera[0], new_w, new_h);
+        var new_x = mouse_x_ - (mouse_x_ - old_x) * (new_w / old_w);
+        var new_y = mouse_y_ - (mouse_y_ - old_y) * (new_h / old_h);
+        camera_set_view_pos(view_camera[0], new_x, new_y)
+
+        // update obj_controller as the new center of the view
+        obj_controller.x = new_x + new_w / 2;
+        obj_controller.y = new_y + new_h / 2;
+        camera_set_view_target(view_camera[0], old_target);
     }
 
     exit;
 }
-
-global.zoom_level = 1;
-
-//Get the starting view size to be used for interpolation later
-global.default_zoom_width = camera_get_view_width(view_camera[0]);
-global.default_zoom_height = camera_get_view_height(view_camera[0]);


### PR DESCRIPTION
* Fixed sector view zooming via mouse wheel or certain keys (scr_zoom_keys) to adjust the view's position to keep the cursor in place (in relation to the map) as you'd expect it from basically any decent map view (eg. GMaps). This involves math to calculate the new offset of the camera view. obj_controller's coords needed to be updated as well to prevent the view from instantly moving back to its previous focus.
* The instant zoom (scr_zoom) is unaffected.
* Some unused code has been removed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes map zooming so the point under your cursor stays in place when using the mouse wheel or +/- keys, and corrects the inverted +/- behavior. Prevents view snapping by recalculating camera size/position around the cursor and syncing `obj_controller`.

- **Bug Fixes**
  - Cursor-anchored zoom: adjusts view size and repositions the camera to keep the cursor’s map point fixed.
  - Temporarily disables and restores the camera target to avoid automatic recentering; sets `obj_controller` to the new view center.
  - Uses a `zoom_delta` with bounds (0.1–3) and corrects +/- direction; keeps instant zoom (`scr_zoom`) unchanged.
  - Removed unused globals and legacy code.

<sup>Written for commit 98c3a1c50054ded98b669f593653baac280c900b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

