### PR TITLE
fix: ui errors from recent refactors

### DIFF
--- a/scripts/scr_buttons/scr_buttons.gml
+++ b/scripts/scr_buttons/scr_buttons.gml
@@ -195,8 +195,6 @@ function ReactiveString(text_param, x1_param = 0, y1_param = 0, data = {}) const
     with_outline = true;
     allow_line_breaks = true;
 
-    move_data_to_current_scope(data);
-
     static update = function(data = {}) {
         move_data_to_current_scope(data);
         var temp_font = draw_get_font();
@@ -224,6 +222,8 @@ function ReactiveString(text_param, x1_param = 0, y1_param = 0, data = {}) const
         }
         draw_set_font(temp_font);
     };
+
+    update(data);
 
     static hit = function() {
         return scr_hit(x1, y1, x2, y2);
@@ -287,8 +287,6 @@ function LabeledIcon(icon_param, text_param, x1_param = 0, y1_param = 0, data = 
 	text_width = string_width(text) + 2;
 	draw_set_font(temp_font);
 
-    move_data_to_current_scope(data);
-
     static update = function(data = {}) {
         move_data_to_current_scope(data);
         if (text_position == "right") {
@@ -303,6 +301,8 @@ function LabeledIcon(icon_param, text_param, x1_param = 0, y1_param = 0, data = 
             y2 = y1 + icon_height;
         }
     };
+
+    update(data);
 
     static hit = function() {
         return scr_hit(x1, y1, x2, y2);
@@ -427,7 +427,6 @@ function UnitButtonObject(data = {}) constructor {
         y2 = y1 + h;
     };
     
-    move_data_to_current_scope(data);
     update_loc();
 
     static update = function(data = {}) {
@@ -440,6 +439,8 @@ function UnitButtonObject(data = {}) constructor {
             update_loc();
         }
     };
+
+    update(data);
 
     static move = function(m_direction, with_gap = false, multiplier = 1) {
         switch (m_direction) {
@@ -489,7 +490,7 @@ function UnitButtonObject(data = {}) constructor {
             var _width_scale = w / _widths[1];
             _widths[1] *= _width_scale;
             draw_sprite_ext(spr_pixel_button_middle, 0, x1 + _widths[0], y1, _width_scale, height_scale, 0, c_white, 1);
-            draw_sprite_ext(spr_pixel_button_right, 0, x1 + _widths[0] + _widths[1], y1, height_scale, height_scale, 0, c_white, 1);
+            draw_sprite_ext(spr_pixel_button_right, allow_click, x1 + _widths[0] + _widths[1], y1, height_scale, height_scale, 0, c_white, 1);
             var _text_position_x = x1 + _widths[0] + 2;
             _text_position_x += _widths[1] / 2;
             draw_set_font(font);
@@ -929,11 +930,11 @@ function MultiSelect(options_array, title_param, data = {}) constructor {
         array_push(toggles, _next_tog);
     }
     
-    move_data_to_current_scope(data);
-    
     static update = function(data = {}) {
         move_data_to_current_scope(data);
     };
+
+    update(data)
 
     static draw_toggle = function(index) {
         var _cur_opt = toggles[index];
@@ -1072,11 +1073,11 @@ function RadioSet(options_array, title_param = "", data = {}) constructor {
         array_push(toggles, new ToggleButton(options_array[i]));
     }
     
-    move_data_to_current_scope(data);
-
     static update = function(data = {}) {
         move_data_to_current_scope(data);
     };
+
+    update(data)
 
     static draw_option = function(_x, _y, index) {
         var _cur_opt = toggles[index];
@@ -1204,8 +1205,6 @@ function ToggleButton(data = {}) constructor {
     //make true to run clicked() within draw sequence
     clicked_check_default = false;
     
-    move_data_to_current_scope(data);
-
     static update = function(data = {}) {
         move_data_to_current_scope(data);
         var temp_font = draw_get_font();
@@ -1227,6 +1226,8 @@ function ToggleButton(data = {}) constructor {
         y2 = y1 + h;
         draw_set_font(temp_font);
     };
+
+    update(data);
 
     static hover = function() {
         return scr_hit(x1, y1, x2, y2);
@@ -1336,9 +1337,7 @@ function InteractiveButton(data = {}) constructor {
     text_halign = fa_left;
     text_color = c_gray;
     button_color = c_gray;
-    
-    move_data_to_current_scope(data);
-    
+        
     static update = function(data = {}) {
         move_data_to_current_scope(data);
         if (width == 0) {
@@ -1350,6 +1349,8 @@ function InteractiveButton(data = {}) constructor {
         x2 = x1 + width;
         y2 = y1 + height;
     };
+
+    update(data);
 
     static hover = function() {
         return scr_hit(x1, y1, x2, y2);


### PR DESCRIPTION
<!--- YOU CAN DELETE ALL OF THIS AFTER READING. -->

<!--- Make use of markdown lists. They make stuff much easier to read through. -->
<!--- Explain why and what your changes do in simple terms. --->
<!--- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. --->

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->

<!--- "Inspired" by the CDDA PR template -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes UI initialization and rendering bugs caused by recent refactors by moving data hydration into `update()` and running an initial `update(data)` on creation. Also corrects the right-cap sprite frame to reflect enabled/disabled state.

- **Bug Fixes**
  - Run `update(data)` once on construct for `ReactiveString`, `LabeledIcon`, `UnitButtonObject`, `MultiSelect`, `RadioSet`, `ToggleButton`, `InteractiveButton`.
  - Remove premature `move_data_to_current_scope(data)` calls to avoid stale state and ensure sizes, bounds, and hit/hover regions are correct.
  - Use `allow_click` as the frame index for `spr_pixel_button_right` so disabled buttons render properly.

<sup>Written for commit 69cc7b7f7ed76cf6c126099c5fb0aec347c11a0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

