### PR TITLE
fix: Fix delete savefile popup

### DIFF
--- a/objects/obj_popup/Step_0.gml
+++ b/objects/obj_popup/Step_0.gml
@@ -20,32 +20,6 @@ try {
         master_crafted = 0;
     }
 
-    if ((image == "fuklaw") && (save > 0)) {
-        if (press == 0) {
-            var del = obj_saveload.save[save];
-            var _save_file = string(PATH_SAVE_FILES, del);
-            if (file_exists(_save_file)) {
-                file_delete(_save_file);
-                if (file_exists($"save{del}log.ini")) {
-                    file_delete($"save{del}log.ini");
-                }
-                with (obj_saveload) {
-                    instance_destroy();
-                }
-                var news = instance_create(0, 0, obj_saveload);
-                news.menu = woopwoopwoop;
-                news.top = owner;
-                news.alarm[4] = 1;
-
-                instance_destroy();
-            }
-        }
-        if (press == 1) {
-            instance_destroy();
-        }
-        exit;
-    }
-
     //! I don't think this is even used?
     if ((room_get_name(room) == "rm_main_menu") && (title == "Tutorial")) {
         if (press == 1) {

--- a/objects/obj_saveload/Draw_64.gml
+++ b/objects/obj_saveload/Draw_64.gml
@@ -169,7 +169,31 @@ if (!hide) {
                         com.image = "fuklaw";
                         com.title = "Delete Save Game?";
                         com.text = "Are you sure you wish to delete Save " + string(save[slot_index]) + "- " + string(save_chapter[save[slot_index]]) + "?";
-                        com.add_option(["Yes", "No"]);
+                        com.add_option([
+                            {
+                                str1: "Yes",
+                                choice_func: function() {
+                                    var del = obj_saveload.save[save];
+                                    var _save_file = string(PATH_SAVE_FILES, del);
+                                    if (file_exists(_save_file)) {
+                                        file_delete(_save_file);
+                                        if (file_exists($"save{del}log.ini")) {
+                                            file_delete($"save{del}log.ini");
+                                        }
+                                        with (obj_saveload) {
+                                            instance_destroy();
+                                        }
+                                        var news = instance_create(0, 0, obj_saveload);
+                                        news.menu = woopwoopwoop;
+                                        news.top = owner;
+                                        news.alarm[4] = 1;
+
+                                        instance_destroy();
+                                    }
+                                }
+                            },
+                            { str1:"No" }
+                        ]);
                         com.save = slot_index;
                         com.woopwoopwoop = menu;
                         com.owner = top;

--- a/scripts/scr_popup_functions/scr_popup_functions.gml
+++ b/scripts/scr_popup_functions/scr_popup_functions.gml
@@ -13,6 +13,7 @@ enum ePOPUP_TYPE {
 }
 
 function reset_popup_options() {
+	var callstack = debug_get_callstack();
     with (obj_popup) {
         options = [];
     }

--- a/scripts/scr_popup_functions/scr_popup_functions.gml
+++ b/scripts/scr_popup_functions/scr_popup_functions.gml
@@ -13,7 +13,6 @@ enum ePOPUP_TYPE {
 }
 
 function reset_popup_options() {
-	var callstack = debug_get_callstack();
     with (obj_popup) {
         options = [];
     }

--- a/scripts/scr_squads/scr_squads.gml
+++ b/scripts/scr_squads/scr_squads.gml
@@ -873,7 +873,7 @@ function SquadArrangementEditor(company) constructor {
                 y1 : required_y + 25,
                 max_clamp : 50,
                 min_clamp : 1,
-            },
+            }
         );
 
         var min_val_shift = new ValueShifter(
@@ -884,7 +884,7 @@ function SquadArrangementEditor(company) constructor {
                 y1 : required_y + 55,
                 min_clamp : 1,
                 max_clamp : 50,
-            },
+            }
         );
 
         var delete_button = new UnitButtonObject({
@@ -938,7 +938,7 @@ function SquadArrangementEditor(company) constructor {
                 y1 : proportional_y + 25,
                 min_clamp : 1,
                 max_clamp : 50,
-            },
+            }
         );
 
         var delete_button = new UnitButtonObject({


### PR DESCRIPTION
* fix: Fix delete savefile popup. The popup was previously unfunctional because of interference from the new(?) scr_popup_functions. I moved the save delete functionality to a choice_func in accordance with scr_popup_functions.
* fix: Remove trailing spaces. Shouldn't matter, but GameMaker issued Feather errors because of this.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Delete Save popup so it actually deletes the selected save and returns to the save menu. Also cleans up formatting to resolve GameMaker Feather errors.

- **Bug Fixes**
  - Moved delete logic into the popup option’s choice_func, removed old handler in `obj_popup`; deletes the save file/log, reloads `obj_saveload`, and closes the popup.
  - Removed trailing spaces and minor formatting issues in squad editor scripts to satisfy Feather.
  - Reverted an accidentally committed file.

<sup>Written for commit 774d9e47a2b08637fd289ddc3f368234a7409257. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

