### PR TITLE
fix: company and number wrong way around in fetch_unit

### DIFF
--- a/scripts/scr_event_code/scr_event_code.gml
+++ b/scripts/scr_event_code/scr_event_code.gml
@@ -161,7 +161,7 @@ function event_end_turn_action() {
                 var marine_name = _event.name;
                 var comp = _event.company;
                 var marine_num = _event.marine;
-                var _unit = fetch_unit([marine_num, comp]);
+                var _unit = fetch_unit([comp, marine_num]);
                 var item = _event.crafted;
 
                 LOGGER.warning($"comp: {comp}, marine_num: {marine_num}");


### PR DESCRIPTION
<!--- YOU CAN DELETE ALL OF THIS AFTER READING. -->

<!--- Make use of markdown lists. They make stuff much easier to read through. -->
<!--- Explain why and what your changes do in simple terms. --->
<!--- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. --->

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->

<!--- "Inspired" by the CDDA PR template -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes unit lookup in end-turn actions by calling `fetch_unit` with `[company, marine_num]` instead of `[marine_num, company]`, ensuring the correct marine is retrieved.

<sup>Written for commit 4547df3e76a4a0f257b71c1710244aa801c5b4a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

