### PR TITLE
fix: Scrollbar dragging and map zoom limits

### DIFF
--- a/scripts/scr_scrollbar/scr_scrollbar.gml
+++ b/scripts/scr_scrollbar/scr_scrollbar.gml
@@ -40,7 +40,7 @@ function scr_scrollbar(argument0, argument1, argument2, argument3, argument4, ar
                 tmv = 0;
                 cp = 0;
 
-                click_y = window_mouse_get_y();
+                click_y = device_mouse_y_to_gui(0);
 
                 center = click_y - (siz2 / 2);
 
@@ -92,7 +92,7 @@ function scr_scrollbar(argument0, argument1, argument2, argument3, argument4, ar
                 tmv = 0;
                 cp = 0;
 
-                click_y = window_mouse_get_y();
+                click_y = device_mouse_y_to_gui(0);
 
                 center = click_y - (siz2 / 2);
 

--- a/scripts/scr_zoom/scr_zoom.gml
+++ b/scripts/scr_zoom/scr_zoom.gml
@@ -32,8 +32,8 @@ function set_zoom_to_default() {
 /// @self obj_controller
 function scr_zoom_keys() {
     var zoom_speed = 0.1;
-    var min_zoom = 0.3;
-    var max_zoom = 2.5;
+    static min_zoom = 0.3;
+    static max_zoom = 2.5;
 
     if (keyboard_check(vk_shift)) {
         zoom_speed *= 2;

--- a/scripts/scr_zoom/scr_zoom.gml
+++ b/scripts/scr_zoom/scr_zoom.gml
@@ -32,6 +32,8 @@ function set_zoom_to_default() {
 /// @self obj_controller
 function scr_zoom_keys() {
     var zoom_speed = 0.1;
+    var min_zoom = 0.3;
+    var max_zoom = 2.5;
 
     if (keyboard_check(vk_shift)) {
         zoom_speed *= 2;
@@ -40,12 +42,12 @@ function scr_zoom_keys() {
     //this is changes the zoom based on scolling but you can set it how ever you like
     var zoom_delta = 0;
     if (keyboard_check(vk_subtract) || keyboard_check(187) || keyboard_check(24) || mouse_wheel_down()) {
-        if (obj_controller.map_scale > 0.1) {
+        if (obj_controller.map_scale > min_zoom) {
             zoom_delta = -1;
         }
     }
     if (keyboard_check(vk_add) || mouse_wheel_up()) {
-        if (obj_controller.map_scale < 3) {
+        if (obj_controller.map_scale < max_zoom) {
             zoom_delta = +1
         }
     }

--- a/scripts/scr_zoom/scr_zoom.gml
+++ b/scripts/scr_zoom/scr_zoom.gml
@@ -31,7 +31,7 @@ function set_zoom_to_default() {
 /// @description This script will zoom in and out of the game view based on the keys pressed.
 /// @self obj_controller
 function scr_zoom_keys() {
-    var zoom_speed = 0.1;
+    static zoom_speed = 0.1;
     static min_zoom = 0.3;
     static max_zoom = 2.5;
 


### PR DESCRIPTION
* fix: scrollbar was jumping around during drag interaction, not following the mouse
* fix: map zoom limits excessively wide after a previous change changed how zoom works

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes jumpy scrollbar dragging by using GUI mouse coordinates, so the handle tracks the cursor. Clamps map zoom to 0.3–2.5 and uses static min/max in `scr_zoom_keys`.

<sup>Written for commit 59b8d3eebfb07506da48ee5a5800dec879fadc0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

