### PR TITLE
fix: Updates of role settings ui not happening

### DIFF
--- a/scripts/scr_ui_settings/scr_ui_settings.gml
+++ b/scripts/scr_ui_settings/scr_ui_settings.gml
@@ -603,11 +603,12 @@ function scr_select_role_settings_ui(){
 function setup_role_settings_buttons(){
     role_settings_ui = {};
     var _button_x = 830;
+    var _settings = obj_controller.settings;
     role_settings_ui.main_weapon_button = new UnitButtonObject({
         style : "pixel",
         x1 : _button_x,
         y1 : 185,
-        label : $"Main Weapon: {obj_ini.wep1[100][settings]}",
+        label : $"Main Weapon: {obj_ini.wep1[100][_settings]}",
         set_width : true,
         w : 250,
         active : true,
@@ -618,7 +619,7 @@ function setup_role_settings_buttons(){
         style : "pixel",
         x1 : _button_x,
         y1 : role_settings_ui.main_weapon_button.y2,
-        label : $"Secondary Weapon: {obj_ini.wep2[100][settings]}",
+        label : $"Secondary Weapon: {obj_ini.wep2[100][_settings]}",
         set_width : true,
         w : 250,
         active : true,
@@ -629,7 +630,7 @@ function setup_role_settings_buttons(){
         style : "pixel",
         x1 : _button_x,
         y1 : role_settings_ui.secondary_weapon_button.y2,
-        label : $"Armour: {obj_ini.armour[100][settings]}",
+        label : $"Armour: {obj_ini.armour[100][_settings]}",
         set_width : true,
         w : 250,
         active : true,
@@ -640,7 +641,7 @@ function setup_role_settings_buttons(){
         style : "pixel",
         x1 : _button_x,
         y1 : role_settings_ui.armour_button.y2,
-        label : $"Special Item: {obj_ini.gear[100][settings]}",
+        label : $"Special Item: {obj_ini.gear[100][_settings]}",
         set_width : true,
         w : 250,
         active : true,
@@ -651,7 +652,7 @@ function setup_role_settings_buttons(){
         style : "pixel",
         x1 : _button_x,
         y1 : role_settings_ui.gear_button.y2,
-        label : $"Mobility Item: {obj_ini.mobi[100][settings]}",
+        label : $"Mobility Item: {obj_ini.mobi[100][_settings]}",
         set_width : true,
         w : 250,
         active : true,
@@ -886,7 +887,9 @@ function scr_draw_mass_equip_gui(){
                     }
                     tab = -1;
                     refresh = true;
-                    setup_role_settings_buttons();
+                    with (obj_controller){
+                        setup_role_settings_buttons();
+                    }
                 }
             }
             y3 += space;


### PR DESCRIPTION
<!--- YOU CAN DELETE ALL OF THIS AFTER READING. -->

<!--- Make use of markdown lists. They make stuff much easier to read through. -->
<!--- Explain why and what your changes do in simple terms. --->
<!--- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. --->

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->

<!--- "Inspired" by the CDDA PR template -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the role settings UI not refreshing after changes. Labels now read from `obj_controller.settings`, and buttons are rebuilt in the controller context so updates show immediately.

- **Bug Fixes**
  - Use `var _settings = obj_controller.settings` and reference `_settings` for weapon/armour/gear labels.
  - Recreate role settings buttons via `with (obj_controller) { setup_role_settings_buttons(); }` to trigger a proper UI refresh.

<sup>Written for commit f783b5d6783d9de9423f86a4ee918856f2f8bc79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

