### PR TITLE
fix: forge world for navy construction logical issues

### DIFF
--- a/scripts/scr_fleet_functions/scr_fleet_functions.gml
+++ b/scripts/scr_fleet_functions/scr_fleet_functions.gml
@@ -12,6 +12,13 @@ function distribute_strength_to_fleet(strength, fleet) {
     }
 }
 
+function standard_fleet_strength_calc(fleet = undefined){
+    if (is_undefined(fleet)){
+        fleet = self;
+    }
+    return fleet.capital_number + (fleet.frigate_number/2) + (fleet.escort_number/4);
+}
+
 /// @self Asset.GMObject.obj_en_fleet
 function random_sector_exit_point() {
     action_x = choose(room_width * -1, room_width * 2);

--- a/scripts/scr_forge_world_functions/scr_forge_world_functions.gml
+++ b/scripts/scr_forge_world_functions/scr_forge_world_functions.gml
@@ -38,8 +38,8 @@ function imperial_navy_fleet_construction() {
             for(var o = 1; o <= _sys.planets; o++) {
                 
                 if (_sys.p_type[o] == "Forge"){
-                    var _nearest = instance_nearest(x,y,obj_en_fleet)
-                    if (_nearest.x == x && _nearest.y == y && _nearest.navy){
+                    var _nearest = instance_nearest(_sys.x,_sys.y,obj_en_fleet)
+                    if (_nearest.x == _sys.x && _nearest.y == _sys.y && _nearest.navy){
                         good=false;
                         break;
                     }                   

--- a/scripts/scr_forge_world_functions/scr_forge_world_functions.gml
+++ b/scripts/scr_forge_world_functions/scr_forge_world_functions.gml
@@ -24,7 +24,7 @@ function imperial_navy_fleet_construction() {
         } 
 
         //if system needs more navy fleets get forge world to make some
-    } else if (navy_fleet_count<target_navy_number) {
+    } else if (navy_fleet_count < target_navy_number) {
         //TODO make standadised system for collating active forge worlds as we  do this a lot       
         var _forge_systems = get_imperium_forge_systems();
 

--- a/scripts/scr_forge_world_functions/scr_forge_world_functions.gml
+++ b/scripts/scr_forge_world_functions/scr_forge_world_functions.gml
@@ -37,7 +37,7 @@ function imperial_navy_fleet_construction() {
             var good=true;
             for(var o = 1; o <= _sys.planets; o++) {
                 
-                if (_sys[p_type] == "Forge"){
+                if (_sys.p_type[o] == "Forge"){
                     var _nearest = instance_nearest(x,y,obj_en_fleet)
                     if (_nearest.x == x && _nearest.y == y && _nearest.navy){
                         good=false;

--- a/scripts/scr_forge_world_functions/scr_forge_world_functions.gml
+++ b/scripts/scr_forge_world_functions/scr_forge_world_functions.gml
@@ -3,71 +3,97 @@
 function imperial_navy_fleet_construction() {
     // ** Check number of navy fleets **
 
-    var new_navy_fleets = [];
-    with (obj_en_fleet) {
-        if ((owner == eFACTION.IMPERIUM) && (navy == 1)) {
-            array_push(new_navy_fleets, id);
-        }
-    }
+    var new_navy_fleets = get_imperial_navy_fleets();
     //delete navy fleets if more than required
     var navy_fleet_count = array_length(new_navy_fleets);
     var cur_fleet;
-    if (navy_fleet_count > target_navy_number) {
-        for (var i = 0; i < navy_fleet_count; i++) {
+    if (navy_fleet_count>target_navy_number) {
+        for (var i = 0;i < navy_fleet_count; i++){
             cur_fleet = new_navy_fleets[i];
-            if (cur_fleet.guardsmen_unloaded) {
+            if (cur_fleet.guardsmen_unloaded){
                 continue;
             } else {
                 instance_destroy(cur_fleet);
                 navy_fleet_count--;
                 array_delete(new_navy_fleets, i, 1);
                 i--;
-                if (navy_fleet_count <= target_navy_number) {
+                if (navy_fleet_count <= target_navy_number){
                     break;
                 }
             }
-        }
+        } 
 
         //if system needs more navy fleets get forge world to make some
-    } else if (navy_fleet_count < target_navy_number) {
-        var forge_systems = [];
-        with (obj_star) {
-            var good = false;
-            for (var o = 1; o <= planets; o++) {
-                if ((p_type[o] == "Forge") && (p_owner[o] == eFACTION.MECHANICUS) && (p_orks[o] + p_tau[o] + p_tyranids[o] + p_chaos[o] + p_traitors[o] + p_necrons[o] == 0)) {
+    } else if (navy_fleet_count<target_navy_number) {
+        //TODO make standadised system for collating active forge worlds as we  do this a lot       
+        var _forge_systems = get_imperium_forge_systems();
+
+        if (array_length(_forge_systems) == 0 && obj_controller.faction_status[eFACTION.IMPERIUM] != "War"){
+            scr_alert("red", "forge_world", "No active uncontested forge worlds imperial navy unable to rebuild at speed");
+        }
+
+        for (var i=array_length(_forge_systems)-1;i>=0;i--){
+            var _sys = _forge_systems[i];
+            var good=true;
+            for(var o = 1; o <= _sys.planets; o++) {
+                
+                if (_sys[p_type] == "Forge"){
+                    var _nearest = instance_nearest(x,y,obj_en_fleet)
+                    if (_nearest.x == x && _nearest.y == y && _nearest.navy){
+                        good=false;
+                        break;
+                    }                   
+                }
+            }
+
+            if (!good){
+                array_delete(_forge_systems,i,1);
+            }
+        }
+    // After initial navy fleet construction fleet growth is handled in obj_en_fleet.alarm_5
+        if (array_length(_forge_systems)){
+            var construction_forge;
+            construction_forge = array_random_element(_forge_systems);
+            build_new_navy_fleet(construction_forge)
+        }
+    }
+}
+
+function get_imperium_forge_systems(){
+    var _forge_systems = [];
+    with(obj_star){
+        var good=false;
+        for(var o=1; o<=planets; o++) {
+            if (p_type[o]=="Forge") 
+                and (p_owner[o]==eFACTION.MECHANICUS) 
+                and (p_orks[o]+p_tau[o]+p_tyranids[o]+p_chaos[o]+p_traitors[o]+p_necrons[o]==0) {
+                    
                     var enemy_fleets = [
                         eFACTION.ORK,
                         eFACTION.TAU,
                         eFACTION.TYRANIDS,
                         eFACTION.CHAOS,
                         eFACTION.NECRONS
-                    ];
-
+                    ]
+                
                     var enemy_fleet_count = array_reduce(enemy_fleets, function(prev, curr) {
-                        return prev + present_fleet[curr];
-                    });
-                    if (enemy_fleet_count == 0) {
-                        good = true;
-                        if (instance_nearest(x, y, obj_en_fleet).navy) {
-                            good = false;
-                        }
-                    }
-                }
+                        return prev + present_fleet[curr]
+                    }, 0);
+
+                    good = enemy_fleet_count<=0;
             }
-            if (good) {
-                good = x <= room_width && y <= room_height;
-            }
-            if (good == true) {
-                array_push(forge_systems, id);
+            if (good){
+                break;
             }
         }
-        // After initial navy fleet construction fleet growth is handled in obj_en_fleet.alarm_5
-        if (array_length(forge_systems)) {
-            var construction_forge, new_navy_fleet;
-            construction_forge = choose_array(forge_systems);
-            build_new_navy_fleet(construction_forge);
+        if (good){
+            good = x<=room_width && y<=room_height;
+        }
+        if (good){
+            array_push(_forge_systems, id);
         }
     }
+    return _forge_systems;
 }
 
 function build_planet_defence_fleets() {


### PR DESCRIPTION
<!--- YOU CAN DELETE ALL OF THIS AFTER READING. -->

<!--- Make use of markdown lists. They make stuff much easier to read through. -->
<!--- Explain why and what your changes do in simple terms. --->
<!--- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. --->

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->

<!--- "Inspired" by the CDDA PR template -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Imperial Navy forge‑world construction by correctly filtering eligible systems and managing navy fleet counts. Adds a rebuild alert when no valid forge worlds exist and a standard fleet strength helper.

- **Bug Fixes**
  - Uses `get_imperial_navy_fleets()` to trim/build to `target_navy_number`.
  - Adds `get_imperium_forge_systems()` for eligible forges (Mechanicus, uncontested, in‑bounds), then skips systems already hosting a navy fleet.
  - Builds one navy fleet at a random valid forge; further growth remains in `obj_en_fleet.alarm_5`.

- **New Features**
  - Alerts when no eligible forge worlds exist and the Imperium is not at war.
  - Adds `standard_fleet_strength_calc()` for consistent strength math.

<sup>Written for commit 651f64bd627338315ea4160b4b32e0c4b18edc0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- gk-ai-analysis-start:651f64bd627338315ea4160b4b32e0c4b18edc0b -->
<!-- gk-ai-analysis-data:eyJzdW1tYXJ5IjoiRml4ZXMgSW1wZXJpYWwgTmF2eSBmb3JnZS13b3JsZCBjb25zdHJ1Y3Rpb24gYnkgc2VwYXJhdGluZyBlbGlnaWJsZSBmb3JnZSB3b3JsZCBsb2dpYyBhbmQgYWRkaW5nIGEgaGVscGVyIGZvciBzdGFuZGFyZCBmbGVldCBzdHJlbmd0aC4iLCJrZXlJbnNpZ2h0cyI6W3sidGl0bGUiOiJFeHRyYWN0ZWQgaGVscGVyIGZ1bmN0aW9uIGdldF9pbXBlcml1bV9mb3JnZV9zeXN0ZW1zIiwiZGVzY3JpcHRpb24iOiJNb3ZlZCB0aGUgbG9naWMgdG8gZmluZCB1bmNvbnRlc3RlZCwgTWVjaGFuaWN1cy1vd25lZCBmb3JnZSB3b3JsZHMgaW50byBhIGRlZGljYXRlZCBoZWxwZXIgZnVuY3Rpb24uIiwic2V2ZXJpdHkiOiJsb3ciLCJmaWxlUGF0aCI6InNjcmlwdHMvc2NyX2ZvcmdlX3dvcmxkX2Z1bmN0aW9ucy9zY3JfZm9yZ2Vfd29ybGRfZnVuY3Rpb25zLmdtbCIsImxpbmVTdGFydCI6NDN9LHsidGl0bGUiOiJBZGRlZCBzdGFuZGFyZF9mbGVldF9zdHJlbmd0aF9jYWxjIiwiZGVzY3JpcHRpb24iOiJJbnRyb2R1Y2VkIGEgbmV3IGZ1bmN0aW9uIHRvIGNhbGN1bGF0ZSB0aGUgc3RyZW5ndGggb2YgYSBmbGVldCBiYXNlZCBvbiBjYXBpdGFsLCBmcmlnYXRlLCBhbmQgZXNjb3J0IHNoaXAgY291bnRzLiIsInNldmVyaXR5IjoibG93IiwiZmlsZVBhdGgiOiJzY3JpcHRzL3Njcl9mbGVldF9mdW5jdGlvbnMvc2NyX2ZsZWV0X2Z1bmN0aW9ucy5nbWwiLCJsaW5lU3RhcnQiOjE1fV0sImlzc3VlcyI6W3sidGl0bGUiOiJQb3RlbnRpYWwgY3Jhc2ggb24gaW5zdGFuY2VfbmVhcmVzdCByZXR1cm5pbmcgbm9vbmUiLCJkZXNjcmlwdGlvbiI6IklmIHRoZXJlIGFyZSBubyBpbnN0YW5jZXMgb2YgYG9ial9lbl9mbGVldGAsIGBpbnN0YW5jZV9uZWFyZXN0YCB3aWxsIHJldHVybiBgbm9vbmVgICg8IDAgaW4gR01TKS4gQXR0ZW1wdGluZyB0byBhY2Nlc3MgYF9uZWFyZXN0LnhgIHdpbGwgY2F1c2UgYSBjcmFzaC4gQSBudWxsIGNoZWNrIHNob3VsZCBiZSBhZGRlZC4iLCJzZXZlcml0eSI6ImhpZ2giLCJmaWxlUGF0aCI6InNjcmlwdHMvc2NyX2ZvcmdlX3dvcmxkX2Z1bmN0aW9ucy9zY3JfZm9yZ2Vfd29ybGRfZnVuY3Rpb25zLmdtbCIsImxpbmVTdGFydCI6MjZ9XSwic3VnZ2VzdGlvbnMiOlt7InRpdGxlIjoiQ29tYmluZSBjb25kaXRpb24gY2hlY2tzIGZvciByZWFkYWJpbGl0eSIsImRlc2NyaXB0aW9uIjoiVGhlIGxvZ2ljIGNoZWNraW5nIGlmIGBwX3R5cGVbb10gPT0gXCJGb3JnZVwiYCBhbmQgdGhlbiBjaGVja2luZyBgaW5zdGFuY2VfbmVhcmVzdGAgY291bGQgc2tpcCBpdGVyYXRpbmcgb3ZlciBldmVyeSBwbGFuZXQgaWYgb25lIGFscmVhZHkgZGlzcXVhbGlmaWVzIHRoZSBzeXN0ZW0sIG9yIGp1c3QgZmluZCB0aGUgZmxlZXQgbmVhcmVzdCB0byB0aGUgc3lzdGVtIGluc3RlYWQgb2YgZG9pbmcgaXQgcGVyIHBsYW5ldCAoc2luY2UgYF9zeXMueGAgYW5kIGBfc3lzLnlgIGFyZSB0aGUgc3lzdGVtIGNvb3JkaW5hdGVzLCBub3QgcGxhbmV0IGNvb3JkaW5hdGVzKS4iLCJzZXZlcml0eSI6Im1lZGl1bSIsImZpbGVQYXRoIjoic2NyaXB0cy9zY3JfZm9yZ2Vfd29ybGRfZnVuY3Rpb25zL3Njcl9mb3JnZV93b3JsZF9mdW5jdGlvbnMuZ21sIiwibGluZVN0YXJ0IjoyNX1dLCJzZWN1cml0eSI6W119 -->
<!-- gk-ai-analysis-end:651f64bd627338315ea4160b4b32e0c4b18edc0b -->

<!-- gitkraken-review-badge-begin -->
---
<a href="https://gitkraken.dev/review/github/Adeptus-Dominus/ChapterMaster/pull/1237?source=pr_review_chip">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://gitkraken.dev/images/figures/gitkraken-review-badge-dark.svg">
    <img src="https://gitkraken.dev/images/figures/gitkraken-review-badge-light.svg" alt="Open with GitKraken">
  </picture>
</a>
<!-- gitkraken-review-badge-end -->