### PR TITLE
refactor: disposition alter functions to return strings

### DIFF
--- a/scripts/scr_ChapterTraits/scr_ChapterTraits.gml
+++ b/scripts/scr_ChapterTraits/scr_ChapterTraits.gml
@@ -334,7 +334,7 @@ function setup_chapter_traits() {
 function ChapterGameData(data = {}) constructor {
     chapter_suspicion = 0;
 
-    faction_disp_mods = array_create(14, {"int_mod": 0, "mult": 1});
+    faction_disp_mods = array_create(14, {"int_mod": 0, "mult": 1, "strings" : []});
 
     equipment_tag_mods = {};
 
@@ -420,6 +420,13 @@ function ChapterGameData(data = {}) constructor {
             alter_value = floor(alter_value * _mods.mult);
         }
 
+        //ensure alter value never brings disposition higher thann 100 or lower than 0
+        var _final_disp_val =  alter_value + obj_controller.disposition[faction];
+        if (_final_disp_val > 100){
+            alter_value -= _final_disp_val - 100;
+        } else if (_final_disp_val < 0){
+            alter_value += (_final_disp_val * -1);
+        }
         return alter_value;
     };
 

--- a/scripts/scr_ChapterTraits/scr_ChapterTraits.gml
+++ b/scripts/scr_ChapterTraits/scr_ChapterTraits.gml
@@ -334,7 +334,10 @@ function setup_chapter_traits() {
 function ChapterGameData(data = {}) constructor {
     chapter_suspicion = 0;
 
-    faction_disp_mods = array_create(14, {"int_mod": 0, "mult": 1, "strings" : []});
+    faction_disp_mods = [];
+    for (var _i = 0; _i < 14; _i++) {
+        faction_disp_mods[_i] = {"int_mod": 0, "mult": 1, "strings": []};
+    }
 
     equipment_tag_mods = {};
 

--- a/scripts/scr_diplomacy_helpers/scr_diplomacy_helpers.gml
+++ b/scripts/scr_diplomacy_helpers/scr_diplomacy_helpers.gml
@@ -42,17 +42,30 @@ function relationship_hostility_matrix(faction) {
     return _rela;
 }
 
-function alter_disposition(faction, alter_value) {
+function alter_disposition(faction, alter_value, return_string = false) {
     chap_data = obj_ini.chapter_data;
 
     alter_value = chap_data.calc_final_disp_value(faction, alter_value);
 
-    obj_controller.disposition[faction] = clamp(obj_controller.disposition[faction] + alter_value, -100, 100);
+    obj_controller.disposition[faction] += alter_value;
+
+    if (return_string){
+        return "{global.faction_names[faction]} : {string_plus_minus(alter_value)}{alter_value}";
+    }
 }
 
-function alter_dispositions(alterations) {
+function alter_dispositions(alterations, return_strings) {
+    var _string;
+    var _strings = [];
     for (var i = 0; i < array_length(alterations); i++) {
-        alter_disposition(alterations[i][0], alterations[i][1]);
+        _string = alter_disposition(alterations[i][0], alterations[i][1], return_strings);
+        if (return_strings){
+            array_push(_strings, _string);
+        }
+    }
+
+    if (return_strings){
+        return _strings;
     }
 }
 

--- a/scripts/scr_diplomacy_helpers/scr_diplomacy_helpers.gml
+++ b/scripts/scr_diplomacy_helpers/scr_diplomacy_helpers.gml
@@ -50,7 +50,7 @@ function alter_disposition(faction, alter_value, return_string = false) {
     obj_controller.disposition[faction] += alter_value;
 
     if (return_string){
-        return "{global.faction_names[faction]} : {string_plus_minus(alter_value)}{alter_value}";
+        return $"{global.faction_names[faction]} : {string_plus_minus(alter_value)}{alter_value}";
     }
 }
 


### PR DESCRIPTION
<!--- YOU CAN DELETE ALL OF THIS AFTER READING. -->

<!--- Make use of markdown lists. They make stuff much easier to read through. -->
<!--- Explain why and what your changes do in simple terms. --->
<!--- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. --->

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->

<!--- "Inspired" by the CDDA PR template -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors disposition alteration helpers to optionally return formatted change strings. Bounds remain -100 to 100, but `alter_disposition` now applies the adjusted delta calculated by `calc_final_disp_value` instead of clamping the result directly.

- Pass `return_string` for a single faction message or `return_strings` for an array of messages.
- Returned messages include the faction name and signed effective change.

<sup>Written for commit a1f4f69d6c351aa97178373e95fa5ae8de68201a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

