### PR TITLE
refactor(files): Path macros; save verification

### DIFF
--- a/objects/obj_event_log/Create_0.gml
+++ b/objects/obj_event_log/Create_0.gml
@@ -23,8 +23,8 @@ repeat (101) {
     e += 1;
     topics[e] = "";
 }
-if (file_exists("main/help.ini")) {
-    ini_open("main/help.ini");
+if (file_exists(PATH_HELP_INI)) {
+    ini_open(PATH_HELP_INI);
     var ch;
     ch = 0;
     repeat (100) {

--- a/objects/obj_event_log/Draw_0.gml
+++ b/objects/obj_event_log/Draw_0.gml
@@ -116,7 +116,7 @@ if (help == 1) {
                 draw_set_alpha(1);
                 if (mouse_button_clicked()) {
                     topic = topics[t];
-                    ini_open("main/help.ini");
+                    ini_open(PATH_HELP_INI);
                     info = ini_read_string(string(t), "info", "");
                     strategy = ini_read_string(string(t), "strategy", "");
                     main_info = ini_read_string(string(t), "main_info", "");

--- a/scripts/__init/__init.gml
+++ b/scripts/__init/__init.gml
@@ -6,6 +6,7 @@
 #macro PATH_LOG_DIRECTORY "Logs/"
 #macro LAST_MESSAGES_LOG "last_messages.log"
 #macro PATH_LAST_MESSAGES PATH_LOG_DIRECTORY + LAST_MESSAGES_LOG
+#macro PATH_HELP_INI "main/help.ini"
 
 /// @desc Called via gml_pragma("global") at startup, before any room.
 function __init() {

--- a/scripts/scr_ui_manage/scr_ui_manage.gml
+++ b/scripts/scr_ui_manage/scr_ui_manage.gml
@@ -574,6 +574,10 @@ function alternative_manage_views(x1, y1) {
             surface_reset_target();
 
             // save to local game folder
+            var main_dir = working_directory + "/main";
+            if (!directory_exists(main_dir)) {
+                directory_create(main_dir);
+            }
             var base_name = working_directory + $"/main/marine_capture_{_unit.name()}_{_unit.marine_number}{_unit.company}";
             var extension = ".png";
             var index = 0;
@@ -592,7 +596,11 @@ function alternative_manage_views(x1, y1) {
             // cleanup
             surface_free(surf);
 
-            LOGGER.debug("Marine image saved to: " + path);
+            if (file_exists(path)) {
+                LOGGER.debug("Marine image saved to: " + path);
+            } else {
+                LOGGER.error("Failed to save marine image to: " + path);
+            }
         }
     }
 }


### PR DESCRIPTION
#### Why and what your changes do
* **Path Macro Consolidation:**
  * Created the `PATH_HELP_INI` macro to consolidate references to `"main/help.ini"`.
  * Replaced hardcoded occurrences of `"main/help.ini"` in `objects/obj_event_log/Create_0.gml` and `objects/obj_event_log/Draw_0.gml` with the new macro.
* **Marine Capture Improvements:**
  * Added safety check in `scripts/scr_ui_manage/scr_ui_manage.gml` to verify if the `/main` subdirectory exists before attempting to save captured marine images, auto-creating it if it's missing.
  * Added verification check (`file_exists`) after writing the image to disk, ensuring a debug log is generated on success and an error is logged if the write failed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces hardcoded "main/help.ini" with a `PATH_HELP_INI` macro and makes marine image saving more reliable by creating the target directory and verifying the saved file. This cleans up path handling and reduces failed saves for marine captures.

- **Refactors**
  - Added `PATH_HELP_INI` in `scripts/__init/__init.gml` and used it in `obj_event_log` Create_0 and Draw_0.

- **Bug Fixes**
  - Create `working_directory + "/main"` if missing before saving capture images.
  - Verify the saved file with `file_exists` and log success or error.

<sup>Written for commit dcc7d3e7566f6dc9a92a9799552dec439727e7bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

