### PR TITLE
fix(linux): Normalize paths for Linux compatibility

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,7 @@
 </p>
 
 # Chapter Master - Adeptus Dominus
+
 [![Release-Development](https://github.com/Adeptus-Dominus/ChapterMaster/actions/workflows/release_dev.yml/badge.svg)](https://github.com/Adeptus-Dominus/ChapterMaster/actions/workflows/release_dev.yml)
 [![](https://dcbadge.limes.pink/api/server/https://discord.gg/zAGpqHzsXQ?style=flat)](https://discord.gg/zAGpqHzsXQ)
 [![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/Adeptus-Dominus/ChapterMaster?logoColor=%23808080&label=CodeRabbit%20Reviews&labelColor=fd5608&color=545454)](https://coderabbit.ai/)
@@ -29,7 +30,26 @@ This project aims to continue development on the game, fix any bugs, expand and 
 - Main repository: [Adeptus-Dominus/ChapterMaster](https://github.com/Adeptus-Dominus/ChapterMaster)
 
 ## Playing
+
+### Windows
+
 Just download the [latest release](https://github.com/Adeptus-Dominus/ChapterMaster/releases/latest) or a [development pre-release](https://github.com/Adeptus-Dominus/ChapterMaster/releases), unzip it and launch the .exe.
+
+### Linux
+
+Pre-compiled Linux binaries are not currently supported. However, you can run the game on Linux in two ways:
+
+#### Option 1: Run the Windows build via WINE (Recommended for players)
+
+You can download the Windows release `.exe` and run it using **WINE** (or **Proton** / **Steam Play**). This has been reported to work well.
+
+#### Option 2: Run from source using GameMaker for Linux (Recommended for developers)
+
+1. Clone the repository.
+2. Install the **GameMaker** IDE for Linux (available on Steam or the GameMaker website).
+3. Open the `ChapterMaster.yyp` project file in GameMaker.
+4. Select **Linux** as the target platform in the IDE.
+5. Press **Run** (F5) to play/debug the game.
 
 ## Compiling
 
@@ -41,6 +61,7 @@ Everything else **must** be covered by [paid **GameMaker** subscriptions](https:
 ## Contributing
 
 Best bet is to ask about everything in our Discord, because things bellow are probably not very helpful at the moment.
+
 - [Working with GameMaker projects](https://github.com/Adeptus-Dominus/ChapterMaster/wiki/Working-with-GameMaker-projects)
 - [Useful Tools/Resources](https://github.com/Adeptus-Dominus/ChapterMaster/wiki/Useful-resources)
 - [Contributing](https://github.com/Adeptus-Dominus/ChapterMaster/wiki/Contributing) wiki page (not filled properly)

--- a/objects/obj_event_log/Create_0.gml
+++ b/objects/obj_event_log/Create_0.gml
@@ -23,8 +23,8 @@ repeat (101) {
     e += 1;
     topics[e] = "";
 }
-if (file_exists("main\\help.ini")) {
-    ini_open("main\\help.ini");
+if (file_exists("main/help.ini")) {
+    ini_open("main/help.ini");
     var ch;
     ch = 0;
     repeat (100) {

--- a/objects/obj_event_log/Create_0.gml
+++ b/objects/obj_event_log/Create_0.gml
@@ -23,8 +23,8 @@ repeat (101) {
     e += 1;
     topics[e] = "";
 }
-if (file_exists("main/help.ini")) {
-    ini_open("main/help.ini");
+if (file_exists(PATH_HELP_INI)) {
+    ini_open(PATH_HELP_INI);
     var ch;
     ch = 0;
     repeat (100) {

--- a/objects/obj_event_log/Draw_0.gml
+++ b/objects/obj_event_log/Draw_0.gml
@@ -116,7 +116,7 @@ if (help == 1) {
                 draw_set_alpha(1);
                 if (mouse_button_clicked()) {
                     topic = topics[t];
-                    ini_open("main\\help.ini");
+                    ini_open("main/help.ini");
                     info = ini_read_string(string(t), "info", "");
                     strategy = ini_read_string(string(t), "strategy", "");
                     main_info = ini_read_string(string(t), "main_info", "");

--- a/objects/obj_event_log/Draw_0.gml
+++ b/objects/obj_event_log/Draw_0.gml
@@ -116,7 +116,7 @@ if (help == 1) {
                 draw_set_alpha(1);
                 if (mouse_button_clicked()) {
                     topic = topics[t];
-                    ini_open("main/help.ini");
+                    ini_open(PATH_HELP_INI);
                     info = ini_read_string(string(t), "info", "");
                     strategy = ini_read_string(string(t), "strategy", "");
                     main_info = ini_read_string(string(t), "main_info", "");

--- a/objects/obj_ini/Create_0.gml
+++ b/objects/obj_ini/Create_0.gml
@@ -271,7 +271,7 @@ deserialize = function(save_data) {
     var all_names = struct_get_names(save_data);
 
     if (!array_contains(all_names, "chapter_squad_arrangement")) {
-        obj_ini.chapter_squad_arrangement = json_to_gamemaker(working_directory + $"main\\squads\\company_squad_builds.json", json_parse);
+        obj_ini.chapter_squad_arrangement = json_to_gamemaker(working_directory + $"main/squads/company_squad_builds.json", json_parse);
     }
 
     var _len = array_length(all_names);

--- a/scripts/ErrorHandler/ErrorHandler.gml
+++ b/scripts/ErrorHandler/ErrorHandler.gml
@@ -73,10 +73,10 @@ function GameError(_header, _message, _stacktrace = "", _critical = false, _repo
 
     /// @description Builds player-facing error message
     static build_player_message = function() {
-        var _path_hint = string_replace_all(game_save_id, "/", "\\");
+        var _path_hint = (os_type == os_windows) ? string_replace_all(game_save_id, "/", "\\") : game_save_id;
         var _msg = $"{header}\n\n{message}\n\n";
 
-        _msg += $"The error log was saved at:\n{_path_hint}Logs\\\n\n";
+        _msg += (os_type == os_windows) ? $"The error log was saved at:\n{_path_hint}Logs\\\n\n" : $"The error log was saved at:\n{_path_hint}Logs/\n\n";
 
         if (UPDATE_CHECKER.compiled) {
             _msg += "You are using a debug build. Automated bug reports disabled.\n\n";

--- a/scripts/NameGenerator/NameGenerator.gml
+++ b/scripts/NameGenerator/NameGenerator.gml
@@ -17,7 +17,7 @@ function NameTracker(set_name) constructor {
 
         var file_loader = new JsonFileListLoader();
 
-        var load_result = file_loader.load_list_from_json_file($"main\\names\\{file_name}.json", [json_names_property_name]);
+        var load_result = file_loader.load_list_from_json_file($"main/names/{file_name}.json", [json_names_property_name]);
 
         if (load_result.is_success) {
             names = load_result.values[$ json_names_property_name];
@@ -48,7 +48,7 @@ function NameTracker(set_name) constructor {
 
         var file_loader = new JsonFileListLoader();
 
-        var load_result = file_loader.load_list_from_json_file($"main\\names\\{file_name}.json", json_names_property_names);
+        var load_result = file_loader.load_list_from_json_file($"main/names/{file_name}.json", json_names_property_names);
 
         var result = {};
 
@@ -186,7 +186,7 @@ function NameTracker(set_name) constructor {
 
 function NameGenerator() constructor {
     // TODO after save rework is finished, check if these static can be converted to instance version
-    var _simple_names = json_to_gamemaker(working_directory + $"main\\name_loader.json", json_parse);
+    var _simple_names = json_to_gamemaker(working_directory + $"main/name_loader.json", json_parse);
 
     if (_simple_names == "") {
         _simple_names = [

--- a/scripts/__init/__init.gml
+++ b/scripts/__init/__init.gml
@@ -6,6 +6,7 @@
 #macro PATH_LOG_DIRECTORY "Logs/"
 #macro LAST_MESSAGES_LOG "last_messages.log"
 #macro PATH_LAST_MESSAGES PATH_LOG_DIRECTORY + LAST_MESSAGES_LOG
+#macro PATH_HELP_INI "main/help.ini"
 
 /// @desc Called via gml_pragma("global") at startup, before any room.
 function __init() {

--- a/scripts/__init/__init.gml
+++ b/scripts/__init/__init.gml
@@ -1,8 +1,8 @@
-#macro PATH_SAVE_FILES "Save Files\\save{0}.json"
-#macro PATH_AUTOSAVE_FILE "Save Files\\save0.json"
-#macro PATH_CUSTOM_ICONS "Custom Files\\Custom Icons\\"
-#macro PATH_CHAPTER_ICONS working_directory + "\\images\\creation\\chapters\\icons\\"
-#macro PATH_INCLUDED_ICONS working_directory + "\\images\\creation\\customicons\\"
+#macro PATH_SAVE_FILES "Save Files/save{0}.json"
+#macro PATH_AUTOSAVE_FILE "Save Files/save0.json"
+#macro PATH_CUSTOM_ICONS "Custom Files/Custom Icons/"
+#macro PATH_CHAPTER_ICONS working_directory + "/images/creation/chapters/icons/"
+#macro PATH_INCLUDED_ICONS working_directory + "/images/creation/customicons/"
 #macro PATH_LOG_DIRECTORY "Logs/"
 #macro LAST_MESSAGES_LOG "last_messages.log"
 #macro PATH_LAST_MESSAGES PATH_LOG_DIRECTORY + LAST_MESSAGES_LOG
@@ -33,8 +33,8 @@ function __init() {
     if (!directory_exists("Logs")) {
         directory_create("Logs");
     }
-    if (!directory_exists("Custom Files\\Custom Icons")) {
-        directory_create("Custom Files\\Custom Icons");
+    if (!directory_exists("Custom Files/Custom Icons")) {
+        directory_create("Custom Files/Custom Icons");
     }
     if (!directory_exists("Save Files")) {
         directory_create("Save Files");
@@ -82,7 +82,7 @@ function __init() {
     global.game_version = "unknown version";
     global.commit_hash = "unknown hash";
 
-    var _version_file_path = working_directory + "\\main\\version.json";
+    var _version_file_path = working_directory + "/main/version.json";
     var _parsed_json = json_to_gamemaker(_version_file_path, json_parse);
 
     if (_parsed_json != undefined) {
@@ -112,18 +112,18 @@ function __init() {
         global.update_checker.compiled = true;
     }
 
-    global.weapons = json_to_gamemaker(working_directory + "\\data\\weapons.json", json_parse);
+    global.weapons = json_to_gamemaker(working_directory + "/data/weapons.json", json_parse);
     global.gear = {
-        "armour": json_to_gamemaker(working_directory + "\\data\\armour.json", json_parse),
-        "gear": json_to_gamemaker(working_directory + "\\data\\gear.json", json_parse),
-        "mobility": json_to_gamemaker(working_directory + "\\data\\mobility.json", json_parse),
+        "armour": json_to_gamemaker(working_directory + "/data/armour.json", json_parse),
+        "gear": json_to_gamemaker(working_directory + "/data/gear.json", json_parse),
+        "mobility": json_to_gamemaker(working_directory + "/data/mobility.json", json_parse),
     };
-    global.vehicles = json_to_gamemaker(working_directory + "\\data\\vehicles.json", json_parse);
-    global.vehicle_gear = json_to_gamemaker(working_directory + "\\data\\vehicle_gear.json", json_parse);
-    global.ships = json_to_gamemaker(working_directory + "\\data\\ships.json", json_parse);
-    global.technologies = json_to_gamemaker(working_directory + "\\data\\technologies.json", json_parse);
+    global.vehicles = json_to_gamemaker(working_directory + "/data/vehicles.json", json_parse);
+    global.vehicle_gear = json_to_gamemaker(working_directory + "/data/vehicle_gear.json", json_parse);
+    global.ships = json_to_gamemaker(working_directory + "/data/ships.json", json_parse);
+    global.technologies = json_to_gamemaker(working_directory + "/data/technologies.json", json_parse);
 
-    global.base_stats = json_to_gamemaker(working_directory + "\\data\\unit_stats.json", json_parse);
+    global.base_stats = json_to_gamemaker(working_directory + "/data/unit_stats.json", json_parse);
 
     layer_force_draw_depth(true, 0); // force all layers to draw at depth 0
     draw_set_colour(c_black);

--- a/scripts/scr_ChapterTraits/scr_ChapterTraits.gml
+++ b/scripts/scr_ChapterTraits/scr_ChapterTraits.gml
@@ -275,11 +275,11 @@ function Disadvantage(trait) : ChapterTrait(trait) constructor {
 // TODO all the chapter start data should be ramed in here as well rather than being hardcoded
 
 function generate_disadvantages() {
-    return json_to_gamemaker(working_directory + $"main\\chapter_disadvantages.json", json_parse);
+    return json_to_gamemaker(working_directory + $"main/chapter_disadvantages.json", json_parse);
 }
 
 function generate_advantages() {
-    return json_to_gamemaker(working_directory + $"main\\chapter_advantages.json", json_parse);
+    return json_to_gamemaker(working_directory + $"main/chapter_advantages.json", json_parse);
 }
 
 function setup_chapter_traits() {

--- a/scripts/scr_chapter_new/scr_chapter_new.gml
+++ b/scripts/scr_chapter_new/scr_chapter_new.gml
@@ -156,7 +156,7 @@ function ChapterData() constructor {
         if (use_app_data) {
             load_result = file_loader.load_struct_from_json_file($"chaptersave#{chapter_id}.json", "chapter", true);
         } else {
-            load_result = file_loader.load_struct_from_json_file($"main\\chapters\\{chapter_id}.json", "chapter", false);
+            load_result = file_loader.load_struct_from_json_file($"main/chapters/{chapter_id}.json", "chapter", false);
         }
         if (!load_result.is_success) {
             // LOGGER.error($"No chapter json exits for chapter_id {chapter_id}");

--- a/scripts/scr_culture_visuals/scr_culture_visuals.gml
+++ b/scripts/scr_culture_visuals/scr_culture_visuals.gml
@@ -1,7 +1,7 @@
 function load_visual_sets() {
-    var _vis_set_directory = working_directory + "\\main\\visual_sets";
+    var _vis_set_directory = working_directory + "/main/visual_sets";
     if (directory_exists(_vis_set_directory)) {
-        var _file_buffer = buffer_load($"{_vis_set_directory}\\use_sets.json");
+        var _file_buffer = buffer_load($"{_vis_set_directory}/use_sets.json");
         if (_file_buffer == -1) {
             throw "Could not open file";
         }
@@ -16,7 +16,7 @@ function load_visual_sets() {
             // LOGGER.debug(_raw_data[i]);
             if (directory_exists(_sepcific_vis_set)) {
                 // LOGGER.debug(_raw_data[i]);
-                var _data_buffer = buffer_load($"{_sepcific_vis_set}\\data.json");
+                var _data_buffer = buffer_load($"{_sepcific_vis_set}/data.json");
                 if (_data_buffer == -1) {
                     buffer_delete(_data_buffer);
                     continue;
@@ -37,10 +37,10 @@ function load_visual_sets() {
 }
 
 function load_symbol_sets(global_area, main_key, sub_sets) {
-    var _cons_directory = working_directory + $"\\main\\{main_key}";
+    var _cons_directory = working_directory + $"/main/{main_key}";
     if (directory_exists(_cons_directory)) {
         // LOGGER.debug($"{_cons_directory}")
-        var _file_buffer = buffer_load($"{_cons_directory}\\load_sets.json");
+        var _file_buffer = buffer_load($"{_cons_directory}/load_sets.json");
         if (_file_buffer == -1) {
             throw false;
         }
@@ -56,7 +56,7 @@ function load_symbol_sets(global_area, main_key, sub_sets) {
             if (directory_exists(_sepcific_vis_set)) {
                 for (var s = 0; s < array_length(sub_sets); s++) {
                     var _sub = sub_sets[s];
-                    var sub_direct = $"{_sepcific_vis_set}\\{_sub}.png";
+                    var sub_direct = $"{_sepcific_vis_set}/{_sub}.png";
                     load_new_icon(_sprite_double_surface, sub_direct, global_area[$ _sub], _raw_data[i]);
                 }
             }
@@ -105,15 +105,15 @@ function load_vis_set_to_global(directory, data) {
         var _sprite_item = data[i];
         // LOGGER.debug(_sprite_item);
 
-        if (directory_exists(directory + $"\\{_sprite_item.name}")) {
-            var _sprite_direct = directory + $"\\{_sprite_item.name}";
+        if (directory_exists(directory + $"/{_sprite_item.name}")) {
+            var _sprite_direct = directory + $"/{_sprite_item.name}";
 
             // --- MAIN SPRITE LOADING ---
-            if (file_exists($"{_sprite_direct}\\1.png")) {
-                var _new_sprite = sprite_add(_sprite_direct + "\\1.png", 1, 0, 0, 0, 0);
+            if (file_exists($"{_sprite_direct}/1.png")) {
+                var _new_sprite = sprite_add(_sprite_direct + "/1.png", 1, 0, 0, 0, 0);
                 var s = 2;
-                while (file_exists(_sprite_direct + $"\\{s}.png")) {
-                    var _merge_sprite = sprite_add(_sprite_direct + $"\\{s}.png", 1, 0, 0, 0, 0);
+                while (file_exists(_sprite_direct + $"/{s}.png")) {
+                    var _merge_sprite = sprite_add(_sprite_direct + $"/{s}.png", 1, 0, 0, 0, 0);
                     if (_merge_sprite == -1) {
                         sprite_delete(_new_sprite);
                         continue;
@@ -126,11 +126,11 @@ function load_vis_set_to_global(directory, data) {
 
             // --- SHADOW SPRITE LOADING ---
             var _new_shadow = -1;
-            if (file_exists($"{_sprite_direct}\\shadow1.png")) {
-                _new_shadow = sprite_add(_sprite_direct + "\\shadow1.png", 1, 0, 0, 0, 0);
+            if (file_exists($"{_sprite_direct}/shadow1.png")) {
+                _new_shadow = sprite_add(_sprite_direct + "/shadow1.png", 1, 0, 0, 0, 0);
                 var sh = 2;
-                while (file_exists(_sprite_direct + $"\\shadow{sh}.png")) {
-                    var _merge_shadow = sprite_add(_sprite_direct + $"\\shadow{sh}.png", 1, 0, 0, 0, 0);
+                while (file_exists(_sprite_direct + $"/shadow{sh}.png")) {
+                    var _merge_shadow = sprite_add(_sprite_direct + $"/shadow{sh}.png", 1, 0, 0, 0, 0);
                     if (_merge_shadow == -1) {
                         sprite_delete(_new_shadow);
                         continue;

--- a/scripts/scr_culture_visuals/scr_culture_visuals.gml
+++ b/scripts/scr_culture_visuals/scr_culture_visuals.gml
@@ -12,7 +12,7 @@ function load_visual_sets() {
             throw "use_sets.json File Wrong Format";
         }
         for (var i = 0; i < array_length(_raw_data); i++) {
-            var _sepcific_vis_set = $"{_vis_set_directory}\\{_raw_data[i]}";
+            var _sepcific_vis_set = $"{_vis_set_directory}/{_raw_data[i]}";
             // LOGGER.debug(_raw_data[i]);
             if (directory_exists(_sepcific_vis_set)) {
                 // LOGGER.debug(_raw_data[i]);
@@ -52,7 +52,7 @@ function load_symbol_sets(global_area, main_key, sub_sets) {
         }
         var _sprite_double_surface = surface_create(200, 200);
         for (var i = 0; i < array_length(_raw_data); i++) {
-            var _sepcific_vis_set = $"{_cons_directory}\\{_raw_data[i]}";
+            var _sepcific_vis_set = $"{_cons_directory}/{_raw_data[i]}";
             if (directory_exists(_sepcific_vis_set)) {
                 for (var s = 0; s < array_length(sub_sets); s++) {
                     var _sub = sub_sets[s];

--- a/scripts/scr_dialogue/scr_dialogue.gml
+++ b/scripts/scr_dialogue/scr_dialogue.gml
@@ -1,6 +1,6 @@
 function initialize_dialogue() {
     global.dialogue = {};
-    global.dialogue.sisters = json_to_gamemaker(working_directory + "\\data\\dialogue\\sisters.json", json_parse);
+    global.dialogue.sisters = json_to_gamemaker(working_directory + "/data/dialogue/sisters.json", json_parse);
 }
 
 function interpret_diag_string(string_data, data) {

--- a/scripts/scr_image/scr_image.gml
+++ b/scripts/scr_image/scr_image.gml
@@ -484,23 +484,23 @@ function scr_image(path, image_id, x1, y1, width, height) {
             }
 
             if (single_image == true) {
-                if ((path == "creation") && file_exists(working_directory + "\\images\\creation\\creation_icons.png")) {
-                    creation[1] = sprite_add(working_directory + "\\images\\creation\\creation_icons.png", 24, false, false, 0, 0);
+                if ((path == "creation") && file_exists(working_directory + "/images/creation/creation_icons.png")) {
+                    creation[1] = sprite_add(working_directory + "/images/creation/creation_icons.png", 24, false, false, 0, 0);
                     creation_exists[1] = true;
                     creation_good = true;
                 }
-                if ((path == "diplomacy_icon") && file_exists(working_directory + "\\images\\diplomacy\\diplomacy_icons.png")) {
-                    diplomacy_icon[1] = sprite_add(working_directory + "\\images\\diplomacy\\diplomacy_icons.png", 28, false, false, 0, 0);
+                if ((path == "diplomacy_icon") && file_exists(working_directory + "/images/diplomacy/diplomacy_icons.png")) {
+                    diplomacy_icon[1] = sprite_add(working_directory + "/images/diplomacy/diplomacy_icons.png", 28, false, false, 0, 0);
                     diplomacy_icon_exists[1] = true;
                     diplomacy_icon_good = true;
                 }
-                if ((path == "menu") && file_exists(working_directory + "\\images\\ui\\ingame_menu.png")) {
-                    menu[1] = sprite_add(working_directory + "\\images\\ui\\ingame_menu.png", 2, false, false, 0, 0);
+                if ((path == "menu") && file_exists(working_directory + "/images/ui/ingame_menu.png")) {
+                    menu[1] = sprite_add(working_directory + "/images/ui/ingame_menu.png", 2, false, false, 0, 0);
                     menu_exists[1] = true;
                     menu_good = true;
                 }
-                if ((path == "title_splash") && file_exists(working_directory + "\\images\\title_splash.png")) {
-                    title_splash[1] = sprite_add(working_directory + "\\images\\title_splash.png", 1, false, false, 0, 0);
+                if ((path == "title_splash") && file_exists(working_directory + "/images/title_splash.png")) {
+                    title_splash[1] = sprite_add(working_directory + "/images/title_splash.png", 1, false, false, 0, 0);
                     title_splash_exists[1] = true;
                     title_splash_good = true;
                 }
@@ -514,8 +514,8 @@ function scr_image(path, image_id, x1, y1, width, height) {
                 repeat (40) {
                     i += 1;
                     if (path == "main_splash") {
-                        if (file_exists(working_directory + "\\images\\creation\\main" + string(i) + ".png")) {
-                            main[i - 1] = sprite_add(working_directory + "\\images\\creation\\main" + string(i) + ".png", 1, false, false, 0, 0);
+                        if (file_exists(working_directory + "/images/creation/main" + string(i) + ".png")) {
+                            main[i - 1] = sprite_add(working_directory + "/images/creation/main" + string(i) + ".png", 1, false, false, 0, 0);
                             main_exists[i - 1] = 1;
                             w += 1;
                         }
@@ -524,8 +524,8 @@ function scr_image(path, image_id, x1, y1, width, height) {
                         }
                     }
                     if (path == "existing_splash") {
-                        if (file_exists(working_directory + "\\images\\creation\\existing" + string(i) + ".png")) {
-                            existing[i - 1] = sprite_add(working_directory + "\\images\\creation\\existing" + string(i) + ".png", 1, false, false, 0, 0);
+                        if (file_exists(working_directory + "/images/creation/existing" + string(i) + ".png")) {
+                            existing[i - 1] = sprite_add(working_directory + "/images/creation/existing" + string(i) + ".png", 1, false, false, 0, 0);
                             existing_exists[i - 1] = 1;
                             w += 1;
                         }
@@ -534,8 +534,8 @@ function scr_image(path, image_id, x1, y1, width, height) {
                         }
                     }
                     if (path == "other_splash") {
-                        if (file_exists(working_directory + "\\images\\creation\\other" + string(i) + ".png")) {
-                            others[i - 1] = sprite_add(working_directory + "\\images\\creation\\other" + string(i) + ".png", 1, false, false, 0, 0);
+                        if (file_exists(working_directory + "/images/creation/other" + string(i) + ".png")) {
+                            others[i - 1] = sprite_add(working_directory + "/images/creation/other" + string(i) + ".png", 1, false, false, 0, 0);
                             others_exists[i - 1] = 1;
                             w += 1;
                         }
@@ -545,8 +545,8 @@ function scr_image(path, image_id, x1, y1, width, height) {
                     }
 
                     if (path == "advisor") {
-                        if (file_exists(working_directory + "\\images\\diplomacy\\advisor" + string(i) + ".png")) {
-                            advisor[i - 1] = sprite_add(working_directory + "\\images\\diplomacy\\advisor" + string(i) + ".png", 1, false, false, 0, 0);
+                        if (file_exists(working_directory + "/images/diplomacy/advisor" + string(i) + ".png")) {
+                            advisor[i - 1] = sprite_add(working_directory + "/images/diplomacy/advisor" + string(i) + ".png", 1, false, false, 0, 0);
                             advisor_exists[i - 1] = 1;
                             w += 1;
                         }
@@ -556,8 +556,8 @@ function scr_image(path, image_id, x1, y1, width, height) {
                     }
 
                     if (path == "diplomacy_splash") {
-                        if (file_exists(working_directory + "\\images\\diplomacy\\diplomacy" + string(i) + ".png")) {
-                            diplomacy_splash[i - 1] = sprite_add(working_directory + "\\images\\diplomacy\\diplomacy" + string(i) + ".png", 1, false, false, 0, 0);
+                        if (file_exists(working_directory + "/images/diplomacy/diplomacy" + string(i) + ".png")) {
+                            diplomacy_splash[i - 1] = sprite_add(working_directory + "/images/diplomacy/diplomacy" + string(i) + ".png", 1, false, false, 0, 0);
                             diplomacy_splash_exists[i - 1] = 1;
                             w += 1;
                         }
@@ -567,8 +567,8 @@ function scr_image(path, image_id, x1, y1, width, height) {
                     }
 
                     if (path == "diplomacy_daemon") {
-                        if (file_exists(working_directory + "\\images\\diplomacy\\daemon" + string(i) + ".png")) {
-                            diplomacy_daemon[i - 1] = sprite_add(working_directory + "\\images\\diplomacy\\daemon" + string(i) + ".png", 1, false, false, 0, 0);
+                        if (file_exists(working_directory + "/images/diplomacy/daemon" + string(i) + ".png")) {
+                            diplomacy_daemon[i - 1] = sprite_add(working_directory + "/images/diplomacy/daemon" + string(i) + ".png", 1, false, false, 0, 0);
                             diplomacy_daemon_exists[i - 1] = 1;
                             w += 1;
                         }
@@ -578,8 +578,8 @@ function scr_image(path, image_id, x1, y1, width, height) {
                     }
                     // loading screen error arg
                     if (path == "loading") {
-                        if (file_exists(working_directory + "\\images\\loading\\loading" + string(i) + ".png")) {
-                            loading[i - 1] = sprite_add(working_directory + "\\images\\loading\\loading" + string(i) + ".png", 1, false, false, 0, 0);
+                        if (file_exists(working_directory + "/images/loading/loading" + string(i) + ".png")) {
+                            loading[i - 1] = sprite_add(working_directory + "/images/loading/loading" + string(i) + ".png", 1, false, false, 0, 0);
                             loading_exists[i - 1] = 1;
                             w += 1;
                         }
@@ -589,8 +589,8 @@ function scr_image(path, image_id, x1, y1, width, height) {
                     }
 
                     if (path == "postbattle") {
-                        if (file_exists(working_directory + "\\images\\ui\\postbattle" + string(i) + ".png")) {
-                            postbattle[i - 1] = sprite_add(working_directory + "\\images\\ui\\postbattle" + string(i) + ".png", 1, false, false, 0, 0);
+                        if (file_exists(working_directory + "/images/ui/postbattle" + string(i) + ".png")) {
+                            postbattle[i - 1] = sprite_add(working_directory + "/images/ui/postbattle" + string(i) + ".png", 1, false, false, 0, 0);
                             postbattle_exists[i - 1] = 1;
                             w += 1;
                         }
@@ -600,8 +600,8 @@ function scr_image(path, image_id, x1, y1, width, height) {
                     }
 
                     if (path == "postspace") {
-                        if (file_exists(working_directory + "\\images\\ui\\postspace" + string(i) + ".png")) {
-                            postspace[i - 1] = sprite_add(working_directory + "\\images\\ui\\postspace" + string(i) + ".png", 1, false, false, 0, 0);
+                        if (file_exists(working_directory + "/images/ui/postspace" + string(i) + ".png")) {
+                            postspace[i - 1] = sprite_add(working_directory + "/images/ui/postspace" + string(i) + ".png", 1, false, false, 0, 0);
                             postspace_exists[i - 1] = 1;
                             w += 1;
                         }
@@ -611,8 +611,8 @@ function scr_image(path, image_id, x1, y1, width, height) {
                     }
 
                     if (path == "formation") {
-                        if (file_exists(working_directory + "\\images\\ui\\formation" + string(i) + ".png")) {
-                            formation[i - 1] = sprite_add(working_directory + "\\images\\ui\\formation" + string(i) + ".png", 1, false, false, 0, 0);
+                        if (file_exists(working_directory + "/images/ui/formation" + string(i) + ".png")) {
+                            formation[i - 1] = sprite_add(working_directory + "/images/ui/formation" + string(i) + ".png", 1, false, false, 0, 0);
                             formation_exists[i - 1] = 1;
                             w += 1;
                         }
@@ -622,8 +622,8 @@ function scr_image(path, image_id, x1, y1, width, height) {
                     }
 
                     if (path == "popup") {
-                        if (file_exists(working_directory + "\\images\\popup\\popup" + string(i) + ".png")) {
-                            popup[i - 1] = sprite_add(working_directory + "\\images\\popup\\popup" + string(i) + ".png", 1, false, false, 0, 0);
+                        if (file_exists(working_directory + "/images/popup/popup" + string(i) + ".png")) {
+                            popup[i - 1] = sprite_add(working_directory + "/images/popup/popup" + string(i) + ".png", 1, false, false, 0, 0);
                             popup_exists[i - 1] = 1;
                             w += 1;
                         }
@@ -633,8 +633,8 @@ function scr_image(path, image_id, x1, y1, width, height) {
                     }
 
                     if (path == "commander") {
-                        if (file_exists(working_directory + "\\images\\ui\\commander" + string(i) + ".png")) {
-                            commander[i - 1] = sprite_add(working_directory + "\\images\\ui\\commander" + string(i) + ".png", 1, false, false, 0, 0);
+                        if (file_exists(working_directory + "/images/ui/commander" + string(i) + ".png")) {
+                            commander[i - 1] = sprite_add(working_directory + "/images/ui/commander" + string(i) + ".png", 1, false, false, 0, 0);
                             commander_exists[i - 1] = 1;
                             w += 1;
                         }
@@ -644,8 +644,8 @@ function scr_image(path, image_id, x1, y1, width, height) {
                     }
 
                     if (path == "planet") {
-                        if (file_exists(working_directory + "\\images\\ui\\planet" + string(i) + ".png")) {
-                            planet[i - 1] = sprite_add(working_directory + "\\images\\ui\\planet" + string(i) + ".png", 1, false, false, 0, 0);
+                        if (file_exists(working_directory + "/images/ui/planet" + string(i) + ".png")) {
+                            planet[i - 1] = sprite_add(working_directory + "/images/ui/planet" + string(i) + ".png", 1, false, false, 0, 0);
                             planet_exists[i - 1] = 1;
                             w += 1;
                         }
@@ -655,8 +655,8 @@ function scr_image(path, image_id, x1, y1, width, height) {
                     }
 
                     if (path == "attacked") {
-                        if (file_exists(working_directory + "\\images\\ui\\attacked" + string(i) + ".png")) {
-                            attacked[i - 1] = sprite_add(working_directory + "\\images\\ui\\attacked" + string(i) + ".png", 1, false, false, 0, 0);
+                        if (file_exists(working_directory + "/images/ui/attacked" + string(i) + ".png")) {
+                            attacked[i - 1] = sprite_add(working_directory + "/images/ui/attacked" + string(i) + ".png", 1, false, false, 0, 0);
                             attacked_exists[i - 1] = 1;
                             w += 1;
                         }
@@ -666,8 +666,8 @@ function scr_image(path, image_id, x1, y1, width, height) {
                     }
 
                     if (path == "force") {
-                        if (file_exists(working_directory + "\\images\\ui\\force" + string(i) + ".png")) {
-                            force[i - 1] = sprite_add(working_directory + "\\images\\ui\\force" + string(i) + ".png", 1, false, false, 0, 0);
+                        if (file_exists(working_directory + "/images/ui/force" + string(i) + ".png")) {
+                            force[i - 1] = sprite_add(working_directory + "/images/ui/force" + string(i) + ".png", 1, false, false, 0, 0);
                             force_exists[i - 1] = 1;
                             w += 1;
                         }
@@ -677,8 +677,8 @@ function scr_image(path, image_id, x1, y1, width, height) {
                     }
 
                     if (path == "purge") {
-                        if (file_exists(working_directory + "\\images\\ui\\purge" + string(i) + ".png")) {
-                            purge[i - 1] = sprite_add(working_directory + "\\images\\ui\\purge" + string(i) + ".png", 1, false, false, 0, 0);
+                        if (file_exists(working_directory + "/images/ui/purge" + string(i) + ".png")) {
+                            purge[i - 1] = sprite_add(working_directory + "/images/ui/purge" + string(i) + ".png", 1, false, false, 0, 0);
                             purge_exists[i - 1] = 1;
                             w += 1;
                         }
@@ -688,8 +688,8 @@ function scr_image(path, image_id, x1, y1, width, height) {
                     }
 
                     if (path == "event") {
-                        if (file_exists(working_directory + "\\images\\ui\\event" + string(i) + ".png")) {
-                            event[i - 1] = sprite_add(working_directory + "\\images\\ui\\event" + string(i) + ".png", 1, false, false, 0, 0);
+                        if (file_exists(working_directory + "/images/ui/event" + string(i) + ".png")) {
+                            event[i - 1] = sprite_add(working_directory + "/images/ui/event" + string(i) + ".png", 1, false, false, 0, 0);
                             event_exists[i - 1] = 1;
                             w += 1;
                         }
@@ -699,8 +699,8 @@ function scr_image(path, image_id, x1, y1, width, height) {
                     }
 
                     if (path == "symbol") {
-                        if (file_exists(working_directory + "\\images\\diplomacy\\symbol" + string(i) + ".png")) {
-                            symbol[i - 1] = sprite_add(working_directory + "\\images\\diplomacy\\symbol" + string(i) + ".png", 1, false, false, 0, 0);
+                        if (file_exists(working_directory + "/images/diplomacy/symbol" + string(i) + ".png")) {
+                            symbol[i - 1] = sprite_add(working_directory + "/images/diplomacy/symbol" + string(i) + ".png", 1, false, false, 0, 0);
                             symbol_exists[i - 1] = 1;
                             w += 1;
                         }
@@ -710,8 +710,8 @@ function scr_image(path, image_id, x1, y1, width, height) {
                     }
 
                     if (path == "defeat") {
-                        if (file_exists(working_directory + "\\images\\ui\\defeat" + string(i) + ".png")) {
-                            defeat[i - 1] = sprite_add(working_directory + "\\images\\ui\\defeat" + string(i) + ".png", 1, false, false, 0, 0);
+                        if (file_exists(working_directory + "/images/ui/defeat" + string(i) + ".png")) {
+                            defeat[i - 1] = sprite_add(working_directory + "/images/ui/defeat" + string(i) + ".png", 1, false, false, 0, 0);
                             defeat_exists[i - 1] = 1;
                             w += 1;
                         }
@@ -721,8 +721,8 @@ function scr_image(path, image_id, x1, y1, width, height) {
                     }
 
                     if (path == "slate") {
-                        if (file_exists(working_directory + "\\images\\creation\\slate" + string(i) + ".png")) {
-                            slate[i - 1] = sprite_add(working_directory + "\\images\\creation\\slate" + string(i) + ".png", 1, false, false, 0, 0);
+                        if (file_exists(working_directory + "/images/creation/slate" + string(i) + ".png")) {
+                            slate[i - 1] = sprite_add(working_directory + "/images/creation/slate" + string(i) + ".png", 1, false, false, 0, 0);
                             slate_exists[i - 1] = 1;
                             w += 1;
                         }
@@ -953,12 +953,12 @@ function scr_image_cache(path, image_id, use_app_data = false) {
         if (sprite_exists(existing_sprite)) {
             drawing_sprite = existing_sprite;
         } else if (image_id > -1) {
-            var folders = string_replace_all(path, "/", "\\");
+            var folders = string_replace_all(path, "\\", "/");
             var dir;
             if (use_app_data) {
                 dir = $"{folders}{string(image_id)}.png";
             } else {
-                dir = $"{working_directory}\\images\\{folders}\\{string(image_id)}.png";
+                dir = $"{working_directory}/images/{folders}/{string(image_id)}.png";
             }
             if (file_exists(dir)) {
                 drawing_sprite = sprite_add(dir, 1, false, false, 0, 0);

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -1662,19 +1662,19 @@ function scr_initialize_custom() {
     switch (obj_creation.squad_distribution) {
         case 1: // equal specialists only
             obj_ini.chapter_squad_arrangement = json_to_gamemaker(
-                working_directory + $"main\\squads\\equal_specialists.json", json_parse);
+                working_directory + $"main/squads/equal_specialists.json", json_parse);
             break;
         case 2: // equal scouts only
             obj_ini.chapter_squad_arrangement = json_to_gamemaker(
-                working_directory + $"main\\squads\\equal_scouts.json", json_parse);
+                working_directory + $"main/squads/equal_scouts.json", json_parse);
             break;
         case 3: // equal specialists and equal scouts
             obj_ini.chapter_squad_arrangement = json_to_gamemaker(
-                working_directory + $"main\\squads\\equal_spescout.json", json_parse);
+                working_directory + $"main/squads/equal_spescout.json", json_parse);
             break;
         default: // 0 = standard
             obj_ini.chapter_squad_arrangement = json_to_gamemaker(
-                working_directory + $"main\\squads\\company_squad_builds.json", json_parse);
+                working_directory + $"main/squads/company_squad_builds.json", json_parse);
             break;
     }
 
@@ -1691,7 +1691,7 @@ function scr_initialize_custom() {
         _squad_name = obj_creation.squad_name;
     }
 
-    squad_types = json_to_gamemaker(working_directory + $"main\\squads\\base_squads.json", json_parse);
+    squad_types = json_to_gamemaker(working_directory + $"main/squads/base_squads.json", json_parse);
     var _swaps = [
         // ── Heavy Ranged ──────────────────────────────────────────────
         {

--- a/scripts/scr_powers/scr_powers.gml
+++ b/scripts/scr_powers/scr_powers.gml
@@ -20,8 +20,8 @@ global.psy_disciplines_starting = [
 #macro PSY_CAST_DIFFICULTY_MIN 1
 #macro PSY_CAST_DIFFICULTY_BASE 40
 
-global.disciplines_data = json_to_gamemaker(working_directory + "\\data\\psychic_disciplines.json", json_parse);
-global.powers_data = json_to_gamemaker(working_directory + "\\data\\psychic_powers.json", json_parse);
+global.disciplines_data = json_to_gamemaker(working_directory + "/data/psychic_disciplines.json", json_parse);
+global.powers_data = json_to_gamemaker(working_directory + "/data/psychic_powers.json", json_parse);
 
 /// @param {Struct.TTRPG_stats} unit
 function generate_marine_powers_description_string(unit) {

--- a/scripts/scr_ruins_reward/scr_ruins_reward.gml
+++ b/scripts/scr_ruins_reward/scr_ruins_reward.gml
@@ -54,7 +54,7 @@ function scr_ruins_reward(_star_system, _pid_idx, _ruins) {
         // Lazy-load JSON from disk once
         if (_loot_registry == undefined) {
             _loot_registry = {};
-            var _path = working_directory + "\\data\\ruins_loot.json";
+            var _path = working_directory + "/data/ruins_loot.json";
             var _raw_json = json_to_gamemaker(_path, json_parse);
 
             var _keys = struct_get_names(_raw_json);

--- a/scripts/scr_ui_manage/scr_ui_manage.gml
+++ b/scripts/scr_ui_manage/scr_ui_manage.gml
@@ -578,7 +578,7 @@ function alternative_manage_views(x1, y1) {
             if (!directory_exists(main_dir)) {
                 directory_create(main_dir);
             }
-            var base_name = working_directory + $"/main/marine_capture_{_unit.name()}_{_unit.marine_number}{_unit.company}";
+            var base_name = main_dir + $"/marine_capture_{_unit.name()}_{_unit.marine_number}{_unit.company}";
             var extension = ".png";
             var index = 0;
             var path;

--- a/scripts/scr_ui_manage/scr_ui_manage.gml
+++ b/scripts/scr_ui_manage/scr_ui_manage.gml
@@ -574,6 +574,10 @@ function alternative_manage_views(x1, y1) {
             surface_reset_target();
 
             // save to local game folder
+            var main_dir = working_directory + "/main";
+            if (!directory_exists(main_dir)) {
+                directory_create(main_dir);
+            }
             var base_name = working_directory + $"/main/marine_capture_{_unit.name()}_{_unit.marine_number}{_unit.company}";
             var extension = ".png";
             var index = 0;
@@ -592,7 +596,11 @@ function alternative_manage_views(x1, y1) {
             // cleanup
             surface_free(surf);
 
-            LOGGER.debug("Marine image saved to: " + path);
+            if (file_exists(path)) {
+                LOGGER.debug("Marine image saved to: " + path);
+            } else {
+                LOGGER.error("Failed to save marine image to: " + path);
+            }
         }
     }
 }

--- a/scripts/scr_ui_manage/scr_ui_manage.gml
+++ b/scripts/scr_ui_manage/scr_ui_manage.gml
@@ -574,7 +574,7 @@ function alternative_manage_views(x1, y1) {
             surface_reset_target();
 
             // save to local game folder
-            var base_name = working_directory + $"\\main\\marine_capture_{_unit.name()}_{_unit.marine_number}{_unit.company}";
+            var base_name = working_directory + $"/main/marine_capture_{_unit.name()}_{_unit.marine_number}{_unit.company}";
             var extension = ".png";
             var index = 0;
             var path;

--- a/scripts/scr_unit_traits/scr_unit_traits.gml
+++ b/scripts/scr_unit_traits/scr_unit_traits.gml
@@ -1,5 +1,5 @@
 function initialize_marine_traits() {
-    global.trait_list = json_to_gamemaker(working_directory + "\\data\\traits.json", json_parse);
+    global.trait_list = json_to_gamemaker(working_directory + "/data/traits.json", json_parse);
 }
 
 function marine_has_trait(wanted_trait) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Normalize file and directory paths to use forward slashes and centralize path macros to improve Linux compatibility while keeping Windows behavior. Also hardened sprite/help loading and marine image saving across OSes; README now includes Linux run options (WINE/Proton and GameMaker IDE).

- **Refactors**
  - Replaced backslashes with forward slashes across JSON/image/INI/buffer paths.
  - Added `PATH_HELP_INI` and updated path macros (`PATH_SAVE_FILES`, icons, images) to use `/`.
  - Error handler now shows OS-appropriate log path hints.
  - Normalized `scr_image`/`scr_image_cache`, culture/symbol visual set loaders, and data JSON loads to platform-safe paths.

- **Bug Fixes**
  - Ensure `main/` exists before saving marine captures; log success or failure.
  - Use `PATH_HELP_INI` to load help topics reliably across platforms.

<sup>Written for commit c4bee4c9229579e8e08756e359a0697c11116ecb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

