### PR TITLE
fix: star draw 64 error

### DIFF
--- a/objects/obj_star/Alarm_3.gml
+++ b/objects/obj_star/Alarm_3.gml
@@ -54,7 +54,8 @@ try {
             if (struct_exists(_data, "planet")) {
                 obj_controller.selecting_planet = _data.planet;
                 if (obj_controller.selecting_planet > 0 && obj_controller.selecting_planet < 5) {
-                    obj_star_select.garrison = get_garrison(obj_controller.selecting_planet);
+                    var _pdata = get_planet_data(obj_controller.selecting_planet);
+                    _pdata.set_star_select_planet();
                 }
             }
             obj_controller.selection_data = false;

--- a/objects/obj_star_select/Draw_64.gml
+++ b/objects/obj_star_select/Draw_64.gml
@@ -260,15 +260,13 @@ try {
                     exit;
                 }
             }
-        } else if (garrison != "" && !population) {
+        } else if (garrison != "" && !population && garrison.planet == obj_controller.selecting_planet) {
             if (garrison.garrison_force) {
                 draw_set_font(fnt_40k_14);
-                if (!garrison.garrison_leader) {
-                    garrison.find_leader();
-                    garrison.garrison_disposition_change(true);
-                    garrison_data_slate.sub_title = $"Garrison Leader {garrison.garrison_leader.name_role()}";
-                    garrison_data_slate.body_text = garrison.garrison_report();
-                }
+
+                garrison_data_slate.sub_title = $"Garrison Leader {garrison.garrison_leader.name_role()}";
+                garrison_data_slate.body_text = garrison.garrison_report();
+
                 garrison_data_slate.inside_method = function() {
                     garrison_data_slate.title = "Garrison Report";
                     draw_set_color(c_gray);
@@ -284,15 +282,15 @@ try {
                     if (scr_hit(xx + 20, half_way + 10, xx + 20 + string_width(defence_string), half_way + 10 + 20)) {
                         tooltip_draw(defence_data[1], 400);
                     }
-                    if (garrison.dispo_change != "none") {
-                        if (garrison.dispo_change > 55) {
-                            draw_text(xx + 20, half_way + 30, $"Garrison Disposition Effect : Positive");
-                        } else if (garrison.dispo_change > 44) {
-                            draw_text(xx + 20, half_way + 30, $"Garrison Disposition Effect : Neutral");
-                        } else {
-                            draw_text(xx + 20, half_way + 30, $"Garrison Disposition Effect : Negative");
-                        }
+
+                    if (garrison.dispo_change > 55) {
+                        draw_text(xx + 20, half_way + 30, $"Garrison Disposition Effect : Positive");
+                    } else if (garrison.dispo_change > 44 || garrison.dispo_change == 0) {
+                        draw_text(xx + 20, half_way + 30, $"Garrison Disposition Effect : Neutral");
+                    } else {
+                        draw_text(xx + 20, half_way + 30, $"Garrison Disposition Effect : Negative");
                     }
+
                 };
                 garrison_data_slate.draw(340 + main_data_slate.width, 160, 0.6, 0.6);
             }

--- a/scripts/scr_PlanetData/scr_PlanetData.gml
+++ b/scripts/scr_PlanetData/scr_PlanetData.gml
@@ -106,7 +106,13 @@ function PlanetData(planet, system) constructor {
         }
 
         garrisons = system.system_garrison[planet];
+        if (garrisons == 0){
+            garrisons = system.get_garrison(planet)
+        }
         sabatours = system.system_sabatours[planet];
+        if (sabatours == 0){
+            sabatours = system.get_sabatours(planet)
+        }
         system.system_datas[planet] = self;
 
         // current planet heresy
@@ -1581,6 +1587,18 @@ function PlanetData(planet, system) constructor {
         instance_destroy(obj_star_select);
     };
 
+    static set_star_select_planet = function(){
+        obj_star_select.garrison = garrisons;
+        system.garrison = garrisons.garrison_force;
+        obj_star_select.feature = "";
+        buttons_selected = false;
+        garrisons.update();
+        if (garrisons.garrison_force){
+            garrisons.find_leader();
+            garrisons.garrison_disposition_change(true);            
+        }     
+    }
+
     static planet_selection_logic = function() {
         var planet_is_allies = scr_is_planet_owned_by_allies(system, planet);
         var garrison_issue = !planet_is_allies || pdf <= 0;
@@ -1602,10 +1620,7 @@ function PlanetData(planet, system) constructor {
                 exit;
             }
         } else if (!_loading) {
-            obj_star_select.garrison = system.get_garrison(planet);
-            system.garrison = obj_star_select.garrison.garrison_force;
-            obj_star_select.feature = "";
-            buttons_selected = false;
+            set_star_select_planet();
         } else if (_loading && planet > 0) {
             obj_controller.unload = planet;
             obj_controller.return_object = system;

--- a/scripts/scr_garrison/scr_garrison.gml
+++ b/scripts/scr_garrison/scr_garrison.gml
@@ -36,6 +36,7 @@ function GarrisonForce(system, planet, type = "garrison") constructor {
     members = [];
     time_on_planet = 0;
     viable_garrison = 0;
+    dispo_change = 0;
     self.type = type;
     self.system = system;
     self.planet = planet;
@@ -213,63 +214,64 @@ function GarrisonForce(system, planet, type = "garrison") constructor {
     static garrison_disposition_change = function(up_or_down = false) {
         dispo_change = 0;
         var _pdata = system.get_planet_data(planet);
-        if (array_contains(obj_controller.imperial_factions, _pdata.current_owner)) {
-            var _planet_disposition = _pdata.player_disposition;
+        if (!array_contains(obj_controller.imperial_factions, _pdata.current_owner)) {
+            return dispo_change;
+        }
+        
+        var _planet_disposition = _pdata.player_disposition;
 
-            var _main_faction_disp = _pdata.owner_faction_disposition();
+        var _main_faction_disp = _pdata.owner_faction_disposition();
 
-            //basivally it is easier to increase dispositioon the nearer you are to 50 but becomminig greatly hated or greaty liked is much harder
-            var _disposition_modifier = _planet_disposition <= 50 ? (_planet_disposition / 10) : ((_planet_disposition - 50) / 10) % 5;
+        //basivally it is easier to increase dispositioon the nearer you are to 50 but becomminig greatly hated or greaty liked is much harder
+        var _disposition_modifier = _planet_disposition <= 50 ? (_planet_disposition / 10) : ((_planet_disposition - 50) / 10) % 5;
 
-            _disposition_modifier /= 10;
+        _disposition_modifier /= 10;
 
-            var _time_modifier = max(time_on_planet / 2.5, 10);
+        var _time_modifier = max(time_on_planet / 2.5, 10);
 
-            if (!is_struct(garrison_leader)) {
-                find_leader();
-            }
-            var _diplomatic_leader = false;
-            if (is_struct(garrison_leader)) {
-                _diplomatic_leader = garrison_leader.has_trait("honorable");
-            } else {
-                scr_alert("yellow", "DEBUG", $"DEBUG: Garrison _Leader on {_pdata.name()} couldn't be found!", 0, 0);
-                scr_event_log("yellow", $"DEBUG: Garrison _Leader on {_pdata.name()} couldn't be found!");
-                LOGGER.error($"DEBUG: Garrison _Leader on {_pdata.name()} couldn't be found!");
-            }
-            var _garrison_size_mod = total_garrison / 10;
+        if (!is_struct(garrison_leader)) {
+            find_leader();
+        }
+        var _diplomatic_leader = false;
+        if (is_struct(garrison_leader)) {
+            _diplomatic_leader = garrison_leader.has_trait("honorable");
+        } else {
+            scr_alert("yellow", "DEBUG", $"DEBUG: Garrison _Leader on {_pdata.name()} couldn't be found!", 0, 0);
+            scr_event_log("yellow", $"DEBUG: Garrison _Leader on {_pdata.name()} couldn't be found!");
+            LOGGER.error($"DEBUG: Garrison _Leader on {_pdata.name()} couldn't be found!");
+        }
+        var _garrison_size_mod = total_garrison / 10;
 
-            var final_modifier = 5 + _garrison_size_mod - _disposition_modifier + _time_modifier;
+        var final_modifier = 5 + _garrison_size_mod - _disposition_modifier + _time_modifier;
 
-            if (up_or_down) {
-                dispo_change = garrison_leader.charisma + final_modifier;
-                if (dispo_change < 50 && ((_planet_disposition < _main_faction_disp) || _diplomatic_leader)) {
-                    dispo_change = 50;
-                }
-            } else {
-                var _charisma_test;
-                if (is_struct(garrison_leader)){
-                    _charisma_test = global.character_tester.standard_test(garrison_leader, "charisma", final_modifier);
-                }  else {
-                    _charisma_test = [bool(irandom(1)), irandom_range(0, 25)];
-                }
-                var dispo_change = _charisma_test[1] / 10;
-                if (!_charisma_test[0]) {
-                    if (_diplomatic_leader) {
-                        dispo_change = "none";
-                    } else {
-                        if (_planet_disposition > _main_faction_disp) {
-                            _pdata.add_disposition(dispo_change);
-                        } else {
-                            dispo_change = 0;
-                        }
-                    }
-                } else {
-                    _pdata.add_disposition(dispo_change);
-                }
+        if (up_or_down) {
+            dispo_change = garrison_leader.charisma + final_modifier;
+            if (dispo_change < 50 && ((_planet_disposition < _main_faction_disp) || _diplomatic_leader)) {
+                dispo_change = 50;
             }
         } else {
-            dispo_change = "none";
+            var _charisma_test;
+            if (is_struct(garrison_leader)){
+                _charisma_test = global.character_tester.standard_test(garrison_leader, "charisma", final_modifier);
+            }  else {
+                _charisma_test = [bool(irandom(1)), irandom_range(0, 25)];
+            }
+            var dispo_change = _charisma_test[1] / 10;
+            if (!_charisma_test[0]) {
+                if (_diplomatic_leader) {
+                    dispo_change = 0;
+                } else {
+                    if (_planet_disposition > _main_faction_disp) {
+                        _pdata.add_disposition(dispo_change);
+                    } else {
+                        dispo_change = 0;
+                    }
+                }
+            } else {
+                _pdata.add_disposition(dispo_change);
+            }
         }
+
         return dispo_change;
     };
 


### PR DESCRIPTION
<!--- YOU CAN DELETE ALL OF THIS AFTER READING. -->

<!--- Make use of markdown lists. They make stuff much easier to read through. -->
<!--- Explain why and what your changes do in simple terms. --->
<!--- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. --->

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->

<!--- "Inspired" by the CDDA PR template -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the star selection overlay crash by initializing garrison data when a planet is selected and tightening Draw_64 guards. Standardizes garrison disposition to numeric values for consistent UI and logic.

- **Bug Fixes**
  - Initialize garrison, leader, and disposition via PlanetData.set_star_select_planet() (used in planet selection and `Alarm_3`) instead of doing it in draw.
  - Draw_64 only renders garrison info if it exists and matches the selected planet; removed on-draw leader lookup.
  - Garrison disposition now uses numbers (0 for neutral) instead of "none"; updated UI to treat 0 as Neutral and adjust thresholds.
  - Added default `dispo_change = 0` and early exit on non-Imperial planets to avoid invalid state.
  - PlanetData now falls back to `system.get_garrison()`/`get_sabatours()` when array slots are empty to prevent 0/undefined access.

<sup>Written for commit 3c1816b5b03377a8d515a6e352059b0eb143e0ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

