### PR TITLE
fix: missing edit_pdf method

### DIFF
--- a/scripts/scr_PlanetData/scr_PlanetData.gml
+++ b/scripts/scr_PlanetData/scr_PlanetData.gml
@@ -253,6 +253,11 @@ function PlanetData(planet, system) constructor {
         guardsmen = system.p_guardsmen[planet];
     };
 
+    static edit_pdf = function(edit_val){
+        system.p_pdf[planet] = max(0, system.p_pdf[planet] + edit_val);
+        pdf = system.p_pdf[planet]
+    }
+    
     pdf = system.p_pdf[planet];
     fortification_level = system.p_fortified[planet];
 


### PR DESCRIPTION
<!--- YOU CAN DELETE ALL OF THIS AFTER READING. -->

<!--- Make use of markdown lists. They make stuff much easier to read through. -->
<!--- Explain why and what your changes do in simple terms. --->
<!--- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. --->

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->

<!--- "Inspired" by the CDDA PR template -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the missing `edit_pdf` method to `PlanetData` to safely adjust a planet’s PDF value. It applies a delta, clamps the result to zero or higher, updates `system.p_pdf[planet]`, and syncs the instance `pdf` field.

<sup>Written for commit 05867dae509c235e07761140e6cf76478b5a349c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

