### PR TITLE
fix: Linux path separator issues; update README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,7 @@
 </p>
 
 # Chapter Master - Adeptus Dominus
+
 [![Release-Development](https://github.com/Adeptus-Dominus/ChapterMaster/actions/workflows/release_dev.yml/badge.svg)](https://github.com/Adeptus-Dominus/ChapterMaster/actions/workflows/release_dev.yml)
 [![](https://dcbadge.limes.pink/api/server/https://discord.gg/zAGpqHzsXQ?style=flat)](https://discord.gg/zAGpqHzsXQ)
 [![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/Adeptus-Dominus/ChapterMaster?logoColor=%23808080&label=CodeRabbit%20Reviews&labelColor=fd5608&color=545454)](https://coderabbit.ai/)
@@ -29,7 +30,26 @@ This project aims to continue development on the game, fix any bugs, expand and 
 - Main repository: [Adeptus-Dominus/ChapterMaster](https://github.com/Adeptus-Dominus/ChapterMaster)
 
 ## Playing
+
+### Windows
+
 Just download the [latest release](https://github.com/Adeptus-Dominus/ChapterMaster/releases/latest) or a [development pre-release](https://github.com/Adeptus-Dominus/ChapterMaster/releases), unzip it and launch the .exe.
+
+### Linux
+
+Pre-compiled Linux binaries are not currently supported. However, you can run the game on Linux in two ways:
+
+#### Option 1: Run the Windows build via WINE (Recommended for players)
+
+You can download the Windows release `.exe` and run it using **WINE** (or **Proton** / **Steam Play**). This has been reported to work well.
+
+#### Option 2: Run from source using GameMaker for Linux (Recommended for developers)
+
+1. Clone the repository.
+2. Install the **GameMaker** IDE for Linux (available on Steam or the GameMaker website).
+3. Open the `ChapterMaster.yyp` project file in GameMaker.
+4. Select **Linux** as the target platform in the IDE.
+5. Press **Run** (F5) to play/debug the game.
 
 ## Compiling
 
@@ -41,6 +61,7 @@ Everything else **must** be covered by [paid **GameMaker** subscriptions](https:
 ## Contributing
 
 Best bet is to ask about everything in our Discord, because things bellow are probably not very helpful at the moment.
+
 - [Working with GameMaker projects](https://github.com/Adeptus-Dominus/ChapterMaster/wiki/Working-with-GameMaker-projects)
 - [Useful Tools/Resources](https://github.com/Adeptus-Dominus/ChapterMaster/wiki/Useful-resources)
 - [Contributing](https://github.com/Adeptus-Dominus/ChapterMaster/wiki/Contributing) wiki page (not filled properly)

--- a/scripts/scr_culture_visuals/scr_culture_visuals.gml
+++ b/scripts/scr_culture_visuals/scr_culture_visuals.gml
@@ -12,7 +12,7 @@ function load_visual_sets() {
             throw "use_sets.json File Wrong Format";
         }
         for (var i = 0; i < array_length(_raw_data); i++) {
-            var _sepcific_vis_set = $"{_vis_set_directory}\\{_raw_data[i]}";
+            var _sepcific_vis_set = $"{_vis_set_directory}/{_raw_data[i]}";
             // LOGGER.debug(_raw_data[i]);
             if (directory_exists(_sepcific_vis_set)) {
                 // LOGGER.debug(_raw_data[i]);
@@ -52,7 +52,7 @@ function load_symbol_sets(global_area, main_key, sub_sets) {
         }
         var _sprite_double_surface = surface_create(200, 200);
         for (var i = 0; i < array_length(_raw_data); i++) {
-            var _sepcific_vis_set = $"{_cons_directory}\\{_raw_data[i]}";
+            var _sepcific_vis_set = $"{_cons_directory}/{_raw_data[i]}";
             if (directory_exists(_sepcific_vis_set)) {
                 for (var s = 0; s < array_length(sub_sets); s++) {
                     var _sub = sub_sets[s];


### PR DESCRIPTION
### Why & What
* Changed path separators from `\\` to `/` in `scr_culture_visuals.gml` for Linux compatibility.
* Added Linux play instructions (via WINE and GameMaker IDE) to README.md.
### Verification
* Followed instructions laid out in README; can confirm the game now compiles natively on Linux. 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Linux path handling by replacing backslashes with forward slashes in `scripts/scr_culture_visuals/scr_culture_visuals.gml`, so asset directories resolve correctly on Linux. Update `docs/README.md` with Linux instructions for running via WINE/Proton or building/running in GameMaker for Linux.

<sup>Written for commit 1aa11f3475176015c9d01859ac7f6c4b2ce3017f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

