### PR TITLE
chore: Update .gitignore with AI folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,11 @@ sprites.import.json
 # This is a cache file for speeding up subsequent pipeline operations. It should not be tracked in git.
 sprites.info.json
 
+# Gamemaker GMRT cache
 Build/
+
+# AI folders
+.gemini/
+.claude/
+.cline/
+.kilo/


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update .gitignore to ignore local tool folders: `.gemini/`, `.claude/`, `.cline/`, `.kilo/`. Also add a comment clarifying `Build/` as GameMaker GMRT cache.

<sup>Written for commit ee898d11a8364edc1dcb15c2970653fd1dd859a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

