### PR TITLE
docs: Update README; Add CONTRIBUTING

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,16 +1,17 @@
-## Introduction
-TODO.
+# Contributing
+
+WIP.
 
 ## GameMaker vs VSCode+Stitch
 
-There are generally two main ways of working with a **GameMaker** project: through **Visual Studio Code** or through **GameMaker**.
+There are generally two main ways of working with a **GameMaker** project: through **Visual Studio Code** or through **GameMaker IDE**.
 
-- Working through **GameMaker** may prove to be a pure torture, as their IDE is very bad and the app itself generally has very bad performance, as such generally is not recommended if you plan on working with the code. Only use if you have to.
+- Working with the code through **GameMaker IDE** is not recommended for people used to normal IDEs. Use if you have to or like it.
 - The preferred alternative is to use [Visual Studio Code](https://code.visualstudio.com/) with the [Stitch](https://github.com/bscotch/stitch) extension, that is available via the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=bscotch.bscotch-stitch-vscode).
 - You can also use any other IDE to work with the code, but you'll have to use one of the above apps to build, as no other building method is available at the moment.
 - Other IDEs have no extended support for **GML** and as such typically are not recommended, unless you know what you're doing.
 
-Nonetheless, some things will have to be done through **GameMaker**, even if you use other IDEs, including VSCode, such as:
+Nonetheless, some things will have to be done through **GameMaker IDE**, even if you use other IDEs, including VSCode, such as:
 
 - Most of the sprite management.
 - Debugging with breakpoints, function steps and real-time debugging.
@@ -20,7 +21,8 @@ Nonetheless, some things will have to be done through **GameMaker**, even if you
 Here we'll only look at the VSCode. If you're interested in using the GameMaker IDE instead, see [this](https://github.com/Adeptus-Dominus/ChapterMaster/wiki/Compiling) and just skip the 1st step in that instruction.
 
 ## Preparations
-1. Learn what is Git, source control, GitHub and how to use them. There is no way around it.
+
+1. Learn what Git, source control, and GitHub are, how to use them. There is no way around it.
    - If you are new to Git, then it's recommended to read the [Pro Git](https://git-scm.com/book/en/v2) book. You only need to read the first 3 chapters to comfortably work with Git, optionally chapter 6 to get more info on GitHub.
    - If you prefer a more comfortable, graphical user interface based approach to Git, instead of command line, then it's recommended to use one of the options below, both are free and popular:
      - [GitKraken](https://www.gitkraken.com/) + [Tutorials](https://www.gitkraken.com/learn/git/tutorials)
@@ -29,6 +31,7 @@ Here we'll only look at the VSCode. If you're interested in using the GameMaker 
 3. Clone your fork locally through Git CLI or any other GUI wrapper you've chosen.
 
 ## Setting up the Visual Studio Code
+
 1. Get the Visual Studio Code (VSCode) installed, if not already.
    - (Optional) It's recommended to get the Insider version, as it's the most frequently updated one and gets all new features first.
    - (Optional) Get a hang of VSCode by reading some guides on the internet, installing some useful QoL extensions, configuring various settings, etc.
@@ -41,6 +44,7 @@ Here we'll only look at the VSCode. If you're interested in using the GameMaker 
 5. Ensure that the game launches and works, exit.
 
 ## Working with the code
+
 - Read the code, modify it, test, repeat.
 - Check some general [GML hints](https://github.com/Adeptus-Dominus/ChapterMaster/wiki/General-GML-hints-from-@sinthorion).
 - Get accustomed to some [basic styling guidelines](https://github.com/Adeptus-Dominus/ChapterMaster/blob/main/docs/CODE_STYLE.md).

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Here we'll only look at the VSCode. If you're interested in using the GameMaker 
      - [GitKraken](https://www.gitkraken.com/) + [Tutorials](https://www.gitkraken.com/learn/git/tutorials)
      - [SourceTree](https://www.sourcetreeapp.com/) + [Tutorials](https://confluence.atlassian.com/get-started-with-sourcetree)
 2. Fork the repository.
-3. Clone your fork locally through Git CL or any other GUI wrapper you've chosen.
+3. Clone your fork locally through Git CLI or any other GUI wrapper you've chosen.
 
 ## Setting up the Visual Studio Code
 1. Get the Visual Studio Code (VSCode) installed, if not already.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+## Introduction
+TODO.
+
+## GameMaker vs VSCode+Stitch
+
+There are generally two main ways of working with a **GameMaker** project: through **Visual Studio Code** or through **GameMaker**.
+
+- Working through **GameMaker** may prove to be a pure torture, as their IDE is very bad and the app itself generally has very bad performance, as such generally is not recommended if you plan on working with the code. Only use if you have to.
+- The preferred alternative is to use [Visual Studio Code](https://code.visualstudio.com/) with the [Stitch](https://github.com/bscotch/stitch) extension, that is available via the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=bscotch.bscotch-stitch-vscode).
+- You can also use any other IDE to work with the code, but you'll have to use one of the above apps to build, as no other building method is available at the moment.
+- Other IDEs have no extended support for **GML** and as such typically are not recommended, unless you know what you're doing.
+
+Nonetheless, some things will have to be done through **GameMaker**, even if you use other IDEs, including VSCode, such as:
+
+- Most of the sprite management.
+- Debugging with breakpoints, function steps and real-time debugging.
+- Profiling.
+- Room management.
+
+Here we'll only look at the VSCode. If you're interested in using the GameMaker IDE instead, see [this](https://github.com/Adeptus-Dominus/ChapterMaster/wiki/Compiling) and just skip the 1st step in that instruction.
+
+## Preparations
+1. Learn what is Git, source control, GitHub and how to use them. There is no way around it.
+   - If you are new to Git, then it's recommended to read the [Pro Git](https://git-scm.com/book/en/v2) book. You only need to read the first 3 chapters to comfortably work with Git, optionally chapter 6 to get more info on GitHub.
+   - If you prefer a more comfortable, graphical user interface based approach to Git, instead of command line, then it's recommended to use one of the options below, both are free and popular:
+     - [GitKraken](https://www.gitkraken.com/) + [Tutorials](https://www.gitkraken.com/learn/git/tutorials)
+     - [SourceTree](https://www.sourcetreeapp.com/) + [Tutorials](https://confluence.atlassian.com/get-started-with-sourcetree)
+2. Fork the repository.
+3. Clone your fork locally through Git CL or any other GUI wrapper you've chosen.
+
+## Setting up the Visual Studio Code
+1. Get the Visual Studio Code (VSCode) installed, if not already.
+   - (Optional) It's recommended to get the Insider version, as it's the most frequently updated one and gets all new features first.
+   - (Optional) Get a hang of VSCode by reading some guides on the internet, installing some useful QoL extensions, configuring various settings, etc.
+2. Add the project's folder that you've cloned to the workspace, wait for it to load.
+3. Get the Stitch extension installed.
+   - (Optional) Watch [this guide video](https://youtu.be/N0wnHauUQjA?si=GPQ22a_LyZq3Y9LP) that covers basic features of **Stitch**, made by its creator.
+   - (Optional) Edit various **Stitch** specific settings, to improve your QoL.
+   - (Optional) It's recommended to disable "Run in Terminal" **Stitch** option. This allows you to goto error lines that come up in the output window and custom color output lines. The explanation is in the "Stitch Runner Panel" section on [this page](https://marketplace.visualstudio.com/items?itemName=bscotch.bscotch-stitch-vscode).
+4. Run the game by pressing F5 or finding the run button on the **Stitch** panel, wait for it to download the **GameMaker** version and build the game.
+5. Ensure that the game launches and works, exit.
+
+## Working with the code
+- Read the code, modify it, test, repeat.
+- Check some general [GML hints](https://github.com/Adeptus-Dominus/ChapterMaster/wiki/General-GML-hints-from-@sinthorion).
+- Get accustomed to some [basic styling guidelines](https://github.com/Adeptus-Dominus/ChapterMaster/blob/main/docs/CODE_STYLE.md).
+- Check the list of some [useful resources](https://github.com/Adeptus-Dominus/ChapterMaster/wiki/Useful-resources).

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,7 +47,7 @@ Same as with Linux.
 2. Clone or download the repository (find the green **<>Code** button and select **Download ZIP**).
 3. Find **ChapterMaster.yyp** in the downloaded folder and open it with **GameMaker**.
 4. Select the target platform in the IDE: **Windows, macOS, Ubuntu**.
-5. Select the output: **GMS2 VM** (no requirments; fast to compile; worse performance) or **GMS2 YYC** (requires a dedicated compiler; slow to compile; better performance).
+5. Select the output: **GMS2 VM** (no requirements; fast to compile; worse performance) or **GMS2 YYC** (requires a dedicated compiler; slow to compile; better performance).
 5. Press **Run** (F5) to play the game or **Debug** (F6) to use debugger features.
 
 ## Contributing

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,51 +11,44 @@
 **Chapter Master** (aka CM) is a strategy/simulation game, written in **Game Maker Language**, originally designed and developed by Duke.\
 This project aims to continue development on the game, fix any bugs, expand and add features.
 
-**Adeptus Dominus** is just how the team of primordial collaborators decided to call themselves.
+**Adeptus Dominus** is just how the team of primordial collaborators decided to call themselves and the new version of the game.
 
-- Our discord server: [Chapter Master Discord](https://discord.gg/zAGpqHzsXQ)
+## Links
+
+Our discord server: [Chapter Master Discord](https://discord.gg/zAGpqHzsXQ)
   - Where most of the development talk, feature suggestion and bug-reporting takes place.
   - GitHub issues are not used at the moment, as such we use #bug-report-forum in this server to handle bug reports.
   - If you can code, draw, design, help with the GitHub stuff or just want to help in any way possible - you'll be welcomed with open arms.
   - If you just love WH40K and want to chat - you'll have a great time in the server as well.
 
-- 1d6Chan Wiki: [Chapter Master: Adeptus Dominus](https://1d6chan.miraheze.org/wiki/Chapter_Master:_Adeptus_Dominus)
+1d6Chan Wiki: [Chapter Master: Adeptus Dominus](https://1d6chan.miraheze.org/wiki/Chapter_Master:_Adeptus_Dominus)
   - With some helpful pages that explain some of the new systems added in the Adeptus Dominus version.
   - Help with expanding it will be welcomed.
 
-- Don't forget about the [GitHub Wiki (WIP)](https://github.com/Adeptus-Dominus/ChapterMaster/wiki)
-  - Help with expanding this one will be welcomed as well.
-
-- Main repository: [Adeptus-Dominus/ChapterMaster](https://github.com/Adeptus-Dominus/ChapterMaster)
+Main repository: [Adeptus-Dominus/ChapterMaster](https://github.com/Adeptus-Dominus/ChapterMaster)
 
 ## Playing
 
 ### Windows
 
-Just download the [latest release](https://github.com/Adeptus-Dominus/ChapterMaster/releases/latest) or a [development pre-release](https://github.com/Adeptus-Dominus/ChapterMaster/releases), unzip it and launch the .exe.
+Download the [latest release](https://github.com/Adeptus-Dominus/ChapterMaster/releases/latest) or a [development pre-release](https://github.com/Adeptus-Dominus/ChapterMaster/releases), unzip it and launch the .exe.
 
 ### Linux
 
-Pre-compiled Linux binaries are not currently supported. However, you can run the game on Linux in two ways:
+Pre-compiled Linux binaries are not currently supported. However, you can run the game on Linux by downloading the Windows release `.exe` and running it using **WINE** (or **Proton** / **Steam Play**). This has been reported to work well. Alternatively, you can compile from source.
 
-#### Option 1: Run the Windows build via WINE (Recommended for players)
+### macOS
 
-You can download the Windows release `.exe` and run it using **WINE** (or **Proton** / **Steam Play**). This has been reported to work well.
+Same as with Linux.
 
-#### Option 2: Run from source using GameMaker for Linux (Recommended for developers)
+## Compiling from source
 
-1. Clone the repository.
-2. Install the **GameMaker** IDE for Linux (available on Steam or the GameMaker website).
-3. Open the `ChapterMaster.yyp` project file in GameMaker.
-4. Select **Linux** as the target platform in the IDE.
-5. Press **Run** (F5) to play/debug the game.
-
-## Compiling
-
-See [Compiling](https://github.com/Adeptus-Dominus/ChapterMaster/wiki/Compiling) wiki page or the [GameMaker tutorial](https://help.gamemaker.io/hc/en-us/articles/235186048-Setting-Up-For-Windows).
-
-Creating packages (i.e., creating an .exe with the game) and exporting them is allowed by YoYo Games for non-commercial use.\
-Everything else **must** be covered by [paid **GameMaker** subscriptions](https://gamemaker.io/en/get).
+1. Install the **GameMaker** IDE matching your system (available on the [GameMaker website](https://releases.gamemaker.io/release-notes/2026/0) or [Steam](https://store.steampowered.com/app/1670460/GameMaker/)).
+2. Clone or download the repository (find the green **<>Code** button and select **Download ZIP**).
+3. Find **ChapterMaster.yyp** in the downloaded folder and open it with **GameMaker**.
+4. Select the target platform in the IDE: **Windows, macOS, Ubuntu**.
+5. Select the output: **GMS2 VM** (no requirments; fast to compile; worse performance) or **GMS2 YYC** (requires a dedicated compiler; slow to compile; better performance).
+5. Press **Run** (F5) to play the game or **Debug** (F6) to use debugger features.
 
 ## Contributing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,7 +48,7 @@ Same as with Linux.
 3. Find **ChapterMaster.yyp** in the downloaded folder and open it with **GameMaker**.
 4. Select the target platform in the IDE: **Windows, macOS, Ubuntu**.
 5. Select the output: **GMS2 VM** (no requirements; fast to compile; worse performance) or **GMS2 YYC** (requires a dedicated compiler; slow to compile; better performance).
-5. Press **Run** (F5) to play the game or **Debug** (F6) to use debugger features.
+6. Press **Run** (F5) to play the game or **Debug** (F6) to use debugger features.
 
 ## Contributing
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a CONTRIBUTING guide migrated from the wiki with Git onboarding, VSCode + `Stitch` setup (including a runner settings tip), guidance on when to use GameMaker vs VSCode, and links to style/resources. Updates the README with a Links section, unified Linux/macOS play steps via WINE/Proton, and a step-by-step compile-from-source guide (install GameMaker, choose platform, VM vs YYC, Run/Debug).

<sup>Written for commit 3008c4cdbdefff23cadec2f8e91dc5bc224ef0ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

