### PR TITLE
fix: Click locking in the save/load menu

### DIFF
--- a/objects/obj_controller/Step_0.gml
+++ b/objects/obj_controller/Step_0.gml
@@ -368,6 +368,10 @@ try {
     var stop = 0;
     // Which menu is highlighted
 
+    if ((cooldown >= 0) && (cooldown < 9000)) {
+        cooldown -= 1;
+    }
+
     if (instance_exists(obj_ingame_menu) || instance_exists(obj_saveload)) {
         exit;
     }
@@ -380,9 +384,6 @@ try {
         otha = 0;
     }
     // Sound controls
-    if ((cooldown >= 0) && (cooldown < 9000)) {
-        cooldown -= 1;
-    }
     if (click > 0) {
         click = -1;
         audio_play_sound(snd_click, -80, false);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes click locking in the save/load menu by moving the cooldown decrement earlier in `obj_controller`’s Step event. The cooldown now ticks down even when `obj_ingame_menu` or `obj_saveload` exists, so clicks unlock as expected.

- **Bug Fixes**
  - Decrement `cooldown` at the start of the Step; removed the redundant decrement in the sound controls block.
  - Prevents the stuck click state that blocked save/load interactions.

<sup>Written for commit 5a46ba4ed900d3e7ceaf201610ba9eff010f59db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

