### PR TITLE
fix: Crashes from constructor saving in obj_star

### DIFF
--- a/objects/obj_star/Create_0.gml
+++ b/objects/obj_star/Create_0.gml
@@ -180,12 +180,6 @@ serialize = function() {
         present_fleet: object_star.present_fleet,
         planet_data: planet_data,
     };
-    if (struct_exists(object_star, "system_garrison")) {
-        save_data.system_garrison = object_star.system_garrison;
-    }
-    if (struct_exists(object_star, "system_sabatours")) {
-        save_data.system_sabatours = object_star.system_sabatours;
-    }
 
     if (struct_exists(object_star, "p_governor")) {
         save_data.p_governor = object_star.p_governor;
@@ -272,10 +266,6 @@ function deserialize(save_data) {
     if (struct_exists(save_data, "p_governor")) {
         variable_struct_set(self, "p_governor", save_data.p_governor);
     }
-    system_datas = array_create(8, false);
-    system_garrison = array_create(8, false);
-    system_sabatours = array_create(8, false);
-
 }
 
 #endregion

--- a/objects/obj_star/Create_0.gml
+++ b/objects/obj_star/Create_0.gml
@@ -72,10 +72,9 @@ p_problem = array_create_advanced(_planet_array_size, array_create(8, ""));
 p_problem_other_data = array_create_advanced(_planet_array_size, array_create_advanced(8, {}));
 p_timer = array_create_advanced(_planet_array_size, array_create(8, -1));
 
-
-system_datas = array_create(8, 0);
+system_datas = array_create(8, false);
 system_garrison = array_create(8, false);
-system_sabatours = array_create(8, 0);
+system_sabatours = array_create(8, false);
 
 get_garrison = function(planet){
     var _gar = system_garrison[planet];
@@ -273,7 +272,9 @@ function deserialize(save_data) {
     if (struct_exists(save_data, "p_governor")) {
         variable_struct_set(self, "p_governor", save_data.p_governor);
     }
-
+    system_datas = array_create(8, false);
+    system_garrison = array_create(8, false);
+    system_sabatours = array_create(8, false);
 
 }
 

--- a/objects/obj_star/Create_0.gml
+++ b/objects/obj_star/Create_0.gml
@@ -196,7 +196,10 @@ serialize = function() {
         "temp",
         "serialize",
         "deserialize",
-        "arraysum"
+        "arraysum",
+        "system_garrison",
+        "system_sabatours",
+        "system_datas"
     ];
     var excluded_from_save_start = ["p_"];
 
@@ -265,13 +268,6 @@ function deserialize(save_data) {
                 // variable_struct_set(self, var_name, planet[$var_name]);
             }
         }
-    }
-
-    if (struct_exists(save_data, "system_sabatours")) {
-        variable_struct_set(self, "system_sabatours", save_data.system_sabatours);
-    }
-    if (struct_exists(save_data, "system_garrison")) {
-        variable_struct_set(self, "system_garrison", save_data.system_garrison);
     }
 
     if (struct_exists(save_data, "p_governor")) {


### PR DESCRIPTION
<!--- YOU CAN DELETE ALL OF THIS AFTER READING. -->

<!--- Make use of markdown lists. They make stuff much easier to read through. -->
<!--- Explain why and what your changes do in simple terms. --->
<!--- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. --->

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->

<!--- "Inspired" by the CDDA PR template -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes crashes when saving `obj_star` by excluding transient `system_*` arrays from save data and keeping the constructor-initialized values after load.

- **Bug Fixes**
  - Add `system_garrison`, `system_sabatours`, and `system_datas` to `serialize()` exclusions; remove their save/restore logic.
  - Initialize these arrays in Create with `array_create(8, false)` for a clean, consistent state.

<sup>Written for commit acb1a22571586d7118f864a488cced29aa3c226d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

