### PR TITLE
Merge branch fix/stuff into main

### DIFF
--- a/objects/obj_controller/Step_0.gml
+++ b/objects/obj_controller/Step_0.gml
@@ -368,6 +368,10 @@ try {
     var stop = 0;
     // Which menu is highlighted
 
+    if ((cooldown >= 0) && (cooldown < 9000)) {
+        cooldown -= 1;
+    }
+
     if (instance_exists(obj_ingame_menu) || instance_exists(obj_saveload)) {
         exit;
     }
@@ -380,9 +384,6 @@ try {
         otha = 0;
     }
     // Sound controls
-    if ((cooldown >= 0) && (cooldown < 9000)) {
-        cooldown -= 1;
-    }
     if (click > 0) {
         click = -1;
         audio_play_sound(snd_click, -80, false);

--- a/objects/obj_ini/Create_0.gml
+++ b/objects/obj_ini/Create_0.gml
@@ -106,13 +106,11 @@ last_ship = array_create_2d(_max_companies, _max_vehicles, {uid: "", name: ""});
 veh_race = array_create_2d(_max_companies, _max_vehicles, 0);
 veh_hp = array_create_2d(_max_companies, _max_vehicles, 100);
 veh_chaos = array_create_2d(_max_companies, _max_vehicles, 0);
-veh_pilots = array_create_2d(_max_companies, _max_vehicles, 0);
 veh_lid = array_create_2d(_max_companies, _max_vehicles, -1);
 veh_wid = array_create_2d(_max_companies, _max_vehicles, 2);
 veh_uid = array_create_2d(_max_companies, _max_vehicles, 0);
 
 veh_loc = array_create_2d(_max_companies, _max_vehicles, "");
-veh_name = array_create_2d(_max_companies, _max_vehicles, "");
 veh_role = array_create_2d(_max_companies, _max_vehicles, "");
 veh_wep1 = array_create_2d(_max_companies, _max_vehicles, "");
 veh_wep2 = array_create_2d(_max_companies, _max_vehicles, "");

--- a/scripts/Armamentarium/Armamentarium.gml
+++ b/scripts/Armamentarium/Armamentarium.gml
@@ -13,6 +13,7 @@ function ShopItem(_name) constructor {
     name = _name;
     display_name = _name;
     area = "";
+    // TODO: Refactor into an enum; Add a separate VEHICLE type; Will break saved queues
     forge_type = "normal";
     item_tooltip = "";
 
@@ -1113,7 +1114,11 @@ function Armamentarium(_controller) constructor {
         var _btn_y = 225 + string_height_ext(advisor_report_text, -1, 536);
         if (enter_forge_button.draw_shutter(526, _btn_y, "Enter Forge", 0.5)) {
             is_in_forge = true;
-            refresh_catalog();
+            if (shop_type == "ships") {
+                _switch_tab("weapons")
+            } else {
+                refresh_catalog();
+            }
         }
     };
 
@@ -1125,9 +1130,9 @@ function Armamentarium(_controller) constructor {
 
             if (shop_type == "technologies") {
                 _switch_tab("weapons");
+            } else {
+                refresh_catalog();
             }
-
-            refresh_catalog();
         }
 
         controller.specialist_point_handler.draw_forge_queue(359, 132);

--- a/scripts/scr_add_vehicle/scr_add_vehicle.gml
+++ b/scripts/scr_add_vehicle/scr_add_vehicle.gml
@@ -127,7 +127,6 @@ function scr_add_vehicle(vehicle_type, target_company, otherdata = {}, weapon1 =
 
             obj_ini.veh_hp[target_company][good] = 100;
             obj_ini.veh_chaos[target_company][good] = 0;
-            obj_ini.veh_pilots[target_company][good] = 0;
         }
 
         return [target_company, good];
@@ -140,7 +139,6 @@ function destroy_vehicle(co, num) {
     try {
         obj_ini.veh_race[co][num] = 0;
         obj_ini.veh_loc[co][num] = "";
-        obj_ini.veh_name[co][num] = "";
         obj_ini.veh_role[co][num] = "";
         obj_ini.veh_wep1[co][num] = "";
         obj_ini.veh_wep2[co][num] = "";
@@ -149,7 +147,6 @@ function destroy_vehicle(co, num) {
         obj_ini.veh_acc[co][num] = "";
         obj_ini.veh_hp[co][num] = 100;
         obj_ini.veh_chaos[co][num] = 0;
-        obj_ini.veh_pilots[co][num] = 0;
         obj_ini.veh_lid[co][num] = -1;
         obj_ini.veh_wid[co][num] = 0;
     } catch (_exception) {

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -3038,7 +3038,6 @@ function add_veh_to_company(name, company, slot, wep1, wep2, wep3, upgrade, acce
     obj_ini.veh_acc[company][slot] = accessory;
     obj_ini.veh_hp[company][slot] = 100;
     obj_ini.veh_chaos[company][slot] = 0;
-    obj_ini.veh_pilots[company][slot] = 0;
     obj_ini.veh_lid[company][slot] = -1;
     obj_ini.veh_wid[company][slot] = 2;
 }

--- a/scripts/scr_mission_reward/scr_mission_reward.gml
+++ b/scripts/scr_mission_reward/scr_mission_reward.gml
@@ -143,7 +143,6 @@ function scr_mission_reward(mission, star, planet) {
                             onceh = 1;
                             obj_ini.veh_race[com][i] = 0;
                             obj_ini.veh_loc[com][i] = "";
-                            obj_ini.veh_name[com][i] = "";
                             obj_ini.veh_role[com][i] = "";
                             obj_ini.veh_lid[com][i] = -1;
                             obj_ini.veh_wid[com][i] = 0;

--- a/scripts/scr_reequip_units/scr_reequip_units.gml
+++ b/scripts/scr_reequip_units/scr_reequip_units.gml
@@ -608,13 +608,13 @@ function draw_popup_equip() {
             }
 
             if (is_struct(armour_data) && is_struct(gear_data)) {
-                if (armour_data.has_tag("terminator") && !gear_data.has_tag("terminator")) {
+                if (armour_data.has_tag("terminator") && !gear_data.has_tag("terminator") && !gear_data.has_tag("terminator_only")) {
                     n_good4 = 0;
                     warning = "Cannot use this with Terminator Armour.";
                 } else if (!armour_data.has_tag("terminator") && gear_data.has_tag("terminator_only")) {
                     n_good4 = 0;
                     warning = "Cannot use this without Terminator Armour.";
-                } else if (armour_data.has_tag("dreadnought") && !gear_data.has_tag("dreadnought")) {
+                } else if (armour_data.has_tag("dreadnought") && !gear_data.has_tag("dreadnought") && !gear_data.has_tag("dreadnought_only")) {
                     n_good4 = 0;
                     warning = "Cannot use this with Dreadnought Armour.";
                 } else if (!armour_data.has_tag("dreadnought") && gear_data.has_tag("dreadnought_only")) {
@@ -646,16 +646,24 @@ function draw_popup_equip() {
             }
 
             if (is_struct(armour_data) && is_struct(mobility_data)) {
-                if (armour_data.has_tag("terminator") && !mobility_data.has_tag("terminator")) {
+                if (armour_data.has_tag("terminator") && !mobility_data.has_tag("terminator") && !mobility_data.has_tag("terminator_only")) {
                     n_good5 = 0;
                     warning = "Cannot use this with Terminator Armour.";
                 } else if (!armour_data.has_tag("terminator") && mobility_data.has_tag("terminator_only")) {
                     n_good5 = 0;
                     warning = "Cannot use this without Terminator Armour.";
-                } else if (armour_data.has_tag("dreadnought") && !mobility_data.has_tag("dreadnought")) {
+                } else if (armour_data.has_tag("dreadnought") && !mobility_data.has_tag("dreadnought") && !mobility_data.has_tag("dreadnought_only")) {
                     n_good5 = 0;
                     warning = "Cannot use this with Dreadnought Armour.";
                 } else if (!armour_data.has_tag("dreadnought") && mobility_data.has_tag("dreadnought_only")) {
+                    n_good5 = 0;
+                    warning = "Cannot use this without Dreadnought Armour.";
+                }
+            } else if (!is_struct(armour_data) && is_struct(mobility_data)) {
+                if (mobility_data.has_tag("terminator") || mobility_data.has_tag("terminator_only")) {
+                    n_good5 = 0;
+                    warning = "Cannot use this without Terminator Armour.";
+                } else if (mobility_data.has_tag("dreadnought") || mobility_data.has_tag("dreadnought_only")) {
                     n_good5 = 0;
                     warning = "Cannot use this without Dreadnought Armour.";
                 }

--- a/scripts/scr_start_load/scr_start_load.gml
+++ b/scripts/scr_start_load/scr_start_load.gml
@@ -105,7 +105,7 @@ function scr_start_load(fleet, load_from_star, load_options) {
         }
 
         //fetch company vehicles
-        for (var _unit = 1; _unit < array_length(obj_ini.veh_role[_comp]); _unit++) {
+        for (var _unit = 0; _unit < array_length(obj_ini.veh_role[_comp]); _unit++) {
             if (array_contains(_vehicles, obj_ini.veh_role[_comp][_unit])) {
                 var _vehic_size = scr_unit_size(false, obj_ini.veh_role[_comp][_unit], false, false);
                 total_vehic_size += _vehic_size;

--- a/scripts/scr_transfer_marines/scr_transfer_marines.gml
+++ b/scripts/scr_transfer_marines/scr_transfer_marines.gml
@@ -99,7 +99,6 @@ function transfer_marines() {
                     obj_ini.veh_acc[target_comp][vehi] = obj_ini.veh_acc[veh_data[0]][veh_data[1]];
                     obj_ini.veh_hp[target_comp][vehi] = obj_ini.veh_hp[veh_data[0]][veh_data[1]];
                     obj_ini.veh_chaos[target_comp][vehi] = obj_ini.veh_chaos[veh_data[0]][veh_data[1]];
-                    obj_ini.veh_pilots[target_comp][vehi] = 0;
                     obj_ini.veh_lid[target_comp][vehi] = obj_ini.veh_lid[veh_data[0]][veh_data[1]];
                     obj_ini.veh_wid[target_comp][vehi] = obj_ini.veh_wid[veh_data[0]][veh_data[1]];
 

--- a/scripts/scr_unit_equip_functions/scr_unit_equip_functions.gml
+++ b/scripts/scr_unit_equip_functions/scr_unit_equip_functions.gml
@@ -367,7 +367,7 @@ function scr_update_unit_mobility_item(new_mobility_item, from_armoury = true, t
 
         var _armour_data = get_armour_data();
         if (is_struct(_armour_data)) {
-            if (_armour_data.has_tag("terminator") && !_mobility_data.has_tag("terminator")) {
+            if (_armour_data.has_tag("terminator") && !_mobility_data.has_tag("terminator") && !_mobility_data.has_tag("terminator_only")) {
                 LOGGER.error($"Failed to equip {new_mobility_item} for {name()} - can't use with terminator armour! (Current: {armour()})");
                 return false;
             } else if (!_armour_data.has_tag("terminator") && _mobility_data.has_tag("terminator_only")) {
@@ -384,7 +384,7 @@ function scr_update_unit_mobility_item(new_mobility_item, from_armoury = true, t
                 LOGGER.error($"Failed to equip {new_mobility_item} for {name()} - requires armour!");
                 return false;
             }
-            if (_mobility_data.has_tag("terminator")) {
+            if (_mobility_data.has_tag("terminator") || _mobility_data.has_tag("terminator_only")) {
                 LOGGER.error($"Failed to equip {new_mobility_item} for {name()} - requires terminator armour!");
                 return false;
             }

--- a/scripts/scr_vehicle_order/scr_vehicle_order.gml
+++ b/scripts/scr_vehicle_order/scr_vehicle_order.gml
@@ -4,7 +4,6 @@
 function reset_vehicle_variable_arrays(company_number, i) {
     veh_race[company_number][i] = 0;
     veh_loc[company_number][i] = "";
-    veh_name[company_number][i] = "";
     veh_role[company_number][i] = "";
     veh_lid[company_number][i] = -1;
     veh_wid[company_number][i] = 0;
@@ -54,7 +53,6 @@ function scr_vehicle_order(company_number) {
         if (_is_vehicle_role) {
             temp_race[company_number][vehicle_count] = veh_race[company_number][i];
             temp_loc[company_number][vehicle_count] = veh_loc[company_number][i];
-            temp_name[company_number][vehicle_count] = veh_name[company_number][i];
             temp_role[company_number][vehicle_count] = veh_role[company_number][i];
             temp_lid[company_number][vehicle_count] = veh_lid[company_number][i];
             temp_wid[company_number][vehicle_count] = veh_wid[company_number][i];
@@ -75,7 +73,6 @@ function scr_vehicle_order(company_number) {
     for (var i = 0; i < vehicle_count; i++) {
         veh_race[company_number][i] = temp_race[company_number][i];
         veh_loc[company_number][i] = temp_loc[company_number][i];
-        veh_name[company_number][i] = temp_name[company_number][i];
         veh_role[company_number][i] = temp_role[company_number][i];
         veh_lid[company_number][i] = temp_lid[company_number][i];
         veh_wid[company_number][i] = temp_wid[company_number][i];


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes several UI/gameplay bugs and cleans up vehicle data. Prevents save/load input lock, avoids accidental ship forging, counts vehicle 0 during ship load, and enforces Terminator/Dreadnought equip rules.

- **Bug Fixes**
  - Cooldown now ticks while save/load is open to avoid input lock. (obj_controller/Step)
  - Entering the forge from ships opens the weapons tab; refresh catalog only when needed. (Armamentarium)
  - Include vehicle index 0 during ship load. (scr_start_load)
  - Honor `terminator_only`/`dreadnought_only` in gear and mobility, including no-armour cases. (reequip + equip)

- **Refactors**
  - Removed unused vehicle fields `veh_pilots` and `veh_name` across init, add/destroy, ordering, transfer, and mission reward paths.

<sup>Written for commit 6a858c71fb00b19960f699e2cd4cc7d2d3f420f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

