### PR TITLE
fix: Guardsman AC adjustments

### DIFF
--- a/objects/obj_enunit/Alarm_1.gml
+++ b/objects/obj_enunit/Alarm_1.gml
@@ -287,8 +287,8 @@ if (obj_ncombat.enemy == 1) {
 if (obj_ncombat.enemy == eFACTION.IMPERIUM) {
     for (var j = 1; j <= 20; j++) {
         if (dudes[j] == "Imperial Guardsman") {
-            dudes_ac[j] = 40;
-            dudes_hp[j] = 5;
+            dudes_ac[j] = 5;
+            dudes_hp[j] = 40;
             men += dudes_num[j];
         }
 


### PR DESCRIPTION

-Changes IG statline from 40 AC 5  Hp -> 5 AC 40 HP

-No Testing was done and I understand the risks.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Imperial Guardsman durability by correcting transposed stats. AC is now 5 and HP is 40 for Imperium enemies.

<sup>Written for commit 9b5e0c6fd2e3ab0de57aea8e931b1c18faf9cc96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

