### PR TITLE
fix: formatting in Black Crusade popup

### DIFF
--- a/scripts/scr_khornate_fleet_functions/scr_khornate_fleet_functions.gml
+++ b/scripts/scr_khornate_fleet_functions/scr_khornate_fleet_functions.gml
@@ -297,7 +297,7 @@ function spawn_chaos_warlord() {
         var tix = $"Chaos Lord {faction_leader[eFACTION.CHAOS]} continues his Black Crusade into Sector {obj_ini.sector_name}.";
         scr_alert("purple", "lol", tix, nfleet.x, nfleet.y);
         scr_event_log("purple", tix, fleet_target.name);
-        scr_popup("Black Crusade", "A Black Crusade led by the Chaos Lord {faction_leader[eFACTION.CHAOS]} has arrived in {obj_ini.sector_name}.  His forces have already carved a bloody path through many sectors and yours is next.  {faction_leader[eFACTION.CHAOS]} also seems to be set on killing you.  The Black Crusade's current target is system {fleet_target.name}.", "", "");
+        scr_popup("Black Crusade", $"A Black Crusade led by the Chaos Lord {faction_leader[eFACTION.CHAOS]} has arrived in {obj_ini.sector_name}.  His forces have already carved a bloody path through many sectors and yours is next.  {faction_leader[eFACTION.CHAOS]} also seems to be set on killing you.  The Black Crusade's current target is system {fleet_target.name}.", "", "");
         // title / text / image / speshul
     }
 }


### PR DESCRIPTION
* Formatting in Black Crusade spawn popup was broken

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the Black Crusade spawn popup message so dynamic values (leader, sector, target system) render correctly. Switched the popup text to a `$`-interpolated string in `scr_popup`.

<sup>Written for commit 8cceda388aa7b48b2519b4cd970c2a758007e314. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

