### PR TITLE
fix: various minor bugs

### DIFF
--- a/datafiles/main/chapters/1.JSON
+++ b/datafiles/main/chapters/1.JSON
@@ -1821,7 +1821,7 @@
         },
         "option": {
           "wep2": [
-            [["Flamer", "Grav-gun", "Meltagun", "Plasma Gun", "Plasma Pistol"], 2]
+            [["Flamer", "Grav-Gun", "Meltagun", "Plasma Gun", "Plasma Pistol"], 2]
           ]
         }
       }

--- a/objects/obj_controller/Create_0.gml
+++ b/objects/obj_controller/Create_0.gml
@@ -1171,7 +1171,11 @@ serialize = function() {
         "tooltips",
         "last_unit",
         "unit_manage_constants",
-        "unit_manage_image"
+        "unit_manage_image",
+        "chapter_master",
+        "armamentarium",
+        "helpful_places_button",
+        "lair_styles"
     ];
     var excluded_from_save_start = ["restart_"];
 

--- a/objects/obj_formation_bar/Create_0.gml
+++ b/objects/obj_formation_bar/Create_0.gml
@@ -29,6 +29,7 @@ bar_hit = function(){
 	    draw_set_color(c_gray);
 	    draw_set_font(fnt_40k_30b);
 	    draw_set_halign(fa_center);
+		draw_set_valign(fa_top); //test next time please
 	    draw_text_transformed(1398, 213, string(tooltip), 0.75, 0.75, 0);
 
 	    draw_set_halign(fa_left);

--- a/objects/obj_ini/Create_0.gml
+++ b/objects/obj_ini/Create_0.gml
@@ -229,6 +229,8 @@ serialize = function() {
         squad_structs: squads,
         equipment: equipment,
         gene_slaves: gene_slaves, // squads // marines,
+        chapter_data: chapter_data,
+        chapter_squad_arrangement: chapter_squad_arrangement,
     };
 
     if (struct_exists(object_ini, "last_ship")) {
@@ -246,7 +248,9 @@ serialize = function() {
         "squad_structs",
         "squad_types",
         "marines",
-        "last_ship"
+        "last_ship",
+        "chapter_data",
+        "chapter_squad_arrangement"
     ];
 
     copy_serializable_fields(object_ini, save_data, excluded_from_save);

--- a/scripts/scr_buttons/scr_buttons.gml
+++ b/scripts/scr_buttons/scr_buttons.gml
@@ -1436,10 +1436,13 @@ function InteractiveButton(data = {}) constructor {
         
     static update = function(data = {}) {
         move_data_to_current_scope(data);
+        if (struct_exists(data, "str1") && !struct_exists(data, "width")) {
+            width = 0;
+        }
         if (width == 0) {
             width = string_width(str1) + 4;
         }
-        if (height == 0) {
+        if (!struct_exists(data, "height")) {
             height = string_height(str1) + 4;
         }
         x2 = x1 + width;

--- a/scripts/scr_drop_select_function/scr_drop_select_function.gml
+++ b/scripts/scr_drop_select_function/scr_drop_select_function.gml
@@ -49,10 +49,10 @@ function drop_select_unit_selection() {
         // draw_rectangle(xx+1084,yy+215,xx+1142,yy+273,0);
 
         // Formation
-        formation.x1 = x1 + 420;
+        var _formation_str = $"Formation: {obj_controller.bat_formation[formation_possible[formation_current]]}";
+        formation.x1 = x2 - 40 - (string_width(_formation_str) + 4);
         formation.y1 = y1 + 80;
-        formation.str1 = $"Formation: {obj_controller.bat_formation[formation_possible[formation_current]]}";
-        formation.update();
+        formation.update({str1: _formation_str});
         formation.draw();
         if (formation.clicked()) {
             formation_current++;
@@ -155,15 +155,15 @@ function drop_select_unit_selection() {
         } else if (race_quantity >= 6) {
             target_threat = threat_levels[6];
         }
-        target.x1 = formation.x1;
-        target.y1 = formation.y2 + 10;
-        target.str1 = "Target: ";
+        var _target_str = "Target: ";
         if (race_quantity != 0) {
-            target.str1 += $"{target_race} ({target_threat} Threat)";
+            _target_str += $"{target_race} ({target_threat} Threat)";
         } else {
-            target.str1 += "None";
+            _target_str += "None";
         }
-        target.update();
+        target.x1 = x2 - 40 - (string_width(_target_str) + 4);
+        target.y1 = formation.y2 + 10;
+        target.update({str1: _target_str});
         target.draw();
         draw_sprite(spr_faction_icons, attacking, x2 - 100, y1 + 40);
         var q = 0;

--- a/scripts/scr_purge_world/scr_purge_world.gml
+++ b/scripts/scr_purge_world/scr_purge_world.gml
@@ -150,7 +150,7 @@ function scr_purge_world(action_type, action_score) {
 	_purge.heres_before = max(total_corruption(), population_influences[eFACTION.TAU],population_influences[eFACTION.TYRANIDS]);// Starting heresy
 
 
-	if (!action_type == eDROP_TYPE.PURGEASSASSINATE){
+	if (action_type != eDROP_TYPE.PURGEASSASSINATE){
 		_purge.calculate_deaths();
 	}
 	var _heres_target = "corruption";


### PR DESCRIPTION
## Fixed
### Formation Settings
- formation description misplaced
- formation label misplaced
- formation image displaced
### Planet actions
- attack menu action buttons broken
- raid menu action buttons broken
- purge results description broken
### General Fixes
- obj_ini unserialised variables
- obj_controller unserialised variables
- Grav-gun typo "Grav-Gun" is the required input
## Testing
- Formation settings checked on several chapters and saves both before and after loading, but I haven't changed any positions
- attacked several planets over several saves
- raided several planets over several saves
- purged by fire on several planets on several saves
- purged selectively on several planets on several saves
- assassinated governor on several planets on several saves
- loaded Dark Angels and found Grav-Guns

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes several UI and logic bugs across formation settings and planet actions, restores working attack/raid buttons, and corrects save serialization and a weapon name typo.

- **Bug Fixes**
  - Formation settings: corrected description/label/image positions and tooltip vertical alignment.
  - Attack/Raid menus: fixed `InteractiveButton.update` width/height defaults to restore clickable buttons.
  - Target/Formation display: right-aligned text with dynamic widths in `drop_select_unit_selection` to prevent overlap.
  - Purge results: corrected logic (`action_type != eDROP_TYPE.PURGEASSASSINATE`) so deaths are calculated only when intended.
  - Serialization: added missing `chapter_data` and `chapter_squad_arrangement` to `obj_ini`; added `chapter_master`, `armamentarium`, `helpful_places_button`, and `lair_styles` to `obj_controller`.
  - Equipment: fixed Ravenwing option typo from "Grav-gun" to "Grav-Gun`.

<sup>Written for commit 0a37f3e0c85461d232cebeb13f5b40539d873fd1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

