### PR TITLE
fix: Dead planets sometimes owned by orks

### DIFF
--- a/scripts/scr_system_search_helpers/scr_system_search_helpers.gml
+++ b/scripts/scr_system_search_helpers/scr_system_search_helpers.gml
@@ -404,7 +404,7 @@ function is_dead_star(star = "none") {
     var dead_star = true;
     if (star == "none") {
         for (var i = 1; i <= planets; i++) {
-            if (p_type[i] != "dead") {
+            if (string_lower(p_type[i]) != "dead") {
                 dead_star = false;
                 break;
             }


### PR DESCRIPTION
* A bug in the dead system check helper caused dead planets to be sometimes owned by orks, which were difficult or impossible to remove by the player. This fix may fix a couple other bugs that depend on the same helper.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix dead system detection by lowercasing planet types before comparison. This prevents dead planets from being assigned to orks and avoids downstream issues that rely on the same helper.

<sup>Written for commit 8c384c7263cf0f34a5ad40aeb81b27aee5635e52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

