### PR TITLE
ci: Rewrite build pipeline to gm-cli

### DIFF
--- a/.github/workflows/gamemaker_build.yml
+++ b/.github/workflows/gamemaker_build.yml
@@ -65,14 +65,17 @@ jobs:
           }
 
           $CommitHash = git rev-parse --short HEAD
+          $RefName = "${{ github.ref_name }}"
+          $RefType = "${{ github.ref_type }}"
+
           try {
-            $Version = "${{ github.ref_name }}".Split('/')[-1]
+            $Version = "$RefName".Split('/')[-1]
           } catch {
             Write-Warning "No tags found, using commit hash as version."
             $Version = $CommitHash
           }
 
-          if ($Version -match "^v") {
+          if ($RefType -eq 'tag' -and $RefName -match '^v\d+\.\d+\.\d+$') {
             $suffix = $Version
           } else {
             $suffix = "$Version-$BuildDate"

--- a/.github/workflows/gamemaker_build.yml
+++ b/.github/workflows/gamemaker_build.yml
@@ -182,6 +182,42 @@ jobs:
           $outputName = "ChapterMaster-${suffix}-${{ matrix.platform }}.zip"
           $yypPath = "${{ steps.find_yyp.outputs.yyp-path }}"
 
+          if ("${{ matrix.target }}" -eq "windows" -and $env:RUNTIME -eq "native") {
+              $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+              $vsPath = $null
+              if (Test-Path $vswhere) {
+                  $installPath = & $vswhere -latest -property installationPath
+                  if ($installPath) {
+                      $vsPath = Join-Path $installPath "Common7\Tools\VsDevCmd.bat"
+                  }
+              }
+              
+              # Fallback check if vswhere failed or the file wasn't found
+              if (-not $vsPath -or -not (Test-Path $vsPath)) {
+                  $fallbacks = @(
+                      "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat",
+                      "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\VsDevCmd.bat",
+                      "C:\Program Files\Microsoft Visual Studio\2022\Professional\Common7\Tools\VsDevCmd.bat"
+                  )
+                  foreach ($fallback in $fallbacks) {
+                      if (Test-Path $fallback) {
+                          $vsPath = $fallback
+                          break
+                      }
+                  }
+              }
+              
+              if (-not $vsPath -or -not (Test-Path $vsPath)) {
+                  Write-Error "Could not locate VsDevCmd.bat using vswhere or fallback paths."
+                  exit 1
+              }
+
+              Write-Host "Using Visual Studio Command Prompt path: $vsPath"
+              $options = @{ gms2 = @{ windows = @{ visualStudioSdk = $vsPath } } }
+              $options | ConvertTo-Json -Depth 5 | Out-File "gm-options.json"
+              Write-Host "Generated gm-options.json for Visual Studio SDK"
+          }
+
           gm-cli package --target "${{ matrix.target }}" --runtime $env:RUNTIME --toolchain gms2 --output $outputName --verbose $yypPath
 
       - name: Upload artifact

--- a/.github/workflows/gamemaker_build.yml
+++ b/.github/workflows/gamemaker_build.yml
@@ -182,11 +182,7 @@ jobs:
           $outputName = "ChapterMaster-${suffix}-${{ matrix.platform }}.zip"
           $yypPath = "${{ steps.find_yyp.outputs.yyp-path }}"
 
-          $cmd = "gm-cli package --target ${{ matrix.target }} --runtime $env:RUNTIME --toolchain gms2 --output $outputName --verbose"
-
-          $cmd += " `"$yypPath`""
-          Write-Host "Running: $cmd"
-          Invoke-Expression $cmd
+          gm-cli package --target "${{ matrix.target }}" --runtime $env:RUNTIME --toolchain gms2 --output $outputName --verbose $yypPath
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/gamemaker_build.yml
+++ b/.github/workflows/gamemaker_build.yml
@@ -190,3 +190,4 @@ jobs:
           name: ChapterMaster-${{ steps.version_info.outputs.suffix }}-${{ matrix.platform }}
           path: ${{ steps.find_yyp.outputs.yyp-dir }}/ChapterMaster-${{ steps.version_info.outputs.suffix }}-${{ matrix.platform }}.zip
           retention-days: 1
+          if-no-files-found: error

--- a/.github/workflows/gamemaker_build.yml
+++ b/.github/workflows/gamemaker_build.yml
@@ -1,4 +1,5 @@
 name: Build GameMaker Project
+
 on:
   workflow_dispatch:
     inputs:
@@ -18,10 +19,24 @@ on:
 
 jobs:
   build:
-    name: Build
-    runs-on: windows-2022
+    name: Build (${{ matrix.platform }})
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: windows
+            platform: Windows
+            runs-on: windows-2022
+          - target: mac
+            platform: macOS
+            runs-on: macos-latest
+          - target: linux
+            platform: Linux
+            runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           lfs: true
           fetch-depth: 0
@@ -37,100 +52,151 @@ jobs:
           $content = [regex]::Replace($content, [regex]::Escape($placeholder), $url)
           Set-Content $file -Value $content -NoNewline
 
-      # Causing issues with the stable release workflow;
-      # - name: fetch tags
-      #   run: git fetch --tags origin
-
-      - name: Set date-time and version info
+      - name: Set version and build info
         id: version_info
         shell: pwsh
         run: |
-          # Generate current date-time directly in the format you want
-          Write-Output "GITHUB_EVENT_NAME is: $env:GITHUB_EVENT_NAME"
-
-          if (-not "${{ inputs.build_date }}") {
-            $BuildDate = (Get-Date).ToString("yyyy-MM-dd-HHmm")
-            Write-Output "No build date provided. Using current date: $BuildDate"
-          } else {
-            $BuildDate = "${{ inputs.build_date }}"
-            Write-Output "Using provided build date: $BuildDate"
-          }
-
+          $BuildNumber = "${{ github.run_number }}"
           $CommitHash = git rev-parse --short HEAD
-
-          try {
-            $Version = "${{ github.ref_name }}".Split('/')[-1]
-          } catch {
-            # If no tags exist, use the commit hash as the version
-            Write-Warning "No tags found, using commit hash as version."
-            $Version = $CommitHash
-          }
-
-          # Set the version number
-          if ($Version -match "^v") {
-            $suffix = $Version
-          } else {
-            $suffix = "$Version-$BuildDate"
-          }
-
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "suffix=$suffix"
-          Write-Output "Suffix: $suffix"
-  
-          # Create the version.json content
-          $VersionJson = @{
-            version     = $Version
-            build_date  = $BuildDate
-            commit_hash = $CommitHash
-          } | ConvertTo-Json
+          $RefName = "${{ github.ref_name }}"
+          $RefType = "${{ github.ref_type }}"  # 'branch' or 'tag'
       
-          # Write the version.json to disk
+          if ($RefType -eq 'tag' -and $RefName -match '^v\d+\.\d+\.\d+$') {
+            $suffix = $RefName
+          } elseif ($RefName -match '^main') {
+            $prefix = "development"
+            $suffix = "$prefix-$BuildNumber"
+          } else {
+            $prefix = "test"
+            $suffix = "$prefix-$RefName-$BuildNumber"
+          }
+      
+          Write-Output "suffix=$suffix" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          Write-Output "Build suffix: $suffix"
+      
+          $VersionJson = @{
+            version      = $suffix
+            build_date   = (Get-Date).ToString("yyyy-MM-dd-HHmm")
+            commit_hash  = $CommitHash
+            build_number = $BuildNumber
+            ref_type     = $RefType
+            ref_name     = $RefName
+          } | ConvertTo-Json
           Set-Content -Path datafiles/main/version.json -Value $VersionJson
 
-      # This step finds the yyp file in the repository and saves the path to an output
       - id: find_yyp
-        name: Find The yyp File
+        name: Find the .yyp file
+        shell: pwsh
         run: |
-          # Search for .yyp file recursively in the repository
           $yypFiles = Get-ChildItem -Path ${{ github.workspace }} -Recurse -Filter ChapterMaster.yyp
-          
-          # Check if the file was found
           if ($yypFiles.Count -eq 0) {
             Write-Error "No .yyp file found in the repository"
             exit 1
           }
-
           $yypPath = $yypFiles[0].FullName
-          
           if ($yypFiles.Count -gt 1) {
             Write-Host "::warning:: Multiple .yyp files found. Using the first one: $yypPath"
           }
-
-          # If found, output the path of the .yyp file
           Write-Output "YYP file found at: $yypPath"
           "yyp-path=$yypPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-          
-      # This step sets up the GameMaker build CLI tool Igor https://github.com/bscotch/igor-setup
-      - id: igor_setup
-        name: Setup Igor
-        uses: bscotch/igor-setup@v1.3.0
-        with:
-          target-yyp: ${{ steps.find_yyp.outputs.yyp-path }}
-          access-key: ${{ secrets.GM_ACCESS_KEY }}
+          $yypDir = Split-Path $yypPath
+          "yyp-dir=$yypDir" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
-      # Update the version.json file with build date and other versioning information
-      - id: igor_build
-        name: Build with Igor
-        uses: bscotch/igor-build@v1.3.2
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
         with:
-          yyp-path: ${{ steps.find_yyp.outputs.yyp-path }}
-          user-dir: ${{ steps.igor_setup.outputs.user-dir }}
-          name: ChapterMaster-${{ steps.version_info.outputs.suffix }}-Windows.zip
-          yyc: ${{ inputs.yyc }}
+          node-version: 24
+
+      - name: Install GameMaker CLI
+        shell: pwsh
+        run: npm install -g @gamemaker/gm-cli@latest
+
+      - name: Login to GameMaker CLI
+        if: env.GM_ACCESS_KEY != ''
+        env:
+          GM_ACCESS_KEY: ${{ secrets.GM_ACCESS_KEY }}
+        shell: pwsh
+        run: npx @gamemaker/gm-cli@latest login $env:GM_ACCESS_KEY
+
+      - name: Disable AppArmor restriction for unprivileged user namespaces (Linux)
+        if: matrix.target == 'linux'
+        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
+      - name: Install ffmpeg (Linux)
+        if: matrix.target == 'linux'
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+
+      - name: Install Steam Runtime (Linux YYC)
+        if: matrix.target == 'linux' && inputs.yyc
+        run: |
+          # Fetch the latest public stable version info and checksums from the official Steam repository
+          BASE_URL="https://repo.steampowered.com/steamrt-images-scout/snapshots/latest-public-stable"
           
-      # Upload built file as an artifact
-      - name: Upload built file as artifact
-        uses: actions/upload-artifact@v4
+          echo "Fetching latest SHA256SUMS from $BASE_URL..."
+          curl -sL -o SHA256SUMS "${BASE_URL}/SHA256SUMS"
+          
+          # Extract the expected checksum for the target sysroot archive
+          TARGET_FILE="com.valvesoftware.SteamRuntime.Sdk-amd64,i386-scout-sysroot.tar.gz"
+          EXPECTED_SHA256=$(grep -F "$TARGET_FILE" SHA256SUMS | cut -d' ' -f1)
+          
+          if [ -z "$EXPECTED_SHA256" ]; then
+            echo "Error: Could not find SHA256 checksum for $TARGET_FILE in SHA256SUMS!"
+            exit 1
+          fi
+          
+          echo "Latest stable SHA256 for $TARGET_FILE is $EXPECTED_SHA256"
+          
+          echo "Downloading latest stable Steam Runtime SDK..."
+          curl -sL -o steam-runtime-sdk.tar.gz "${BASE_URL}/${TARGET_FILE}"
+          
+          if ! echo "${EXPECTED_SHA256}  steam-runtime-sdk.tar.gz" | sha256sum -c -; then
+            echo "Error: Steam Runtime SDK checksum verification failed!"
+            exit 1
+          fi
+          
+          sudo mkdir -p /opt/steam-runtime
+          sudo tar -xzf steam-runtime-sdk.tar.gz -C /opt/steam-runtime
+          rm steam-runtime-sdk.tar.gz SHA256SUMS
+
+      - name: Workaround GameMaker Xcode GUI wait (macOS)
+        if: matrix.target == 'mac'
+        shell: bash
+        run: mkdir -p ~/gamemakerstudio2/GM_MAC/ChapterMaster/ChapterMaster/ChapterMaster.xcodeproj/xcuserdata
+
+      - name: Build and package for ${{ matrix.platform }}
+        shell: pwsh
+        working-directory: ${{ steps.find_yyp.outputs.yyp-dir }}
+        env:
+          RUNTIME: ${{ inputs.yyc && 'native' || 'vm' }}
+          SEE_MASK_NOZONECHECKS: "1"
+        run: |
+          $suffix = "${{ steps.version_info.outputs.suffix }}"
+          $outputName = "ChapterMaster-${suffix}-${{ matrix.platform }}.zip"
+          $yypPath = "${{ steps.find_yyp.outputs.yyp-path }}"
+
+          $cmd = "gm-cli package --target ${{ matrix.target }} --runtime $env:RUNTIME --toolchain gms2 --output $outputName --verbose"
+
+          $cmd += " `"$yypPath`""
+          Write-Host "Running: $cmd"
+          Invoke-Expression $cmd
+
+      - name: Extract package for artifact upload
+        shell: pwsh
+        working-directory: ${{ steps.find_yyp.outputs.yyp-dir }}
+        run: |
+          $suffix = "${{ steps.version_info.outputs.suffix }}"
+          $zipFile = "ChapterMaster-${suffix}-${{ matrix.platform }}.zip"
+          $nestedFolder = "ChapterMaster"
+          $stageFolder = "artifact-stage-${{ matrix.platform }}"
+
+          New-Item -ItemType Directory -Force -Path "$stageFolder/$nestedFolder"
+          Expand-Archive -Path $zipFile -DestinationPath "$stageFolder/$nestedFolder" -Force
+
+          Write-Output "Extracted to $stageFolder/$nestedFolder"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
         with:
-          name: built-file
-          path: ${{ steps.igor_build.outputs.out-dir }}
+          name: ChapterMaster-${{ steps.version_info.outputs.suffix }}-${{ matrix.platform }}
+          path: ${{ steps.find_yyp.outputs.yyp-dir }}/artifact-stage-${{ matrix.platform }}
           retention-days: 1

--- a/.github/workflows/gamemaker_build.yml
+++ b/.github/workflows/gamemaker_build.yml
@@ -185,23 +185,9 @@ jobs:
           Write-Host "Running: $cmd"
           Invoke-Expression $cmd
 
-      - name: Extract package for artifact upload
-        shell: pwsh
-        working-directory: ${{ steps.find_yyp.outputs.yyp-dir }}
-        run: |
-          $suffix = "${{ steps.version_info.outputs.suffix }}"
-          $zipFile = "ChapterMaster-${suffix}-${{ matrix.platform }}.zip"
-          $nestedFolder = "ChapterMaster"
-          $stageFolder = "artifact-stage-${{ matrix.platform }}"
-
-          New-Item -ItemType Directory -Force -Path "$stageFolder/$nestedFolder"
-          Expand-Archive -Path $zipFile -DestinationPath "$stageFolder/$nestedFolder" -Force
-
-          Write-Output "Extracted to $stageFolder/$nestedFolder"
-
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
           name: ChapterMaster-${{ steps.version_info.outputs.suffix }}-${{ matrix.platform }}
-          path: ${{ steps.find_yyp.outputs.yyp-dir }}/artifact-stage-${{ matrix.platform }}
+          path: ${{ steps.find_yyp.outputs.yyp-dir }}/ChapterMaster-${{ steps.version_info.outputs.suffix }}-${{ matrix.platform }}.zip
           retention-days: 1

--- a/.github/workflows/gamemaker_build.yml
+++ b/.github/workflows/gamemaker_build.yml
@@ -52,36 +52,41 @@ jobs:
           $content = [regex]::Replace($content, [regex]::Escape($placeholder), $url)
           Set-Content $file -Value $content -NoNewline
 
-      - name: Set version and build info
+      - name: Set date-time and version info
         id: version_info
         shell: pwsh
         run: |
-          $BuildNumber = "${{ github.run_number }}"
-          $CommitHash = git rev-parse --short HEAD
-          $RefName = "${{ github.ref_name }}"
-          $RefType = "${{ github.ref_type }}"  # 'branch' or 'tag'
-      
-          if ($RefType -eq 'tag' -and $RefName -match '^v\d+\.\d+\.\d+$') {
-            $suffix = $RefName
-          } elseif ($RefName -match '^main') {
-            $prefix = "development"
-            $suffix = "$prefix-$BuildNumber"
+          if (-not "${{ inputs.build_date }}") {
+            $BuildDate = (Get-Date).ToString("yyyy-MM-dd-HHmm")
+            Write-Output "No build date provided. Using current date: $BuildDate"
           } else {
-            $prefix = "test"
-            $suffix = "$prefix-$RefName-$BuildNumber"
+            $BuildDate = "${{ inputs.build_date }}"
+            Write-Output "Using provided build date: $BuildDate"
           }
-      
-          Write-Output "suffix=$suffix" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-          Write-Output "Build suffix: $suffix"
-      
+
+          $CommitHash = git rev-parse --short HEAD
+          try {
+            $Version = "${{ github.ref_name }}".Split('/')[-1]
+          } catch {
+            Write-Warning "No tags found, using commit hash as version."
+            $Version = $CommitHash
+          }
+
+          if ($Version -match "^v") {
+            $suffix = $Version
+          } else {
+            $suffix = "$Version-$BuildDate"
+          }
+
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "suffix=$suffix"
+          Write-Output "Suffix: $suffix"
+
           $VersionJson = @{
-            version      = $suffix
-            build_date   = (Get-Date).ToString("yyyy-MM-dd-HHmm")
-            commit_hash  = $CommitHash
-            build_number = $BuildNumber
-            ref_type     = $RefType
-            ref_name     = $RefName
+            version     = $Version
+            build_date  = $BuildDate
+            commit_hash = $CommitHash
           } | ConvertTo-Json
+
           Set-Content -Path datafiles/main/version.json -Value $VersionJson
 
       - id: find_yyp

--- a/.github/workflows/gamemaker_build.yml
+++ b/.github/workflows/gamemaker_build.yml
@@ -117,7 +117,7 @@ jobs:
 
       - name: Install GameMaker CLI
         shell: pwsh
-        run: npm install -g @gamemaker/gm-cli@latest
+        run: npm install -g @gamemaker/gm-cli@2.2.0
 
       - name: Login to GameMaker CLI
         if: env.GM_ACCESS_KEY != ''

--- a/.github/workflows/release_dev.yml
+++ b/.github/workflows/release_dev.yml
@@ -23,7 +23,7 @@ jobs:
       needed: ${{ steps.commit_check.outputs.needed }}  # Output for skipping
       last_tag: ${{ steps.commit_check.outputs.last_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -100,7 +100,7 @@ jobs:
       build_date: ${{ steps.tag_info.outputs.build_date }}
       from_tag: ${{ needs.build_needed.outputs.last_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -192,11 +192,11 @@ jobs:
     permissions:
       contents: write # Needed for softprops/action-gh-release
     steps:
-      - name: Download built file artifact
-        uses: actions/download-artifact@v4
+      - name: Download all built artifacts
+        uses: actions/download-artifact@v8
         with:
-          name: built-file
           path: ./build_output
+          merge-multiple: true
 
       - name: List downloaded files # Debug step
         run: ls -R ./build_output
@@ -264,4 +264,4 @@ jobs:
           prerelease: false
           make_latest: true
           files: |
-            ./build_output/${{ needs.gamemaker_build.outputs.built_file }}/*
+            ./build_output/**/*.zip

--- a/.github/workflows/release_dev.yml
+++ b/.github/workflows/release_dev.yml
@@ -117,62 +117,62 @@ jobs:
           echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
           echo "build_date=$DATE_TAG" >> $GITHUB_OUTPUT
 
-      - name: Cleanup old releases
-        run: |
-          set -euo pipefail # Exit immediately if a command exits with a non-zero status
+      # - name: Cleanup old releases
+      #   run: |
+      #     set -euo pipefail # Exit immediately if a command exits with a non-zero status
 
-          # tag_name looks like: branch-name/date (e.g., main/2025-05-10-2220)
-          TAG_NAME="${{ steps.tag_info.outputs.tag_name }}"
+      #     # tag_name looks like: branch-name/date (e.g., main/2025-05-10-2220)
+      #     TAG_NAME="${{ steps.tag_info.outputs.tag_name }}"
 
-          # Extract the branch prefix from the tag name (e.g., "main/")
-          # This assumes your tag format is always 'branch-name/date'
-          BRANCH_PREFIX="${TAG_NAME%%/*}/"
+      #     # Extract the branch prefix from the tag name (e.g., "main/")
+      #     # This assumes your tag format is always 'branch-name/date'
+      #     BRANCH_PREFIX="${TAG_NAME%%/*}/"
 
-          echo "Starting cleanup for releases with prefix: ${BRANCH_PREFIX}"
+      #     echo "Starting cleanup for releases with prefix: ${BRANCH_PREFIX}"
 
-          # --- Added Step: List all tag names found before filtering ---
-          echo "--- All tag names found by 'gh release list --json tagName': ---"
-          # Get all tag names first
-          ALL_TAG_NAMES=$(gh release list --limit 100 --json tagName | jq -r '.[].tagName' || true)
-          if [ -z "$ALL_TAG_NAMES" ]; then
-            echo "No releases found at all."
-          else
-             echo "$ALL_TAG_NAMES" | cat -n # List all found tags with line numbers
-          fi
-          echo "-----------------------------------------------------------"
+      #     # --- Added Step: List all tag names found before filtering ---
+      #     echo "--- All tag names found by 'gh release list --json tagName': ---"
+      #     # Get all tag names first
+      #     ALL_TAG_NAMES=$(gh release list --limit 100 --json tagName | jq -r '.[].tagName' || true)
+      #     if [ -z "$ALL_TAG_NAMES" ]; then
+      #       echo "No releases found at all."
+      #     else
+      #        echo "$ALL_TAG_NAMES" | cat -n # List all found tags with line numbers
+      #     fi
+      #     echo "-----------------------------------------------------------"
 
 
-          # Get tag names starting with the prefix, sort reverse chronologically by tag name.
-          # We use the previously fetched ALL_TAG_NAMES to avoid calling gh release list again
-          # Use || true at the end of the pipe to prevent the step from failing if no releases match the prefix
-          TAGS_TO_PROCESS=$(echo "$ALL_TAG_NAMES" | grep "^${BRANCH_PREFIX}" | sort -r || true)
+      #     # Get tag names starting with the prefix, sort reverse chronologically by tag name.
+      #     # We use the previously fetched ALL_TAG_NAMES to avoid calling gh release list again
+      #     # Use || true at the end of the pipe to prevent the step from failing if no releases match the prefix
+      #     TAGS_TO_PROCESS=$(echo "$ALL_TAG_NAMES" | grep "^${BRANCH_PREFIX}" | sort -r || true)
 
-          if [ -z "$TAGS_TO_PROCESS" ]; then
-            echo "No releases found matching prefix '${BRANCH_PREFIX}'. No cleanup needed."
-            exit 0
-          fi
+      #     if [ -z "$TAGS_TO_PROCESS" ]; then
+      #       echo "No releases found matching prefix '${BRANCH_PREFIX}'. No cleanup needed."
+      #       exit 0
+      #     fi
 
-          # --- The rest of the logic (count, keep, delete) remains the same ---
-          # Count the filtered tags
-          NUM_MATCHING=$(echo "$TAGS_TO_PROCESS" | wc -l)
-          RELEASES_TO_KEEP=20 # How many releases per branch prefix to keep
-          echo "Found ${NUM_MATCHING} releases matching prefix '${BRANCH_PREFIX}'. Will keep the latest $RELEASES_TO_KEEP."
+      #     # --- The rest of the logic (count, keep, delete) remains the same ---
+      #     # Count the filtered tags
+      #     NUM_MATCHING=$(echo "$TAGS_TO_PROCESS" | wc -l)
+      #     RELEASES_TO_KEEP=20 # How many releases per branch prefix to keep
+      #     echo "Found ${NUM_MATCHING} releases matching prefix '${BRANCH_PREFIX}'. Will keep the latest $RELEASES_TO_KEEP."
 
-          COUNT=0
-          IFS=$'\n' # Set IFS to newline to correctly iterate over tags
-          for TAG in $TAGS_TO_PROCESS; do
-            COUNT=$((COUNT + 1))
-            if [ $COUNT -gt $RELEASES_TO_KEEP ]; then
-              echo "Deleting old release+tag: $TAG"
-              gh release delete "$TAG" -y --cleanup-tag || echo "Warning: Failed to delete release $TAG. It may have been deleted already."
-            else
-              echo "Keeping release+tag: $TAG (it's within the latest $RELEASES_TO_KEEP)"
-            fi
-          done
-          unset IFS # Reset IFS
+      #     COUNT=0
+      #     IFS=$'\n' # Set IFS to newline to correctly iterate over tags
+      #     for TAG in $TAGS_TO_PROCESS; do
+      #       COUNT=$((COUNT + 1))
+      #       if [ $COUNT -gt $RELEASES_TO_KEEP ]; then
+      #         echo "Deleting old release+tag: $TAG"
+      #         gh release delete "$TAG" -y --cleanup-tag || echo "Warning: Failed to delete release $TAG. It may have been deleted already."
+      #       else
+      #         echo "Keeping release+tag: $TAG (it's within the latest $RELEASES_TO_KEEP)"
+      #       fi
+      #     done
+      #     unset IFS # Reset IFS
 
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needs permissions to delete releases/tags
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needs permissions to delete releases/tags
 
   gamemaker_build:
     name: Build
@@ -201,67 +201,67 @@ jobs:
       - name: List downloaded files # Debug step
         run: ls -R ./build_output
 
-      - name: Prepare Release Name
-        id: prep_release_name
-        run: |
-          rawTagName="${{ needs.prepare_release.outputs.tag_name }}"
-          # Use Bash parameter expansion: ${parameter//pattern/string}
-          # Replaces all occurrences of '/' with '-'
-          formattedTagName="${rawTagName//\//-}"
-          releaseName="$formattedTagName"
-          echo "Calculated release name: $releaseName"
-          # Set the output using standard Bash redirection to the GITHUB_OUTPUT file
-          echo "release_name=$releaseName" >> $GITHUB_OUTPUT
+      # - name: Prepare Release Name
+      #   id: prep_release_name
+      #   run: |
+      #     rawTagName="${{ needs.prepare_release.outputs.tag_name }}"
+      #     # Use Bash parameter expansion: ${parameter//pattern/string}
+      #     # Replaces all occurrences of '/' with '-'
+      #     formattedTagName="${rawTagName//\//-}"
+      #     releaseName="$formattedTagName"
+      #     echo "Calculated release name: $releaseName"
+      #     # Set the output using standard Bash redirection to the GITHUB_OUTPUT file
+      #     echo "release_name=$releaseName" >> $GITHUB_OUTPUT
 
-      - id: build_changelog
-        name: Build Changelog
-        uses: mikepenz/release-changelog-builder-action@v6.1.0
-        with:
-          mode: "COMMIT"
-          fromTag: ${{ needs.prepare_release.outputs.from_tag }}
-          toTag: ${{ github.sha }}
-          configurationJson: |
-            {
-              "template": "#{{CHANGELOG}}\n\n**Changed Lines:** #{{CHANGES}}\n**Full Changelog:** #{{RELEASE_DIFF}}",
-              "commit_template": "- [#{{TITLE}}](https://github.com/Adeptus-Dominus/ChapterMaster/commit/#{{MERGE_SHA}}) by #{{AUTHOR}}",
-              "sort": {
-                "order": "ASC",
-                "on_property": "title"
-              },
-              "categories": [
-                {
-                    "title": "### Features",
-                    "labels": ["feat"]
-                },
-                {
-                    "title": "### Fixes",
-                    "labels": ["fix"]
-                },
-                {
-                    "title": "### Other",
-                    "labels": []
-                }
-              ],
-              "label_extractor": [
-                {
-                  "pattern": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|merge){1}(\\([\\w\\-\\.]+\\))?(!)?: ([\\w ])+([\\s\\S]*)",
-                  "on_property": "title",
-                  "target": "$1"
-                }
-              ]
-            }
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # - id: build_changelog
+      #   name: Build Changelog
+      #   uses: mikepenz/release-changelog-builder-action@v6.1.0
+      #   with:
+      #     mode: "COMMIT"
+      #     fromTag: ${{ needs.prepare_release.outputs.from_tag }}
+      #     toTag: ${{ github.sha }}
+      #     configurationJson: |
+      #       {
+      #         "template": "#{{CHANGELOG}}\n\n**Changed Lines:** #{{CHANGES}}\n**Full Changelog:** #{{RELEASE_DIFF}}",
+      #         "commit_template": "- [#{{TITLE}}](https://github.com/Adeptus-Dominus/ChapterMaster/commit/#{{MERGE_SHA}}) by #{{AUTHOR}}",
+      #         "sort": {
+      #           "order": "ASC",
+      #           "on_property": "title"
+      #         },
+      #         "categories": [
+      #           {
+      #               "title": "### Features",
+      #               "labels": ["feat"]
+      #           },
+      #           {
+      #               "title": "### Fixes",
+      #               "labels": ["fix"]
+      #           },
+      #           {
+      #               "title": "### Other",
+      #               "labels": []
+      #           }
+      #         ],
+      #         "label_extractor": [
+      #           {
+      #             "pattern": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|merge){1}(\\([\\w\\-\\.]+\\))?(!)?: ([\\w ])+([\\s\\S]*)",
+      #             "on_property": "title",
+      #             "target": "$1"
+      #           }
+      #         ]
+      #       }
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - id: create_release
-        name: Create a release and upload the build
-        uses: softprops/action-gh-release@v2.3.2
-        with:
-          name: ${{ steps.prep_release_name.outputs.release_name }}
-          body: ${{steps.build_changelog.outputs.changelog}}
-          token: ${{ secrets.RELEASE_TOKEN_SECRET }}
-          tag_name: ${{ needs.prepare_release.outputs.tag_name }}
-          prerelease: false
-          make_latest: true
-          files: |
-            ./build_output/**/*.zip
+      # - id: create_release
+      #   name: Create a release and upload the build
+      #   uses: softprops/action-gh-release@v2.3.2
+      #   with:
+      #     name: ${{ steps.prep_release_name.outputs.release_name }}
+      #     body: ${{steps.build_changelog.outputs.changelog}}
+      #     token: ${{ secrets.RELEASE_TOKEN_SECRET }}
+      #     tag_name: ${{ needs.prepare_release.outputs.tag_name }}
+      #     prerelease: false
+      #     make_latest: true
+      #     files: |
+      #       ./build_output/**/*.zip

--- a/.github/workflows/release_dev.yml
+++ b/.github/workflows/release_dev.yml
@@ -117,62 +117,62 @@ jobs:
           echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
           echo "build_date=$DATE_TAG" >> $GITHUB_OUTPUT
 
-      # - name: Cleanup old releases
-      #   run: |
-      #     set -euo pipefail # Exit immediately if a command exits with a non-zero status
+      - name: Cleanup old releases
+        run: |
+          set -euo pipefail # Exit immediately if a command exits with a non-zero status
 
-      #     # tag_name looks like: branch-name/date (e.g., main/2025-05-10-2220)
-      #     TAG_NAME="${{ steps.tag_info.outputs.tag_name }}"
+          # tag_name looks like: branch-name/date (e.g., main/2025-05-10-2220)
+          TAG_NAME="${{ steps.tag_info.outputs.tag_name }}"
 
-      #     # Extract the branch prefix from the tag name (e.g., "main/")
-      #     # This assumes your tag format is always 'branch-name/date'
-      #     BRANCH_PREFIX="${TAG_NAME%%/*}/"
+          # Extract the branch prefix from the tag name (e.g., "main/")
+          # This assumes your tag format is always 'branch-name/date'
+          BRANCH_PREFIX="${TAG_NAME%%/*}/"
 
-      #     echo "Starting cleanup for releases with prefix: ${BRANCH_PREFIX}"
+          echo "Starting cleanup for releases with prefix: ${BRANCH_PREFIX}"
 
-      #     # --- Added Step: List all tag names found before filtering ---
-      #     echo "--- All tag names found by 'gh release list --json tagName': ---"
-      #     # Get all tag names first
-      #     ALL_TAG_NAMES=$(gh release list --limit 100 --json tagName | jq -r '.[].tagName' || true)
-      #     if [ -z "$ALL_TAG_NAMES" ]; then
-      #       echo "No releases found at all."
-      #     else
-      #        echo "$ALL_TAG_NAMES" | cat -n # List all found tags with line numbers
-      #     fi
-      #     echo "-----------------------------------------------------------"
+          # --- Added Step: List all tag names found before filtering ---
+          echo "--- All tag names found by 'gh release list --json tagName': ---"
+          # Get all tag names first
+          ALL_TAG_NAMES=$(gh release list --limit 100 --json tagName | jq -r '.[].tagName' || true)
+          if [ -z "$ALL_TAG_NAMES" ]; then
+            echo "No releases found at all."
+          else
+             echo "$ALL_TAG_NAMES" | cat -n # List all found tags with line numbers
+          fi
+          echo "-----------------------------------------------------------"
 
 
-      #     # Get tag names starting with the prefix, sort reverse chronologically by tag name.
-      #     # We use the previously fetched ALL_TAG_NAMES to avoid calling gh release list again
-      #     # Use || true at the end of the pipe to prevent the step from failing if no releases match the prefix
-      #     TAGS_TO_PROCESS=$(echo "$ALL_TAG_NAMES" | grep "^${BRANCH_PREFIX}" | sort -r || true)
+          # Get tag names starting with the prefix, sort reverse chronologically by tag name.
+          # We use the previously fetched ALL_TAG_NAMES to avoid calling gh release list again
+          # Use || true at the end of the pipe to prevent the step from failing if no releases match the prefix
+          TAGS_TO_PROCESS=$(echo "$ALL_TAG_NAMES" | grep "^${BRANCH_PREFIX}" | sort -r || true)
 
-      #     if [ -z "$TAGS_TO_PROCESS" ]; then
-      #       echo "No releases found matching prefix '${BRANCH_PREFIX}'. No cleanup needed."
-      #       exit 0
-      #     fi
+          if [ -z "$TAGS_TO_PROCESS" ]; then
+            echo "No releases found matching prefix '${BRANCH_PREFIX}'. No cleanup needed."
+            exit 0
+          fi
 
-      #     # --- The rest of the logic (count, keep, delete) remains the same ---
-      #     # Count the filtered tags
-      #     NUM_MATCHING=$(echo "$TAGS_TO_PROCESS" | wc -l)
-      #     RELEASES_TO_KEEP=20 # How many releases per branch prefix to keep
-      #     echo "Found ${NUM_MATCHING} releases matching prefix '${BRANCH_PREFIX}'. Will keep the latest $RELEASES_TO_KEEP."
+          # --- The rest of the logic (count, keep, delete) remains the same ---
+          # Count the filtered tags
+          NUM_MATCHING=$(echo "$TAGS_TO_PROCESS" | wc -l)
+          RELEASES_TO_KEEP=20 # How many releases per branch prefix to keep
+          echo "Found ${NUM_MATCHING} releases matching prefix '${BRANCH_PREFIX}'. Will keep the latest $RELEASES_TO_KEEP."
 
-      #     COUNT=0
-      #     IFS=$'\n' # Set IFS to newline to correctly iterate over tags
-      #     for TAG in $TAGS_TO_PROCESS; do
-      #       COUNT=$((COUNT + 1))
-      #       if [ $COUNT -gt $RELEASES_TO_KEEP ]; then
-      #         echo "Deleting old release+tag: $TAG"
-      #         gh release delete "$TAG" -y --cleanup-tag || echo "Warning: Failed to delete release $TAG. It may have been deleted already."
-      #       else
-      #         echo "Keeping release+tag: $TAG (it's within the latest $RELEASES_TO_KEEP)"
-      #       fi
-      #     done
-      #     unset IFS # Reset IFS
+          COUNT=0
+          IFS=$'\n' # Set IFS to newline to correctly iterate over tags
+          for TAG in $TAGS_TO_PROCESS; do
+            COUNT=$((COUNT + 1))
+            if [ $COUNT -gt $RELEASES_TO_KEEP ]; then
+              echo "Deleting old release+tag: $TAG"
+              gh release delete "$TAG" -y --cleanup-tag || echo "Warning: Failed to delete release $TAG. It may have been deleted already."
+            else
+              echo "Keeping release+tag: $TAG (it's within the latest $RELEASES_TO_KEEP)"
+            fi
+          done
+          unset IFS # Reset IFS
 
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needs permissions to delete releases/tags
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needs permissions to delete releases/tags
 
   gamemaker_build:
     name: Build
@@ -201,67 +201,67 @@ jobs:
       - name: List downloaded files # Debug step
         run: ls -R ./build_output
 
-      # - name: Prepare Release Name
-      #   id: prep_release_name
-      #   run: |
-      #     rawTagName="${{ needs.prepare_release.outputs.tag_name }}"
-      #     # Use Bash parameter expansion: ${parameter//pattern/string}
-      #     # Replaces all occurrences of '/' with '-'
-      #     formattedTagName="${rawTagName//\//-}"
-      #     releaseName="$formattedTagName"
-      #     echo "Calculated release name: $releaseName"
-      #     # Set the output using standard Bash redirection to the GITHUB_OUTPUT file
-      #     echo "release_name=$releaseName" >> $GITHUB_OUTPUT
+      - name: Prepare Release Name
+        id: prep_release_name
+        run: |
+          rawTagName="${{ needs.prepare_release.outputs.tag_name }}"
+          # Use Bash parameter expansion: ${parameter//pattern/string}
+          # Replaces all occurrences of '/' with '-'
+          formattedTagName="${rawTagName//\//-}"
+          releaseName="$formattedTagName"
+          echo "Calculated release name: $releaseName"
+          # Set the output using standard Bash redirection to the GITHUB_OUTPUT file
+          echo "release_name=$releaseName" >> $GITHUB_OUTPUT
 
-      # - id: build_changelog
-      #   name: Build Changelog
-      #   uses: mikepenz/release-changelog-builder-action@v6.1.0
-      #   with:
-      #     mode: "COMMIT"
-      #     fromTag: ${{ needs.prepare_release.outputs.from_tag }}
-      #     toTag: ${{ github.sha }}
-      #     configurationJson: |
-      #       {
-      #         "template": "#{{CHANGELOG}}\n\n**Changed Lines:** #{{CHANGES}}\n**Full Changelog:** #{{RELEASE_DIFF}}",
-      #         "commit_template": "- [#{{TITLE}}](https://github.com/Adeptus-Dominus/ChapterMaster/commit/#{{MERGE_SHA}}) by #{{AUTHOR}}",
-      #         "sort": {
-      #           "order": "ASC",
-      #           "on_property": "title"
-      #         },
-      #         "categories": [
-      #           {
-      #               "title": "### Features",
-      #               "labels": ["feat"]
-      #           },
-      #           {
-      #               "title": "### Fixes",
-      #               "labels": ["fix"]
-      #           },
-      #           {
-      #               "title": "### Other",
-      #               "labels": []
-      #           }
-      #         ],
-      #         "label_extractor": [
-      #           {
-      #             "pattern": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|merge){1}(\\([\\w\\-\\.]+\\))?(!)?: ([\\w ])+([\\s\\S]*)",
-      #             "on_property": "title",
-      #             "target": "$1"
-      #           }
-      #         ]
-      #       }
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - id: build_changelog
+        name: Build Changelog
+        uses: mikepenz/release-changelog-builder-action@v6.1.0
+        with:
+          mode: "COMMIT"
+          fromTag: ${{ needs.prepare_release.outputs.from_tag }}
+          toTag: ${{ github.sha }}
+          configurationJson: |
+            {
+              "template": "#{{CHANGELOG}}\n\n**Changed Lines:** #{{CHANGES}}\n**Full Changelog:** #{{RELEASE_DIFF}}",
+              "commit_template": "- [#{{TITLE}}](https://github.com/Adeptus-Dominus/ChapterMaster/commit/#{{MERGE_SHA}}) by #{{AUTHOR}}",
+              "sort": {
+                "order": "ASC",
+                "on_property": "title"
+              },
+              "categories": [
+                {
+                    "title": "### Features",
+                    "labels": ["feat"]
+                },
+                {
+                    "title": "### Fixes",
+                    "labels": ["fix"]
+                },
+                {
+                    "title": "### Other",
+                    "labels": []
+                }
+              ],
+              "label_extractor": [
+                {
+                  "pattern": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|merge){1}(\\([\\w\\-\\.]+\\))?(!)?: ([\\w ])+([\\s\\S]*)",
+                  "on_property": "title",
+                  "target": "$1"
+                }
+              ]
+            }
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # - id: create_release
-      #   name: Create a release and upload the build
-      #   uses: softprops/action-gh-release@v2.3.2
-      #   with:
-      #     name: ${{ steps.prep_release_name.outputs.release_name }}
-      #     body: ${{steps.build_changelog.outputs.changelog}}
-      #     token: ${{ secrets.RELEASE_TOKEN_SECRET }}
-      #     tag_name: ${{ needs.prepare_release.outputs.tag_name }}
-      #     prerelease: false
-      #     make_latest: true
-      #     files: |
-      #       ./build_output/**/*.zip
+      - id: create_release
+        name: Create a release and upload the build
+        uses: softprops/action-gh-release@v2.3.2
+        with:
+          name: ${{ steps.prep_release_name.outputs.release_name }}
+          body: ${{steps.build_changelog.outputs.changelog}}
+          token: ${{ secrets.RELEASE_TOKEN_SECRET }}
+          tag_name: ${{ needs.prepare_release.outputs.tag_name }}
+          prerelease: false
+          make_latest: true
+          files: |
+            ./build_output/**/*.zip

--- a/.github/workflows/release_stable.yml
+++ b/.github/workflows/release_stable.yml
@@ -19,11 +19,11 @@ jobs:
       contents: write
     steps:
       - id: download_artifact
-        name: Download built file artifact
-        uses: actions/download-artifact@v4
+        name: Download all built artifacts
+        uses: actions/download-artifact@v8
         with:
-          name: built-file
           path: ./build_output
+          merge-multiple: true
 
       - id: create_release
         name: Create a release and upload the build
@@ -36,4 +36,4 @@ jobs:
           generate_release_notes: true
           make_latest: true
           files: |
-            ./build_output/${{ needs.gamemaker_build.outputs.built_file }}/*
+            ./build_output/**/*.zip

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,17 +29,9 @@ Main repository: [Adeptus-Dominus/ChapterMaster](https://github.com/Adeptus-Domi
 
 ## Playing
 
-### Windows
+### Windows, Linux, macOS
 
-Download the [latest release](https://github.com/Adeptus-Dominus/ChapterMaster/releases/latest) or a [development pre-release](https://github.com/Adeptus-Dominus/ChapterMaster/releases), unzip it and launch the .exe.
-
-### Linux
-
-Pre-compiled Linux binaries are not currently supported. However, you can run the game on Linux by downloading the Windows release `.exe` and running it using **WINE** (or **Proton** / **Steam Play**). This has been reported to work well. Alternatively, you can compile from source.
-
-### macOS
-
-Same as with Linux.
+Download the [latest release](https://github.com/Adeptus-Dominus/ChapterMaster/releases/latest) or a [development pre-release](https://github.com/Adeptus-Dominus/ChapterMaster/releases), unzip and launch.
 
 ## Compiling from source
 

--- a/options/mac/options_mac.yy
+++ b/options/mac/options_mac.yy
@@ -25,7 +25,7 @@
   "option_mac_output_dir":"~/gamemakerstudio2",
   "option_mac_resize_window":true,
   "option_mac_scale":0,
-  "option_mac_signing_identity":"DD 43 55 BA D2 D6 29 A4 A2 2E 7A 9B 34 E7 E4 02 1A 8F 19 95 5B FF 94 CC 26 E8 EB 58 FF 20 60 61",
+  "option_mac_signing_identity":"",
   "option_mac_splash_png":"${options_dir}/mac/splash/splash.png",
   "option_mac_start_fullscreen":false,
   "option_mac_team_id":"",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Rewrote CI to `@gamemaker/gm-cli` with cross‑platform matrix builds and per‑platform zips. Stable/dev releases now merge artifacts and upload all zips; version suffix uses the semver tag only when on `vX.Y.Z`.

- **New Features**
  - OS matrix builds for Windows/macOS/Linux; VM or YYC (Linux YYC uses Steam Runtime with checksum).
  - Per‑platform packaging via `gm-cli package`; writes `datafiles/main/version.json`.

- **Refactors**
  - Replaced Igor with `@gamemaker/gm-cli` (pinned to 2.2.0); Node 24; actions bumped to `actions/checkout@v7`, `actions/download-artifact@v8` (with `merge-multiple`), `actions/upload-artifact@v7`.
  - Stability tweaks: Linux AppArmor toggle + `ffmpeg`; macOS Xcode wait workaround; Windows YYC auto-detects Visual Studio via `vswhere` with fallback paths; mac signing identity cleared; artifact upload errors on missing files.
  - Docs: unified “Playing” instructions for Windows/Linux/macOS.

<sup>Written for commit 2639fc866e48638ceef9e4f8eb52ea2d00edec73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

