### PR TITLE
ci: Gobo format workflow

### DIFF
--- a/.github/workflows/gobo_format.yml
+++ b/.github/workflows/gobo_format.yml
@@ -1,0 +1,35 @@
+name: Gobo Formatter
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  format-all:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Download Latest Gobo Release
+        run: |
+          curl -LO https://github.com/EttyKitty/Gobo/releases/download/v1.0.0/gobo-ubuntu.zip
+          unzip gobo-ubuntu.zip
+          chmod +x ./gobo
+
+      - name: Run Formatter
+        run: |
+          ./gobo .
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "style: Automated Gobo format"
+          title: "style: Automated Gobo format"
+          body: "This is an automated PR containing formatting updates for all .gml files."
+          branch: automation/gobo-format-all
+          delete-branch: true


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a manual GitHub Actions workflow to run the `Gobo` formatter and open an automated PR with `.gml` formatting changes. Keeps formatting consistent without local setup.

- **New Features**
  - `workflow_dispatch` job on `ubuntu-latest` downloads `gobo` v1.0.0 and runs `./gobo .`.
  - Creates a PR via `peter-evans/create-pull-request@v6` on `automation/gobo-format-all` with a standard style commit/title.
  - Grants `contents` and `pull-requests` write permissions for PR creation.

<sup>Written for commit 05686f78509d33617b4f5a6bd531b91de1a74034. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

