### PR TITLE
ci: Optional build toggles; Explicit Discord step

### DIFF
--- a/.github/workflows/release_dev.yml
+++ b/.github/workflows/release_dev.yml
@@ -279,6 +279,7 @@ jobs:
             ./build_output/**/*.zip
 
       - name: Send Discord Notification
+        if: ${{ github.event.inputs.send_discord != 'false' }}
         uses: tsickert/discord-webhook-action@v7.0.0
         with:
           webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/release_dev.yml
+++ b/.github/workflows/release_dev.yml
@@ -10,6 +10,18 @@ on:
         options:
           - YYC
           - VM
+      prerelease:
+        type: boolean
+        description: "Post as a pre-release?"
+        default: false
+      make_latest:
+        type: boolean
+        description: "Mark this release as latest?"
+        default: true
+      send_discord:
+        type: boolean
+        description: "Send Discord notification?"
+        default: true
   schedule:
     - cron: "0 */6 * * *"
 
@@ -254,14 +266,28 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - id: create_release
-        name: Create a release and upload the build
+        name: Create a release and upload files
         uses: softprops/action-gh-release@v2.3.2
         with:
           name: ${{ steps.prep_release_name.outputs.release_name }}
           body: ${{steps.build_changelog.outputs.changelog}}
           token: ${{ secrets.RELEASE_TOKEN_SECRET }}
           tag_name: ${{ needs.prepare_release.outputs.tag_name }}
-          prerelease: false
-          make_latest: true
+          prerelease: ${{ github.event.inputs.prerelease || 'false' }}
+          make_latest: ${{ github.event.inputs.make_latest || 'true' }}
           files: |
             ./build_output/**/*.zip
+
+      - name: Send Discord Notification
+        uses: tsickert/discord-webhook-action@v7.0.0
+        with:
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          username: "GitHub Releases"
+          content: |
+            <@&1318332223232938014>
+            -# :warning: These builds are auto-generated. They may be **heavily unstable**, in which case try using an older build (20 exist at the same time). :warning:
+          embed-title: "${{ steps.prep_release_name.outputs.release_name }}"
+          embed-url: ${{ steps.create_release.outputs.html_url }}
+          embed-description: |
+            **Changelog:**
+            ${{ steps.build_changelog.outputs.changelog }}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add toggles to the dev release workflow and an optional Discord notification step with release details. Maintainers can control prerelease, latest, and whether to notify Discord from `workflow_dispatch`.

- **New Features**
  - Added `workflow_dispatch` inputs: `prerelease` (default false), `make_latest` (default true), `send_discord` (default true).
  - Wired `prerelease` and `make_latest` into `softprops/action-gh-release@v2.3.2`.
  - Added an optional Discord webhook step (gated by `send_discord`) using `tsickert/discord-webhook-action@v7.0.0` with role mention, release link, and changelog embed.

<sup>Written for commit e178360300bb9e08662cc6c99851691a1d63d1fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1267?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

