### PR TITLE
fix: Discord webhook action name

### DIFF
--- a/.github/workflows/release_dev.yml
+++ b/.github/workflows/release_dev.yml
@@ -280,7 +280,7 @@ jobs:
 
       - name: Send Discord Notification
         if: ${{ github.event.inputs.send_discord != 'false' }}
-        uses: tsickert/discord-webhook-action@v7.0.0
+        uses: tsickert/discord-webhook@v7.0.0
         with:
           webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL }}
           username: "GitHub Releases"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the Discord notification step in the release workflow by using the correct action `tsickert/discord-webhook@v7.0.0` instead of `tsickert/discord-webhook-action`. This restores release notifications when `send_discord` is enabled.

<sup>Written for commit 4222c543e0595523ced7aecd714b76ac2952769f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

