### PR TITLE
A pack of fixes

### DIFF
--- a/objects/obj_star_select/Draw_64.gml
+++ b/objects/obj_star_select/Draw_64.gml
@@ -283,9 +283,10 @@ try {
                         tooltip_draw(defence_data[1], 400);
                     }
 
-                    if (garrison.dispo_change > 55) {
+                    var _dispo_change = garrison.dispo_change;
+                    if (_dispo_change > 55) {
                         draw_text(xx + 20, half_way + 30, $"Garrison Disposition Effect : Positive");
-                    } else if (garrison.dispo_change > 44 || garrison.dispo_change == 0) {
+                    } else if (_dispo_change > 44 || _dispo_change == 0) {
                         draw_text(xx + 20, half_way + 30, $"Garrison Disposition Effect : Neutral");
                     } else {
                         draw_text(xx + 20, half_way + 30, $"Garrison Disposition Effect : Negative");

--- a/scripts/scr_ComplexSet/scr_ComplexSet.gml
+++ b/scripts/scr_ComplexSet/scr_ComplexSet.gml
@@ -129,6 +129,23 @@ function ComplexSet(_unit) constructor {
 
     right_arm_data = [];
 
+    hand_scratchpads = [
+        {
+            total: 0,
+            sources: [0],
+            offsets: [0],
+            source_frames: [0],
+            flip_x: false
+        },
+        {
+            total: 0,
+            sources: [0],
+            offsets: [0],
+            source_frames: [0],
+            flip_x: true
+        }
+    ];
+
     // Tracks sprites that ComplexSet owns (e.g. weapon duplicates) for cleanup
     owned_sprites = [];
 
@@ -739,7 +756,7 @@ function ComplexSet(_unit) constructor {
         }
     };
 
-    static draw_component_with_textures = function(resolved_sprite, resolved_choice, component_name) {
+    static draw_component_with_textures = function(resolved_sprite, resolved_choice, component_name, flip_x = false) {
         var _return_surface = surface_get_target();
         surface_reset_target();
         shader_reset();
@@ -786,7 +803,13 @@ function ComplexSet(_unit) constructor {
                 texture_set_stage(armour_texture_sampler, tex_texture);
                 shader_set_uniform_f_array(texture_replace_col_uniform, _tex_data.areas[t]);
 
-                draw_sprite(resolved_sprite, resolved_choice, component_final_draw_x, component_final_draw_y);
+                if (flip_x) {
+                    var _w = sprite_get_width(resolved_sprite);
+                    var _ox = sprite_get_xoffset(resolved_sprite);
+                    draw_sprite_ext(resolved_sprite, resolved_choice, component_final_draw_x + _w - _ox * 2, component_final_draw_y, -1, 1, 0, c_white, 1);
+                } else {
+                    draw_sprite(resolved_sprite, resolved_choice, component_final_draw_x, component_final_draw_y);
+                }
             }
         }
 
@@ -797,22 +820,25 @@ function ComplexSet(_unit) constructor {
         shader_set(full_livery_shader);
         set_component_shadow_packs(component_name, resolved_original_choice, resolved_sprite, resolved_choice);
 
-        draw_sprite(resolved_sprite, resolved_choice ?? 0, component_final_draw_x, component_final_draw_y);
+        if (flip_x) {
+            var _w = sprite_get_width(resolved_sprite);
+            var _ox = sprite_get_xoffset(resolved_sprite);
+            draw_sprite_ext(resolved_sprite, resolved_choice ?? 0, component_final_draw_x + _w - _ox * 2, component_final_draw_y, -1, 1, 0, c_white, 1);
+        } else {
+            draw_sprite(resolved_sprite, resolved_choice ?? 0, component_final_draw_x, component_final_draw_y);
+        }
         draw_surface(global.base_component_surface, 0, 0);
     };
 
     // Main function
-    static draw_component = function(component_name, texture_draws = {}, choice_lock = -1) {
+    static draw_component = function(component_name, texture_draws = undefined, choice_lock = -1) {
+        texture_draws ??= {};
         if (array_contains(banned, component_name)) {
             return "banned component";
         }
         if (struct_exists(self, component_name)) {
             shadow_enabled = 0;
             current_texture_draws = texture_draws;
-
-            if (!struct_exists(self, component_name)) {
-                return "error failed no sprite found";
-            }
 
             component_final_draw_x = x_surface_offset;
             component_final_draw_y = y_surface_offset;
@@ -851,16 +877,19 @@ function ComplexSet(_unit) constructor {
                 var _ox = sprite_get_xoffset(_resolved.sprite);
                 draw_sprite_ext(_resolved.sprite, _resolved.frame ?? 0, component_final_draw_x + _w - _ox * 2, component_final_draw_y, -1, 1, 0, c_white, 1);
             } else if (array_length(_tex_names) > 0) {
-                draw_component_with_textures(_resolved.sprite, _resolved.frame, component_name);
+                draw_component_with_textures(_resolved.sprite, _resolved.frame, component_name, _flip_x);
             } else {
                 draw_sprite(_resolved.sprite, _resolved.frame ?? 0, component_final_draw_x, component_final_draw_y);
             }
 
             handle_component_subcomponents(component_name, _choice);
+        } else {
+            return "error failed no sprite found";
         }
     };
 
-    static draw_unit_arms = function() {
+    static draw_unit_arms = function(texture_draws = undefined) {
+        texture_draws ??= {};
         var _bionic_options = [];
         if (array_contains([eARMOUR_TYPE.NORMAL, eARMOUR_TYPE.TERMINATOR, eARMOUR_TYPE.SCOUT], armour_type)) {
             for (var _right_left = 0; _right_left <= 1; _right_left++) {
@@ -906,12 +935,13 @@ function ComplexSet(_unit) constructor {
                 if (array_length(_bio)) {
                     replace_area(_arm_string, _bio[_right_left]);
                 }
-                draw_component(_arm_string);
+                draw_component(_arm_string, texture_draws);
             }
         }
     };
 
-    static draw_unit_hands = function(right_left) {
+    static draw_unit_hands = function(right_left, texture_draws = undefined) {
+        texture_draws ??= {};
         var _arm_data = arms_data[right_left];
         if (_arm_data.arm_type == 1) {
             return;
@@ -921,44 +951,86 @@ function ComplexSet(_unit) constructor {
         if (armour_type != eARMOUR_TYPE.NONE) {
             var offset_x = x_surface_offset;
             var offset_y = y_surface_offset;
+            var _hand_spr = spr_pa_hands;
             switch (armour_type) {
                 case eARMOUR_TYPE.TERMINATOR:
-                    var _hand_spr = spr_terminator_hands;
+                    _hand_spr = spr_terminator_hands;
                     break;
                 case eARMOUR_TYPE.SCOUT:
-                    var _hand_spr = spr_pa_hands;
+                    _hand_spr = spr_pa_hands;
                     offset_y += 11;
                     offset_x += _arm_data.ui_xmod;
                     break;
                 default:
                 case eARMOUR_TYPE.NORMAL:
-                    var _hand_spr = spr_pa_hands;
+                    _hand_spr = spr_pa_hands;
                     break;
             }
             if (_hand > 0) {
                 var _spr_index = (_hand - 1) * 2;
-                if (right_left == 1) {
-                    draw_sprite_flipped(_hand_spr, _spr_index, offset_x, offset_y);
+                var _hand_string = right_left == 0 ? "right_hand" : "left_hand";
+                var _old_x = x_surface_offset;
+                var _old_y = y_surface_offset;
+                x_surface_offset = offset_x;
+                y_surface_offset = offset_y;
+                
+                var _old_hand_struct = struct_exists(self, _hand_string) ? self[$ _hand_string] : undefined;
+
+                var _scratchpad = hand_scratchpads[right_left];
+                var _num_frames = sprite_get_number(_hand_spr);
+                _scratchpad.total = _num_frames;
+                _scratchpad.sources[0] = _hand_spr;
+                _scratchpad.source_frames[0] = _num_frames;
+                _scratchpad.flip_x = (right_left == 1);
+                
+                self[$ _hand_string] = _scratchpad;
+                draw_component(_hand_string, texture_draws, _spr_index);
+                
+                if (_old_hand_struct == undefined) {
+                    struct_remove(self, _hand_string);
                 } else {
-                    draw_sprite(_hand_spr, _spr_index, offset_x, offset_y);
+                    self[$ _hand_string] = _old_hand_struct;
                 }
+                x_surface_offset = _old_x;
+                y_surface_offset = _old_y;
             }
             // Draw bionic hands
             if (_hand == 1) {
                 if (armour_type == eARMOUR_TYPE.NORMAL && !hide_bionics && struct_exists(body[$ (right_left == 0 ? "right_arm" : "left_arm")], "bionic")) {
                     var bionic_hand = body[$ (right_left == 0 ? "right_arm" : "left_arm")][$ "bionic"];
                     var bionic_spr_index = bionic_hand.variant * 2;
-                    if (right_left == 1) {
-                        draw_sprite_flipped(spr_bionics_hand, 0, offset_x, offset_y);
+                    var _bionic_hand_string = right_left == 0 ? "right_hand" : "left_hand";
+                    var _old_x = x_surface_offset;
+                    var _old_y = y_surface_offset;
+                    x_surface_offset = offset_x;
+                    y_surface_offset = offset_y;
+                    
+                    var _old_bionic_struct = struct_exists(self, _bionic_hand_string) ? self[$ _bionic_hand_string] : undefined;
+
+                    var _scratchpad = hand_scratchpads[right_left];
+                    var _num_frames = sprite_get_number(spr_bionics_hand);
+                    _scratchpad.total = _num_frames;
+                    _scratchpad.sources[0] = spr_bionics_hand;
+                    _scratchpad.source_frames[0] = _num_frames;
+                    _scratchpad.flip_x = (right_left == 1);
+
+                    self[$ _bionic_hand_string] = _scratchpad;
+                    draw_component(_bionic_hand_string, texture_draws, bionic_spr_index);
+                    
+                    if (_old_bionic_struct == undefined) {
+                        struct_remove(self, _bionic_hand_string);
                     } else {
-                        draw_sprite(spr_bionics_hand, 0, offset_x, offset_y);
+                        self[$ _bionic_hand_string] = _old_bionic_struct;
                     }
+                    x_surface_offset = _old_x;
+                    y_surface_offset = _old_y;
                 }
             }
         }
     };
 
-    static draw_weapon_and_hands = function() {
+    static draw_weapon_and_hands = function(texture_draws = undefined) {
+        texture_draws ??= {};
         if (armour_type == eARMOUR_TYPE.DREADNOUGHT) {
             if ((weapon_right.sprite != 0) && sprite_exists(weapon_right.sprite)) {
                 draw_sprite(weapon_right.sprite, 0, x_surface_offset + weapon_right.ui_xmod, y_surface_offset + weapon_right.ui_ymod);
@@ -973,7 +1045,7 @@ function ComplexSet(_unit) constructor {
             for (var i = 0; i <= 1; i++) {
                 var _arm_data = arms_data[i];
                 if (!_arm_data.hand_on_top) {
-                    draw_unit_hands(i);
+                    draw_unit_hands(i, texture_draws);
                 }
             }
         }
@@ -983,36 +1055,37 @@ function ComplexSet(_unit) constructor {
         if (!weapon_right.single_left_right_profile) {
             if ((weapon_right.sprite != 0) && sprite_exists(weapon_right.sprite)) {
                 if ((weapon_right.ui_twoh == false && weapon_left.ui_twoh == false) || weapon_right.ui_twoh == true) {
-                    draw_weapon(weapon_right, "right_weapon", 0);
+                    draw_weapon(weapon_right, "right_weapon", 0, texture_draws);
                 }
             }
         } else {
             if ((weapon_right.sprite != 0) && sprite_exists(weapon_right.sprite)) {
-                draw_weapon(weapon_right, "right_weapon");
+                draw_weapon(weapon_right, "right_weapon", -1, texture_draws);
             }
         }
 
         if (!weapon_left.single_left_right_profile) {
             if ((weapon_left.sprite != 0) && sprite_exists(weapon_left.sprite) && (weapon_right.ui_twoh == false)) {
-                draw_weapon(weapon_left, "left_weapon", 1);
+                draw_weapon(weapon_left, "left_weapon", 1, texture_draws);
             }
         } else {
             if ((weapon_left.sprite != 0) && sprite_exists(weapon_left.sprite) && (weapon_right.ui_twoh == false)) {
                 weapon_left.flip_x = true;
-                draw_weapon(weapon_left, "left_weapon");
+                draw_weapon(weapon_left, "left_weapon", -1, texture_draws);
             }
         }
         if (!weapon_right.ui_twoh && !weapon_left.ui_twoh) {
             for (var i = 0; i <= 1; i++) {
                 var _arm_data = arms_data[i];
                 if (_arm_data.hand_on_top) {
-                    draw_unit_hands(i);
+                    draw_unit_hands(i, texture_draws);
                 }
             }
         }
     };
 
-    static draw_weapon = function(weapon, position, choice_lock = -1) {
+    static draw_weapon = function(weapon, position, choice_lock = -1, texture_draws = undefined) {
+        texture_draws ??= {};
         x_surface_offset += weapon.ui_xmod;
         y_surface_offset += weapon.ui_ymod;
 
@@ -1031,7 +1104,7 @@ function ComplexSet(_unit) constructor {
             }
         }
 
-        draw_component(position, {}, choice_lock);
+        draw_component(position, texture_draws, choice_lock);
 
         x_surface_offset -= weapon.ui_xmod;
         y_surface_offset -= weapon.ui_ymod;
@@ -1165,7 +1238,7 @@ function ComplexSet(_unit) constructor {
                 _arm.ui_ymod += 11;
             }
         }
-        draw_unit_arms();
+        draw_unit_arms(_texture_draws);
         var _complex_helm = false;
         var unit_role = unit.role();
         var _role = active_roles();
@@ -1266,7 +1339,7 @@ function ComplexSet(_unit) constructor {
             }
         }
         purity_seals_and_hangings();
-        draw_weapon_and_hands();
+        draw_weapon_and_hands(_texture_draws);
 
         shader_reset();
         surface_reset_target();

--- a/scripts/scr_complex_colour_kit/scr_complex_colour_kit.gml
+++ b/scripts/scr_complex_colour_kit/scr_complex_colour_kit.gml
@@ -120,7 +120,7 @@ function setup_complex_livery_shader(setup_role, unit = "none") {
                     continue;
                 }
                 var _colour = data_set[$ spot_names[i]];
-                if (_colour == -1) {
+                if (_colour == -1 || is_array(_colour)) {
                     continue;
                 }
                 if (!array_contains(_distinct_colours, _colour)) {
@@ -129,9 +129,11 @@ function setup_complex_livery_shader(setup_role, unit = "none") {
             }
             var _choice = 0;
             if (array_length(_distinct_colours)) {
-                var _choice = cloth_variation % array_length(_distinct_colours);
+                _choice = cloth_variation % array_length(_distinct_colours);
+                set_complex_shader_area(["robes_colour_replace"], _distinct_colours[_choice]);
+            } else {
+                shader_set_uniform_f_array(shader_get_uniform(full_livery_shader, "robes_colour_replace"), cloth_col);
             }
-            set_complex_shader_area(["robes_colour_replace"], _distinct_colours[_choice]);
         } else {
             shader_set_uniform_f_array(shader_get_uniform(full_livery_shader, "robes_colour_replace"), cloth_col);
         }

--- a/scripts/scr_complex_colour_kit/scr_complex_colour_kit.gml
+++ b/scripts/scr_complex_colour_kit/scr_complex_colour_kit.gml
@@ -186,6 +186,16 @@ function setup_complex_livery_shader(setup_role, unit = "none") {
             0,
             128 / 255
         ],
+        right_thorax: [
+            0,
+            0.75,
+            0
+        ],
+        left_thorax: [
+            0,
+            0,
+            0.75
+        ],
         right_trim: [
             0,
             128 / 255,

--- a/scripts/scr_creation_draw_slides/scr_creation_draw_slides.gml
+++ b/scripts/scr_creation_draw_slides/scr_creation_draw_slides.gml
@@ -465,6 +465,7 @@ function draw_chapter_trait_select() {
         if (custom != eCHAPTER_TYPE.CUSTOM) {
             draw_set_alpha(0.5);
         }
+        chapter_type_radio.allow_changes = (custom == eCHAPTER_TYPE.CUSTOM);
         chapter_type_radio.draw();
         fleet_type = chapter_type_radio.current_selection + 1;
 

--- a/scripts/scr_garrison/scr_garrison.gml
+++ b/scripts/scr_garrison/scr_garrison.gml
@@ -256,7 +256,7 @@ function GarrisonForce(system, planet, type = "garrison") constructor {
             }  else {
                 _charisma_test = [bool(irandom(1)), irandom_range(0, 25)];
             }
-            var dispo_change = _charisma_test[1] / 10;
+            dispo_change = _charisma_test[1] / 10;
             if (!_charisma_test[0]) {
                 if (_diplomatic_leader) {
                     dispo_change = 0;

--- a/scripts/scr_mission_functions/scr_mission_functions.gml
+++ b/scripts/scr_mission_functions/scr_mission_functions.gml
@@ -141,8 +141,8 @@ function problem_end_turn_checks(){
                 return;
             }            
             var _alert_text = "Inquisition Mission Failed: Investigate ";
-            var _disp_string = alter_disposition(eFACTION.INQUISITION, -5);
-            _alert_text += $"{name()}. {_disp_string}";
+            alter_disposition(eFACTION.INQUISITION, -5);
+            _alert_text += $"{name()}.";
             scr_alert("red", "mission_failed", _alert_text, 0, 0);
             scr_event_log("red", _alert_text);
             remove_problem("recon");            
@@ -174,11 +174,11 @@ function problem_end_turn_checks(){
                 scr_event_log("", "Fleet embarks upon Crusade.");
             } else {
                 // hit loyalty here
-                var _disp_hits = alter_dispositions([
+                alter_dispositions([
                     [eFACTION.INQUISITION , -10],
                     [eFACTION.IMPERIUM, -5],
-                ])
-                var _string = "No ships designated for Crusade. {_disp_hits}"
+                ]);
+                var _string = $"No ships designated for Crusade.";
                 if (obj_controller.penitent == 1) {
                     obj_controller.penitent_current = 0;
                     _string += "Your penitence crusade has been lengthened for your failings";
@@ -196,8 +196,8 @@ function problem_end_turn_checks(){
             }
             var _alert_text = "The Necron Tomb of planet ";
 
-            var _disp_string = alter_disposition(eFACTION.INQUISITION, -8);
-            _alert_text += $"{numeral_name} has not been deactivated in time.  It has awakened, rank upon rank of Necrons pouring out to the planet's surface.  The Inquisition is not pleased with your failure. {_disp_string}";
+            alter_disposition(eFACTION.INQUISITION, -8);
+            _alert_text += $"{numeral_name} has not been deactivated in time.  It has awakened, rank upon rank of Necrons pouring out to the planet's surface.  The Inquisition is not pleased with your failure.";
             scr_popup("Inquisition Mission Failed", _alert_text, "necron_army", "");
             scr_event_log("red", $"Inquisition Mission Failed: Bombing run failed; the Necron Tomb on {name()} has become active.");
 
@@ -214,8 +214,8 @@ function problem_end_turn_checks(){
                 return;
             }
             var _planet_name = name();
-            var _disp_string = alter_disposition(eFACTION.INQUISITION, -3);
-            var _alert_text = $"The Spyrer on {_planet_name} has been left unchecked.  In the ensuing carnage some high-ranking officials have been killed, along with several Nobles.  Panic is running amock in several parts of the hives and the Inquisition is less than pleased.{_disp_string}";
+            alter_disposition(eFACTION.INQUISITION, -3);
+            var _alert_text = $"The Spyrer on {_planet_name} has been left unchecked.  In the ensuing carnage some high-ranking officials have been killed, along with several Nobles.  Panic is running amock in several parts of the hives and the Inquisition is less than pleased.";
             var _text = "Inquisition Mission Failed: The Spyrer on {_planet_name} was not removed.";
             scr_popup("Inquisition Mission Failed", _alert_text, "spyrer", "");
             scr_event_log("red", _text);

--- a/scripts/scr_zoom/scr_zoom.gml
+++ b/scripts/scr_zoom/scr_zoom.gml
@@ -63,17 +63,19 @@ function scr_zoom_keys() {
         var old_y = camera_get_view_y(view_camera[0]);
         var old_w = camera_get_view_width(view_camera[0]);
         var old_h = camera_get_view_height(view_camera[0]);
-        var zoom_factor = 1 - zoom_speed * zoom_delta;
-        var new_w = old_w * zoom_factor;
-        var new_h = old_h * zoom_factor;
-        camera_set_view_size(view_camera[0], new_w, new_h);
-        var new_x = mouse_x_ - (mouse_x_ - old_x) * (new_w / old_w);
-        var new_y = mouse_y_ - (mouse_y_ - old_y) * (new_h / old_h);
-        camera_set_view_pos(view_camera[0], new_x, new_y)
+        if (old_w > 0 && old_h > 0) {
+            var zoom_factor = 1 - zoom_speed * zoom_delta;
+            var new_w = old_w * zoom_factor;
+            var new_h = old_h * zoom_factor;
+            camera_set_view_size(view_camera[0], new_w, new_h);
+            var new_x = mouse_x_ - (mouse_x_ - old_x) * (new_w / old_w);
+            var new_y = mouse_y_ - (mouse_y_ - old_y) * (new_h / old_h);
+            camera_set_view_pos(view_camera[0], new_x, new_y)
 
-        // update obj_controller as the new center of the view
-        obj_controller.x = new_x + new_w / 2;
-        obj_controller.y = new_y + new_h / 2;
+            // update obj_controller as the new center of the view
+            obj_controller.x = new_x + new_w / 2;
+            obj_controller.y = new_y + new_h / 2;
+        }
         camera_set_view_target(view_camera[0], old_target);
     }
 

--- a/shaders/full_livery_shader/full_livery_shader.fsh
+++ b/shaders/full_livery_shader/full_livery_shader.fsh
@@ -174,6 +174,7 @@ void main() {
 
     vec4 col = col_orig;
 
+    //! Thorax is not here, because it crashes shader compilation for unknown reason
     // === Existing replacement logic ===
     if (col.rgb == vec3(0.0, 0.0, _128COL).rgb) {
         col.rgb = left_head.rgb;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds texture-overlay support and horizontal flipping for hands, arms, and weapons in the `ComplexSet` renderer, with a small hand scratchpad cache to reduce allocations. Also fixes shader color setup, creation UI controls, zoom stability, and disposition display/updates.

- **New Features**
  - Hands, arms, and weapons render via `draw_component` with `texture_draws`, `flip_x`, and choice lock; texture draws pass through `draw_unit_arms`, `draw_unit_hands`, `draw_weapon_and_hands`, and `draw_weapon`.
  - Hand draws reuse per-side scratchpads; `draw_component_with_textures` flips correctly; `draw_component` accepts undefined `texture_draws` and reports missing sprites.

- **Bug Fixes**
  - Color kit: skip array values; add `right_thorax`/`left_thorax` swaps; fall back to `cloth_col` for robes; shader comment notes thorax exclusion.
  - Creation UI: chapter type radio is disabled unless the chapter is custom.
  - Zoom: guard zoom math when view size is zero.
  - Disposition/messaging: fix `GarrisonForce` `dispo_change`; star select reads a cached value for stable text; mission failure alerts apply disposition changes without embedding return strings.

<sup>Written for commit e166267543cb889a4435ab20a3a91e67fe8c0c54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

