### PR TITLE
ci: Add save breaking changelog section

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -245,6 +245,10 @@ jobs:
               },
               "categories": [
                 {
+                    "title": "### Save Breaking!",
+                    "labels": ["feat"]
+                },
+                {
                     "title": "### Features",
                     "labels": ["feat"]
                 },
@@ -262,6 +266,12 @@ jobs:
                   "pattern": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|merge){1}(\\([\\w\\-\\.]+\\))?(!)?: ([\\w ])+([\\s\\S]*)",
                   "on_property": "title",
                   "target": "$1"
+                },
+                {
+                  "pattern": "^(breaking.*:|.*!.*:).*",
+                  "on_property": "title",
+                  "target": "breaking",
+                  "flags": "i"
                 }
               ]
             }

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -246,7 +246,7 @@ jobs:
               "categories": [
                 {
                     "title": "### Save Breaking!",
-                    "labels": ["feat"]
+                    "labels": ["breaking"]
                 },
                 {
                     "title": "### Features",

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -263,7 +263,7 @@ jobs:
               ],
               "label_extractor": [
                 {
-                  "pattern": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|merge){1}(\\([\\w\\-\\.]+\\))?(!)?: ([\\w ])+([\\s\\S]*)",
+                  "pattern": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|merge){1}(\\([\\w\\-\\.]+\\))?: ([\\w ])+([\\s\\S]*)",
                   "on_property": "title",
                   "target": "$1"
                 },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updates the release notes workflow to add a "### Save Breaking!" section and map titles with "breaking:" or a "!" (Conventional Commits) to the `breaking` category. Tweaks the label extractor to avoid double entries (don’t assign type labels to `feat!`/`fix!` etc) and fixes the label name.

<sup>Written for commit 984b635a0a1fc264c43a6cf850fb1a0d9f66c117. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

