### PR TITLE
ci: Fix the release URL (I hope)

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -303,4 +303,4 @@ jobs:
           embed-title: "[${{ needs.prepare_release.outputs.release_name }}](${{ steps.create_release.outputs.url }})"
           embed-description: |
             ${{ steps.build_changelog.outputs.changelog }}
-          embed-footer-text: "Download: ${{ steps.create_release.outputs.outputs.url }}" 
+          embed-footer-text: "Download: ${{ steps.create_release.outputs.url }}"

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -300,7 +300,7 @@ jobs:
           content: |
             <@&1318332223232938014>
             -# :warning: These builds are auto-generated. They may be **heavily unstable**, in which case try using an older build (20 exist at the same time). :warning:
-          embed-title: "[${{ needs.prepare_release.outputs.release_name }}](${{ steps.create_release.outputs.html_url }})"
+          embed-title: "[${{ needs.prepare_release.outputs.release_name }}](${{ steps.create_release.outputs.url }})"
           embed-description: |
             ${{ steps.build_changelog.outputs.changelog }}
-          embed-footer-text: "Download: ${{ steps.create_release.outputs.html_url }}" 
+          embed-footer-text: "Download: ${{ steps.create_release.outputs.outputs.url }}" 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes broken release links in the workflow’s Discord embed by using `steps.create_release.outputs.url` instead of `steps.create_release.outputs.html_url`. The embed title and footer now link to the correct GitHub release.

<sup>Written for commit 7f07f0d7489a59cbf82ba22cfb5722e05d0ef37a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

