### PR TITLE
Merge branch development into main

### DIFF
--- a/ChapterMaster.yyp
+++ b/ChapterMaster.yyp
@@ -919,6 +919,7 @@
     {"id":{"name":"scr_shader_initialize","path":"scripts/scr_shader_initialize/scr_shader_initialize.yy",},},
     {"id":{"name":"scr_ship_battle","path":"scripts/scr_ship_battle/scr_ship_battle.yy",},},
     {"id":{"name":"scr_ship_count","path":"scripts/scr_ship_count/scr_ship_count.yy",},},
+    {"id":{"name":"scr_ship_functions","path":"scripts/scr_ship_functions/scr_ship_functions.yy",},},
     {"id":{"name":"scr_ship_occupants","path":"scripts/scr_ship_occupants/scr_ship_occupants.yy",},},
     {"id":{"name":"scr_shoot","path":"scripts/scr_shoot/scr_shoot.yy",},},
     {"id":{"name":"scr_special_view","path":"scripts/scr_special_view/scr_special_view.yy",},},

--- a/objects/obj_al_ship/Draw_0.gml
+++ b/objects/obj_al_ship/Draw_0.gml
@@ -1,17 +1,8 @@
 if (name != "") {
     draw_self();
 
-    draw_set_color(CM_GREEN_COLOR);
     draw_set_font(fnt_info);
     draw_set_halign(fa_center);
 
-    if (maxhp != 0) {
-        var _value = shields <= 0 ? hp / maxhp : shields / maxshields;
-
-        if (obj_controller.zoomed == 0) {
-            draw_text(x, y - sprite_height, string_hash_to_newline(string(floor(_value * 100)) + "%"));
-        } else {
-            draw_text_transformed(x, y - sprite_height, string_hash_to_newline(string(floor(_value * 100)) + "%"), 2, 2, 0);
-        }
-    }
+    draw_ship_status_overlay(self, CM_GREEN_COLOR, COL_REQUISITION);
 }

--- a/objects/obj_en_ship/Draw_0.gml
+++ b/objects/obj_en_ship/Draw_0.gml
@@ -15,21 +15,11 @@ if (name != "") {
         scr_bolt(x - 1, y + 1, target.x - 1, target.y + 1, 0);
     }
 
-    draw_set_color(CM_GREEN_COLOR);
-
     if (class == "Battlekroozer") {
         draw_sprite_ext(sprite_index, 0, x, y, 0.75, 0.75, direction, c_white, 1);
     } else {
         draw_self();
     }
 
-    if (maxhp != 0) {
-        var _value = shields <= 0 ? hp / maxhp : shields / maxshields;
-
-        if (obj_controller.zoomed == 0) {
-            draw_text(x, y - sprite_height, string_hash_to_newline(string(floor(_value * 100)) + "%"));
-        } else {
-            draw_text_transformed(x, y - sprite_height, string_hash_to_newline(string(floor(_value * 100)) + "%"), 2, 2, 0);
-        }
-    }
+    draw_ship_status_overlay(self, CM_GREEN_COLOR, COL_REQUISITION);
 }

--- a/objects/obj_fleet/Create_0.gml
+++ b/objects/obj_fleet/Create_0.gml
@@ -20,7 +20,6 @@ view_y = obj_controller.y;
 obj_controller.x = 0;
 obj_controller.y = 240;
 obj_controller.combat = 1;
-is_zoomed = obj_controller.zoomed;
 start = 0;
 combat_end = 170;
 
@@ -29,6 +28,11 @@ if (obj_controller.zoomed == 0) {
         scr_zoom();
     }
 }
+
+var _surface_h = surface_get_height(application_surface);
+speed_button = new SpriteButton({sprite: spr_fast_forward, x1: 10, y1: _surface_h / 2});
+original_speed = game_get_speed(gamespeed_fps);
+speed_mode = 0;
 
 enemy = 0;
 enemy_status = "attacking";

--- a/objects/obj_fleet/Draw_64.gml
+++ b/objects/obj_fleet/Draw_64.gml
@@ -49,11 +49,8 @@ if (start == 0) {
     draw_text(_begin_x, _begin_y, _begin_text);
 }
 
-// fast forward icon
-if (game_get_speed(gamespeed_fps) != 90 && start == 5) {
-    draw_set_alpha(1);
-    var _ff_h = sprite_get_height(spr_fast_forward);
-    draw_sprite(spr_fast_forward, 0, 12, (_surface_h / 2) - (_ff_h / 2));
+if (start == 5) {
+    speed_button.draw();
 }
 
 // battle stat box

--- a/objects/obj_fleet/KeyPress_32.gml
+++ b/objects/obj_fleet/KeyPress_32.gml
@@ -1,6 +1,0 @@
-if (obj_controller.cooldown <= 0) {
-    obj_controller.cooldown = 8;
-    with (obj_controller) {
-        scr_zoom();
-    }
-}

--- a/objects/obj_fleet/Mouse_56.gml
+++ b/objects/obj_fleet/Mouse_56.gml
@@ -37,15 +37,3 @@ if (instance_exists(obj_p_ship) && (control == 1)) {
         sel_y2 = 0;
     }
 }
-
-//Why is this here?
-if ((start == 5) && (obj_controller.zoomed == 0)) {
-    if ((mouse_x >= camera_get_view_x(view_camera[0]) + 12) && (mouse_y >= camera_get_view_y(view_camera[0]) + 436) && (mouse_x < camera_get_view_x(view_camera[0]) + 48) && (mouse_y < camera_get_view_y(view_camera[0]) + 480) && (game_get_speed(gamespeed_fps) < 90)) {
-        game_set_speed(game_get_speed(gamespeed_fps) + 30, gamespeed_fps);
-    }
-}
-if ((start == 5) && (obj_controller.zoomed == 1)) {
-    if ((mouse_x > 24) && (mouse_y > 872) && (mouse_x < 90) && (mouse_y < 960) && (game_get_speed(gamespeed_fps) < 90)) {
-        game_set_speed(game_get_speed(gamespeed_fps) + 30, gamespeed_fps);
-    }
-}

--- a/objects/obj_fleet/Step_0.gml
+++ b/objects/obj_fleet/Step_0.gml
@@ -56,4 +56,15 @@ if (start == 5) {
             }
         }
     }
+
+    if (speed_button.is_clicked) {
+        speed_mode = (speed_mode + 1) % 3;
+        var new_speed = 0;
+        if (speed_mode == 0) {
+            new_speed = original_speed;
+        } else {
+            new_speed = original_speed + 30 * speed_mode;
+        }
+        game_set_speed(new_speed, gamespeed_fps);
+    }
 }

--- a/objects/obj_fleet_select/Create_0.gml
+++ b/objects/obj_fleet_select/Create_0.gml
@@ -184,8 +184,8 @@ selection_window.inside_method = function() {
                         }
                     }
                 }
-                if (obj_ini.ship_maxhp[current_ship] > 0) {
-                    ship_health = round((obj_ini.ship_hp[current_ship] / obj_ini.ship_maxhp[current_ship]) * 100);
+                if (obj_ini.ship_maxhp[full_id] > 0) {
+                    ship_health = round((obj_ini.ship_hp[full_id] / obj_ini.ship_maxhp[full_id]) * 100);
                 }
 
                 if (ship_select == 0) {

--- a/objects/obj_p_fleet/Alarm_1.gml
+++ b/objects/obj_p_fleet/Alarm_1.gml
@@ -6,11 +6,7 @@ try {
         exit;
     } else if (action == "") {
         var spid = instance_nearest(x, y, obj_star);
-        spid.present_fleet[1] += 1;
-        if (spid.vision == 0) {
-            spid.vision = 1;
-        }
-        orbiting = spid;
+        set_fleet_orbiting(self, spid);
 
         if ((orbiting != noone) && instance_exists(orbiting)) {
             if (orbiting.visited == 0) {

--- a/objects/obj_p_ship/Draw_0.gml
+++ b/objects/obj_p_ship/Draw_0.gml
@@ -34,7 +34,6 @@ if (name != "") {
     draw_self();
 
     shader_reset();
-    draw_set_color(CM_GREEN_COLOR);
     draw_set_font(fnt_info);
     draw_set_halign(fa_center);
 
@@ -42,25 +41,10 @@ if (name != "") {
         // draw_sprite(spr_force_icon,0,x-16,y+12);
         scr_image("ui/force", 1, x - 16 - 32, y + 12 - 32, 64, 64);
 
-        draw_set_color(0);
-        draw_text(x - 16, y + 12, string_hash_to_newline(string(boarders)));
-        draw_text(x - 16 - 1, y + 12 - 1, string_hash_to_newline(string(boarders)));
-        draw_text(x - 16 + 1, y + 12 + 1, string_hash_to_newline(string(boarders)));
-        draw_text(x - 16 + 1, y + 12, string_hash_to_newline(string(boarders)));
-        draw_set_color(c_white);
-        draw_text(x - 16, y + 12, string_hash_to_newline(string(boarders)));
+        draw_text_outline(x - 16, y + 12, boarders,,c_white);
     }
-    draw_set_color(CM_GREEN_COLOR);
 
-    if (maxhp != 0) {
-        var _value = shields <= 0 ? hp / maxhp : shields / maxshields;
-
-        if (obj_controller.zoomed == 0) {
-            draw_text(x, y - sprite_height, string_hash_to_newline(string(floor(_value * 100)) + "%"));
-        } else {
-            draw_text_transformed(x, y - sprite_height, string_hash_to_newline(string(floor(_value * 100)) + "%"), 2, 2, 0);
-        }
-    }
+    draw_ship_status_overlay(self, CM_GREEN_COLOR, COL_REQUISITION);
 
     if (master_present != 0) {
         draw_sprite_ext(spr_popup_select, 0, x, y, 2, 2, 0, c_white, 1);

--- a/objects/obj_popup/Create_0.gml
+++ b/objects/obj_popup/Create_0.gml
@@ -120,14 +120,14 @@ company_promote_data = [
     } //10th company
 ];
 
-role_name = array_create(11, "");
-role_exp = array_create(11, 0);
+role_name = array_create(12, "");
+role_exp = array_create(12, 0);
 
 // TODO: connect this logic with the other_manage_data() to reduce verboseness;
 get_unit_promotion_options = function() {
     var spec = 0;
-    role_name = array_create(11, "");
-    role_exp = array_create(11, 0);
+    array_set_value(role_name, "");
+    array_set_value(role_exp, 0);
     var i = 0;
     // this area does the required exp for roles per company
     if (unit_role == obj_ini.role[100][16]) {

--- a/objects/obj_turn_end/Mouse_56.gml
+++ b/objects/obj_turn_end/Mouse_56.gml
@@ -23,6 +23,12 @@ if (!instance_exists(obj_saveload) && !instance_exists(obj_popup) && !instance_e
 
         if ((mouse_x >= xxx + 272) && (mouse_y >= yyy + 354) && (mouse_x < xxx + 399) && (mouse_y < yyy + 389)) {
             // Fight fight fight, space
+            var _battle_fleet = battle_pobject[current_battle];
+            if (_battle_fleet.capital_number + _battle_fleet.frigate_number + _battle_fleet.escort_number <= 0) {
+                alarm[4] = 1;
+                exit;
+            }
+
             obj_controller.cooldown = 8000;
             instance_activate_all();
 

--- a/scripts/Armamentarium/Armamentarium.gml
+++ b/scripts/Armamentarium/Armamentarium.gml
@@ -1,4 +1,6 @@
-#macro SHOP_SELL_MOD 0.8
+#macro SHOP_SELL_MOD 0.5
+#macro SHOP_BUY_MIN_MOD 0.5
+#macro SHOP_SELL_MIN_MOD 0.1
 #macro ROGUE_TRADER_DISCOUNT 0.8
 #macro SHOP_FORGE_MOD 6
 #macro WAR_PENALTY 0.5
@@ -22,6 +24,7 @@ function ShopItem(_name) constructor {
     value = 0;
 
     buy_cost = 0;
+    sell_cost = 0;
     buyable = true;
     buy_cost_mod = 1;
     best_seller = "unknown";
@@ -95,7 +98,12 @@ function ShopItem(_name) constructor {
             forge_cost_mod = _forge_mod;
             forge_cost = round(value * SHOP_FORGE_MOD * forge_cost_mod);
         } else {
-            buy_cost = round(value * buy_cost_mod);
+            var _min_buy_cost = round(value * SHOP_BUY_MIN_MOD);
+            buy_cost = max(round(value * buy_cost_mod), _min_buy_cost);
+            var _sell_mod = SHOP_SELL_MOD * (2.0 - buy_cost_mod);
+            _sell_mod = clamp(_sell_mod, SHOP_SELL_MIN_MOD, 1.0);
+            sell_cost = round(value * _sell_mod);
+            sell_cost = min(sell_cost, buy_cost);
         }
     };
 
@@ -823,15 +831,14 @@ function Armamentarium(_controller) constructor {
     /// @desc Sells an item back to the market.
     /// @param {Struct.ShopItem} _item The item to sell.
     /// @param {real} _count Quantity to sell.
-    /// @param {real} _modifier Price multiplier for selling.
     /// @returns {bool} Success of the transaction.
-    static _sell_item = function(_item, _count, _modifier) {
+    static _sell_item = function(_item, _count) {
         if (_item.stocked < 1) {
             return false;
         }
 
         var _sold_count = min(_item.stocked, _count);
-        var _sell_price = round((_item.value * _modifier) * _sold_count);
+        var _sell_price = _item.sell_cost * _sold_count;
 
         scr_add_item(_item.name, -_sold_count, "standard");
         _item.stocked -= _sold_count;
@@ -1049,15 +1056,15 @@ function Armamentarium(_controller) constructor {
         var _can_sell = !array_contains(["ships", "vehicles"], shop_type) && _item.stocked > 0;
 
         sell_button.update({
-            tooltip_text : $"Sell for {round(_item.value * SHOP_SELL_MOD)} (x{SHOP_SELL_MOD} of value)",
+            tooltip_text : $"Sell for {_item.sell_cost * min(_item.stocked, _count)}",
             x1 : 1480,
             y1 : _y + 2
-        })
+        });
 
         sell_button.draw(_can_sell);
 
         if (sell_button.is_clicked) {
-            _sell_item(_item, _count, SHOP_SELL_MOD);
+            _sell_item(_item, _count);
         }
 
         draw_set_alpha(1);

--- a/scripts/Armamentarium/Armamentarium.gml
+++ b/scripts/Armamentarium/Armamentarium.gml
@@ -150,7 +150,7 @@ function ShopItem(_name) constructor {
     static _get_tech_display_name = function(_tech_key) {
         static _name_cache = {};
 
-        if (variable_struct_exists(_name_cache, _tech_key)) {
+        if (struct_exists(_name_cache, _tech_key)) {
             return _name_cache[$ _tech_key];
         }
 
@@ -253,7 +253,7 @@ function STCResearchPanel(_controller_ref, _on_change_callback) constructor {
             return;
         }
 
-        var _level = variable_instance_get(controller, $"stc_{_focus}");
+        var _level = variable_instance_get(controller, $"stc_{_focus}") ?? 0;
         var _remaining = (STC_POINTS_PER_LEVEL * (_level + 1)) - controller.stc_research[$ _focus];
         var _months = ceil(_remaining / _points_per_turn);
 
@@ -500,10 +500,10 @@ function Armamentarium(_controller) constructor {
             value: "technologies",
         }
     ];
-
+    
     category_dropdown = new UIDropdown(_cat_options, 200);
-
-    _cat_options = [];
+    
+    var _comp_options = [];
     var _roman = [
         "I",
         "II",
@@ -514,16 +514,16 @@ function Armamentarium(_controller) constructor {
         "VII",
         "VIII",
         "IX",
-        "X"
+        "X",
     ];
-
+    
     var _roman_length = array_length(_roman);
 
-    for (var i = 0; i < min(obj_ini.companies, _roman_length); i++) {
-        array_push(_cat_options, {label: $"{_roman[i]} Company", value: i + 1});
+    for (var i = 0, _limit = min(obj_ini.companies, _roman_length); i < _limit; i++) {
+        array_push(_comp_options, {label: $"{_roman[i]} Company", value: i + 1});
     }
 
-    company_dropdown = new UIDropdown(_cat_options, 180);
+    company_dropdown = new UIDropdown(_comp_options, 180);
 
     // --- Data Storage ---
     shop_items = {
@@ -642,7 +642,8 @@ function Armamentarium(_controller) constructor {
 
         forge_cost_mod = max(0.1, 1.0 - (discount_stc / 100));
 
-        var _has_hangars = array_length(controller.player_forge_data.vehicle_hanger) > 0;
+        var _hangers = controller.player_forge_data[$ "vehicle_hanger"] ?? [];
+        var _has_hangars = array_length(_hangers) > 0;
 
         for (var i = 0, len = array_length(master_catalog); i < len; i++) {
             /// @type {Struct.ShopItem}
@@ -859,11 +860,12 @@ function Armamentarium(_controller) constructor {
         // 1. Warships
         if (shop_type == "ships") {
             add_event({e_id: "ship_construction", ship_class: _item.name, duration: _item.request_duration});
+            audio_play_sound(snd_click, 10, false);
             return;
         }
 
         // 2. Vehicles
-        if (variable_struct_exists(global.vehicles, _item.name)) {
+        if (struct_exists(global.vehicles, _item.name)) {
             repeat (_count) {
                 scr_add_vehicle(_item.name, target_comp, {});
             }
@@ -1022,7 +1024,7 @@ function Armamentarium(_controller) constructor {
                 tooltip_text: _can_forge ? "Add to Forge Queue" : _item.get_missing_technologies_tooltip(),
                 x1: 1530,
                 y1 : _y + 2
-            })
+            });
             
             forge_button.draw(_can_forge);
 
@@ -1171,7 +1173,7 @@ function Armamentarium(_controller) constructor {
 
             for (var j = 0, _rlen = array_length(_reqs); j < _rlen; j++) {
                 var _tech_key = _reqs[j];
-                if (!variable_struct_exists(_unlock_map, _tech_key)) {
+                if (!struct_exists(_unlock_map, _tech_key)) {
                     _unlock_map[$ _tech_key] = [];
                 }
                 array_push(_unlock_map[$ _tech_key], _item.display_name);

--- a/scripts/scr_PlanetData/scr_PlanetData.gml
+++ b/scripts/scr_PlanetData/scr_PlanetData.gml
@@ -1655,18 +1655,19 @@ function PlanetData(_planet, _system) constructor {
     };
 
     static draw_planet_population_controls = function() {
-        draw_set_color(c_gray);
-        var _gar_slate = obj_star_select.garrison_data_slate;
-        _gar_slate.sub_title = "";
-        _gar_slate.body_text = "";
-        _gar_slate.title = "";
-        var xx = _gar_slate.XX;
-        var yy = _gar_slate.YY;
-        var _half_way = _gar_slate.height / 2;
-        var spacing_x = 100;
-        var spacing_y = 65;
-        draw_set_halign(fa_left);
         if (!is_hulk) {
+            draw_set_color(c_gray);
+            var _gar_slate = obj_star_select.garrison_data_slate;
+            _gar_slate.sub_title = "";
+            _gar_slate.body_text = "";
+            _gar_slate.title = "";
+            var xx = _gar_slate.XX;
+            var yy = _gar_slate.YY;
+            var _half_way = _gar_slate.height / 2;
+            var spacing_x = 100;
+            var spacing_y = 65;
+            draw_set_halign(fa_left);
+
             var _imperium_status = obj_controller.faction_status[eFACTION.IMPERIUM];
             if ((_imperium_status != "War" && current_owner <= 5) || (_imperium_status == "War")) {
                 var _col_button = obj_star_select.colonist_button;

--- a/scripts/scr_PlanetData/scr_PlanetData.gml
+++ b/scripts/scr_PlanetData/scr_PlanetData.gml
@@ -8,15 +8,15 @@ global.force_strength_descriptions = [
     "Overwhelming",
 ];
 
-/// @param {Real} planet
-/// @param {Id.Instance.obj_star} system
-function PlanetData(planet, system) constructor {
+/// @param {Real} _planet
+/// @param {Id.Instance.obj_star} _system
+function PlanetData(_planet, _system) constructor {
     //safeguards // TODO LOW DEBUG_LOGGING // Log when tripped somewhere
     //disposition
     static large_pop_conversion = 1000000000;
 
-    self.planet = planet;
-    self.system = system;
+    planet = _planet;
+    system = _system;
 
     static refresh_data = function() {
         features = system.p_feature[planet];

--- a/scripts/scr_buttons/scr_buttons.gml
+++ b/scripts/scr_buttons/scr_buttons.gml
@@ -424,6 +424,12 @@ function SpriteButton(data) constructor {
 
     cycle_index = false;
     draw_index = 0;
+    width = 0;
+    height = 0;
+    x1 = 0;
+    x2 = 0;
+    y1 = 0;
+    y2 = 0;
     scale_x = 1.0;
     scale_y = 1.0;
     alpha_hover = 1.0;
@@ -444,8 +450,6 @@ function SpriteButton(data) constructor {
         x2 = x1 + (width * scale_x);
         y2 = y1 + (height * scale_y);
     }
-
-    update(data);
 
     /// @desc Updates interaction state and draws the button.
     /// @param {bool} _enabled If false, interaction is disabled and the button appears faded.
@@ -473,6 +477,8 @@ function SpriteButton(data) constructor {
         draw_sprite_ext(_draw_sprite, draw_index, x1, y1, scale_x, scale_y, 0, c_white, _draw_alpha);
         pop_draw_return_values();
     };
+
+    update(data);
 }
 
 /// @function UnitButtonObject(data)

--- a/scripts/scr_fleet_functions/scr_fleet_functions.gml
+++ b/scripts/scr_fleet_functions/scr_fleet_functions.gml
@@ -1181,118 +1181,143 @@ function merge_fleets(main_fleet, merge_fleet) {
 
 /// @self Asset.GMObject.obj_en_fleet|Asset.GMObject.obj_p_fleet
 function fleet_respond_crusade() {
-    if (owner != eFACTION.IMPERIUM) {
-        exit;
-    }
-    if (!navy) {
-        exit;
-    }
-    if (orbiting.owner > eFACTION.ECCLESIARCHY) {
-        exit;
-    }
-    if (trade_goods != "") {
-        exit;
-    }
-    if (action != "") {
-        exit;
-    }
-    if (guardsmen_unloaded > 0) {
-        exit;
-    }
-
-    // Crusade AI
-    obj_controller.temp[88] = owner;
-    with (obj_crusade) {
-        if (owner != obj_controller.temp[88]) {
-            y -= 20000;
+    try {
+        if (owner != eFACTION.IMPERIUM) {
+            exit;
         }
-    }
-
-    var enemu;
-    with (obj_star) {
-        var cs = instance_nearest(x, y, obj_crusade);
-
-        if (point_distance(x, y, cs.x, cs.y) > cs.radius) {
-            y -= 20000;
+        if (!navy) {
+            exit;
         }
-        enemu = 0;
-
-        var nids = array_reduce(
-            p_tyranids,
-            function(prev, curr) {
-                return prev || curr > 3;
-            },
-            false
-        );
-
-        var tau = array_reduce(
-            p_tau,
-            function(prev, curr) {
-                return prev || curr > 0;
-            },
-            false
-        );
-
-        enemu += nids + tau;
-
-        if (present_fleet[eFACTION.ELDAR] > 0) {
-            enemu += 2;
+        if (orbiting.owner > eFACTION.ECCLESIARCHY) {
+            exit;
         }
-        if (present_fleet[eFACTION.ORK] > 0) {
-            enemu += 2;
+        if (trade_goods != "") {
+            exit;
         }
-        if (present_fleet[eFACTION.TAU] > 0) {
-            enemu += 2;
+        if (action != "") {
+            exit;
         }
-        if (present_fleet[eFACTION.TYRANIDS] > 0) {
-            enemu += 2;
+        if (guardsmen_unloaded > 0) {
+            exit;
         }
-        if (present_fleet[eFACTION.CHAOS] > 0) {
-            enemu += 2;
-        }
-        //nothing for heritics faction
-        if (present_fleet[eFACTION.NECRONS] > 0) {
-            enemu += 2;
-        }
-    }
-    var ns = instance_nearest(x, y, obj_star);
-    var ok = false;
-    var max_dist = 800;
-    var min_dist = 40;
-    var to_ignore = [
-        eFACTION.IMPERIUM,
-        eFACTION.MECHANICUS,
-        eFACTION.INQUISITION,
-        eFACTION.ECCLESIARCHY
-    ];
-
-    var dist = point_distance(x, y, ns.x, ns.y);
-    var valid_target = !array_contains_ext(ns.p_owner, to_ignore, false);
-    if (valid_target && dist <= max_dist && dist >= min_dist && (owner == eFACTION.IMPERIUM)) {
-        ok = true;
-    }
-
-    // if ((ns.owner>5) or (ns.owner  = eFACTION.PLAYER)) and (point_distance(x,y,ns.x,ns.y)<=max_dis) and (point_distance(x,y,ns.x,ns.y)>40) and (owner = eFACTION.IMPERIUM){
-    if (ok) {
-        action_x = ns.x;
-        action_y = ns.y;
-        set_fleet_movement();
-        orbiting.present_fleet[owner] -= 1;
-        home_x = orbiting.x;
-        home_y = orbiting.y;
-
-        var i;
-        i = 0;
-        repeat (orbiting.planets) {
-            i += 1;
-            if ((orbiting.p_owner[i] == eFACTION.IMPERIUM) && (orbiting.p_guardsmen[i] > 500)) {
-                guardsmen += round(orbiting.p_guardsmen[i] / 2);
-                orbiting.p_guardsmen[i] = round(orbiting.p_guardsmen[i] / 2);
+    
+        // Crusade AI
+        obj_controller.temp[88] = owner;
+        with (obj_crusade) {
+            if (owner != obj_controller.temp[88]) {
+                y -= 20000;
             }
         }
-
-        alarm[5] = 2;
-
+    
+        var enemu;
+        with (obj_star) {
+            var cs = instance_nearest(x, y, obj_crusade);
+    
+            if (point_distance(x, y, cs.x, cs.y) > cs.radius) {
+                y -= 20000;
+            }
+            enemu = 0;
+    
+            var nids = array_reduce(
+                p_tyranids,
+                function(prev, curr) {
+                    return prev || curr > 3;
+                },
+                false
+            );
+    
+            var tau = array_reduce(
+                p_tau,
+                function(prev, curr) {
+                    return prev || curr > 0;
+                },
+                false
+            );
+    
+            enemu += nids + tau;
+    
+            if (present_fleet[eFACTION.ELDAR] > 0) {
+                enemu += 2;
+            }
+            if (present_fleet[eFACTION.ORK] > 0) {
+                enemu += 2;
+            }
+            if (present_fleet[eFACTION.TAU] > 0) {
+                enemu += 2;
+            }
+            if (present_fleet[eFACTION.TYRANIDS] > 0) {
+                enemu += 2;
+            }
+            if (present_fleet[eFACTION.CHAOS] > 0) {
+                enemu += 2;
+            }
+            //nothing for heritics faction
+            if (present_fleet[eFACTION.NECRONS] > 0) {
+                enemu += 2;
+            }
+        }
+        var ns = instance_nearest(x, y, obj_star);
+        var ok = false;
+        var max_dist = 800;
+        var min_dist = 40;
+        var to_ignore = [
+            eFACTION.IMPERIUM,
+            eFACTION.MECHANICUS,
+            eFACTION.INQUISITION,
+            eFACTION.ECCLESIARCHY
+        ];
+    
+        var dist = point_distance(x, y, ns.x, ns.y);
+        var valid_target = !array_contains_ext(ns.p_owner, to_ignore, false);
+        if (valid_target && dist <= max_dist && dist >= min_dist && (owner == eFACTION.IMPERIUM)) {
+            ok = true;
+        }
+    
+        // if ((ns.owner>5) or (ns.owner  = eFACTION.PLAYER)) and (point_distance(x,y,ns.x,ns.y)<=max_dis) and (point_distance(x,y,ns.x,ns.y)>40) and (owner = eFACTION.IMPERIUM){
+        if (ok) {
+            action_x = ns.x;
+            action_y = ns.y;
+            set_fleet_movement();
+            orbiting.present_fleet[owner] -= 1;
+            home_x = orbiting.x;
+            home_y = orbiting.y;
+    
+            var i;
+            i = 0;
+            repeat (orbiting.planets) {
+                i += 1;
+                if ((orbiting.p_owner[i] == eFACTION.IMPERIUM) && (orbiting.p_guardsmen[i] > 500)) {
+                    guardsmen += round(orbiting.p_guardsmen[i] / 2);
+                    orbiting.p_guardsmen[i] = round(orbiting.p_guardsmen[i] / 2);
+                }
+            }
+    
+            alarm[5] = 2;
+    
+            with (obj_crusade) {
+                if (y < -10000) {
+                    y += 20000;
+                }
+            }
+            with (obj_crusade) {
+                if (y < -10000) {
+                    y += 20000;
+                }
+            }
+            with (obj_star) {
+                if (y < -10000) {
+                    y += 20000;
+                }
+            }
+            with (obj_star) {
+                if (y < -10000) {
+                    y += 20000;
+                }
+            }
+    
+            exit;
+        }
+    
         with (obj_crusade) {
             if (y < -10000) {
                 y += 20000;
@@ -1312,29 +1337,14 @@ function fleet_respond_crusade() {
             if (y < -10000) {
                 y += 20000;
             }
+        }   
+    } catch (_ex) {
+        LOGGER.error(self);
+        LOGGER.error($"owner: {owner}");
+        LOGGER.error($"orbiting: {orbiting}");
+        if (instance_exists(orbiting)) {
+            LOGGER.error($"orbiting.present_fleet: {orbiting.present_fleet}");
         }
-
-        exit;
-    }
-
-    with (obj_crusade) {
-        if (y < -10000) {
-            y += 20000;
-        }
-    }
-    with (obj_crusade) {
-        if (y < -10000) {
-            y += 20000;
-        }
-    }
-    with (obj_star) {
-        if (y < -10000) {
-            y += 20000;
-        }
-    }
-    with (obj_star) {
-        if (y < -10000) {
-            y += 20000;
-        }
+        ERROR_HANDLER.handle_exception(_ex);
     }
 }

--- a/scripts/scr_imperial_navy_functions/scr_imperial_navy_functions.gml
+++ b/scripts/scr_imperial_navy_functions/scr_imperial_navy_functions.gml
@@ -305,7 +305,7 @@ function navy_hunt_player_assets() {
         var chase_fleet = get_nearest_player_fleet(x, y, false, true);
         if (chase_fleet != noone) {
             var thatp, my_dis;
-            etah = chase_fleet.eta;
+            etah = chase_fleet.action_eta;
 
             var intercept = fleet_intercept_time_calculate(chase_fleet);
             if (intercept) {

--- a/scripts/scr_khornate_fleet_functions/scr_khornate_fleet_functions.gml
+++ b/scripts/scr_khornate_fleet_functions/scr_khornate_fleet_functions.gml
@@ -1,3 +1,4 @@
+/// @self Id.Instance.obj_en_fleet
 function khorne_fleet_cargo() {
     //This handles khorne fleets killing planet popultions moving planet and then choosing a new target ot chase
     warband = cargo_data.warband;
@@ -160,7 +161,7 @@ function khorne_fleet_cargo() {
                         if ((chase_fleet != noone) && (action == "")) {
                             var intercept_time = fleet_intercept_time_calculate(chase_fleet);
                             if (chase_fleet.action != "") {
-                                if (intercept_time <= chase_fleet.eta) {
+                                if (intercept_time <= chase_fleet.action_eta) {
                                     target = chase_fleet;
                                     chase_fleet_target_set(target);
                                     target_chosen = true;
@@ -291,6 +292,7 @@ function spawn_chaos_warlord() {
 }
 
 //TODO make this make sense
+/// @self Id.Instance.obj_en_fleet
 function destroy_khorne_fleet() {
     var chaos_lord_killed = false;
     with (instance_nearest(x, y, obj_star)) {

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -363,7 +363,7 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
     static update_mobility_item = scr_update_unit_mobility_item;
 
     static max_health = function(base = false) {
-        var max_h = 100 * (1 + ((constitution - 40) * 0.05));
+        var max_h = max(1, 100 * (1 + ((constitution - 40) * 0.05)));
         if (!base) {
             max_h += gear_weapon_data("armour", armour(), "hp_mod");
             max_h += gear_weapon_data("gear", gear(), "hp_mod");

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -363,19 +363,20 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
     static update_mobility_item = scr_update_unit_mobility_item;
 
     static max_health = function(base = false) {
-        var max_h = max(1, 100 * (1 + ((constitution - 40) * 0.05)));
-        if (!base) {
-            max_h += gear_weapon_data("armour", armour(), "hp_mod");
-            max_h += gear_weapon_data("gear", gear(), "hp_mod");
-            max_h += gear_weapon_data("mobility", mobility_item(), "hp_mod");
-            max_h += gear_weapon_data("weapon", weapon_one(), "hp_mod");
-            max_h += gear_weapon_data("weapon", weapon_two(), "hp_mod");
-        }
-        return max_h;
-    };
+        var _max_h = max(1, constitution * 3);
 
-    static increase_max_health = function(increase) {
-        return max_health() + (increase * (1 + ((constitution - 40) * 0.05))); //calculate the effect of unit_health buffs
+        if (!base) {
+            var _gear_mod = 100;
+            _gear_mod += get_armour_data("hp_mod");
+            _gear_mod += get_gear_data("hp_mod");
+            _gear_mod += get_mobility_data("hp_mod");
+            _gear_mod += get_weapon_one_data("hp_mod");
+            _gear_mod += get_weapon_two_data("hp_mod");
+            _gear_mod /= 100;
+            _max_h *= _gear_mod;
+        }
+
+        return round(_max_h);
     };
 
     // used both to load unit data from save and to add preset base_stats

--- a/scripts/scr_mission_functions/scr_mission_functions.gml
+++ b/scripts/scr_mission_functions/scr_mission_functions.gml
@@ -86,6 +86,7 @@ function mission_name_key(mission) {
 
 /// @self Struct.PlanetData
 function problem_end_turn_checks(){
+    /// @self Struct.PlanetData
     static problem_functions = {
         "succession" : function(problem_index){
             if (problem_timers[problem_index] > 0){
@@ -194,10 +195,9 @@ function problem_end_turn_checks(){
             if (problem_timers[problem_index] > 0){
                 return;
             }
-            var _alert_text = "The Necron Tomb of planet ";
 
             alter_disposition(eFACTION.INQUISITION, -8);
-            _alert_text += $"{numeral_name} has not been deactivated in time.  It has awakened, rank upon rank of Necrons pouring out to the planet's surface.  The Inquisition is not pleased with your failure.";
+            var _alert_text = $"The Necron Tomb of planet {name()} has not been deactivated in time.  It has awakened, rank upon rank of Necrons pouring out to the planet's surface.  The Inquisition is not pleased with your failure.";
             scr_popup("Inquisition Mission Failed", _alert_text, "necron_army", "");
             scr_event_log("red", $"Inquisition Mission Failed: Bombing run failed; the Necron Tomb on {name()} has become active.");
 

--- a/scripts/scr_player_fleet_functions/scr_player_fleet_functions.gml
+++ b/scripts/scr_player_fleet_functions/scr_player_fleet_functions.gml
@@ -580,6 +580,7 @@ function player_fleet_selected_count(fleet = noone) {
     return ship_count;
 }
 
+/// @returns {Id.Instance.obj_p_fleet} 
 function get_nearest_player_fleet(nearest_x, nearest_y, is_static = false, is_moving = false, stop_complex_actions = true) {
     var chosen_fleet = noone;
     if (instance_exists(obj_p_fleet)) {

--- a/scripts/scr_player_fleet_functions/scr_player_fleet_functions.gml
+++ b/scripts/scr_player_fleet_functions/scr_player_fleet_functions.gml
@@ -63,6 +63,17 @@ function split_selected_into_new_fleet(start_fleet) {
     return new_fleet;
 }
 
+/// @param {Id.Instance.obj_p_fleet} _fleet
+/// @param {Id.Instance.obj_star} _star
+function set_fleet_orbiting(_fleet, _star) {
+    _star.present_fleet[1] += 1;
+    if (_star.vision == 0) {
+        _star.vision = 1;
+    }
+    _fleet.orbiting = _star;
+}
+
+/// @self Id.Instance.obj_p_fleet
 function cancel_fleet_movement() {
     var nearest_star = instance_nearest(x, y, obj_star);
     action = "";
@@ -72,6 +83,8 @@ function cancel_fleet_movement() {
     action_y = 0;
     complex_route = [];
     just_left = false;
+    set_fleet_location(nearest_star.name);
+    set_fleet_orbiting(self, nearest_star);
 }
 
 function set_new_player_fleet_course(target_array) {

--- a/scripts/scr_player_ship_functions/scr_player_ship_functions.gml
+++ b/scripts/scr_player_ship_functions/scr_player_ship_functions.gml
@@ -17,7 +17,7 @@ function return_lost_ship() {
             }
         }
         var _star = instance_find(obj_star, irandom(instance_number(obj_star) - 1));
-        _new_fleet = instance_create(_star.x, _star.y, obj_p_fleet);
+        var _new_fleet = instance_create(_star.x, _star.y, obj_p_fleet);
         _new_fleet.owner = eFACTION.PLAYER;
         if (_lost_fleet != noone) {
             find_and_move_ship_between_fleets(_lost_fleet, _new_fleet, _return_id);
@@ -84,6 +84,11 @@ function return_lost_ship() {
             } else {
                 _text += $"The fate of your ship {obj_ini.ship[_return_id]} has now become clear. While it did not survive it's travels through the warp and tore itself apart somewhere in the  {_star.name} system. ";
                 scr_kill_ship(_return_id);
+                if (player_fleet_ship_count(_new_fleet) == 0) {
+                    with (_new_fleet) {
+                        instance_destroy();
+                    }
+                }
                 if (array_length(_units) > 0) {
                     _text += "Some of your astartes may have been able to jetison and survive the ships destruction";
                 }

--- a/scripts/scr_population_influence/scr_population_influence.gml
+++ b/scripts/scr_population_influence/scr_population_influence.gml
@@ -1,3 +1,4 @@
+/// @param {Id.Instance.obj_star} star
 function adjust_influence(faction, value, planet, star) {
     with (star) {
         p_influence[planet][faction] += value;
@@ -28,6 +29,7 @@ function adjust_influence(faction, value, planet, star) {
     }
 }
 
+/// @self Id.Instance.obj_star
 function merge_influences(doner_influence, planet) {
     for (var i = 0; i < 15; i++) {
         if (i == 2) {

--- a/scripts/scr_promote/scr_promote.gml
+++ b/scripts/scr_promote/scr_promote.gml
@@ -1,5 +1,7 @@
+/// @self Id.Instance.obj_controller
 function setup_promotion_popup() {
     if ((sel_promoting == 1) && (!instance_exists(obj_popup))) {
+        /// @self Id.Instance.obj_popup
         var pip = instance_create(0, 0, obj_popup);
         pip.type = 5;
         pip.company = managing;
@@ -154,6 +156,7 @@ function setup_promotion_popup() {
     }
 }
 
+/// @self Id.Instance.obj_popup
 function target_company_radio(min_exp = 0) {
     var _company_options = [
         {
@@ -179,6 +182,7 @@ function target_company_radio(min_exp = 0) {
     companies_select.current_selection = 0;
 }
 
+/// @self Id.Instance.obj_popup
 function draw_popup_promotion() {
     add_draw_return_values();
     manag = obj_controller.managing;
@@ -215,7 +219,7 @@ function draw_popup_promotion() {
     var role_x = 0;
     role_y = 0;
     if (target_comp != -1) {
-        for (var r = 1; r <= 11; r++) {
+        for (var r = 1, l = array_length(role_name); r < l; r++) {
             if (role_name[r] != "") {
                 draw_set_alpha(1);
                 check = " ";

--- a/scripts/scr_promote/scr_promote.gml
+++ b/scripts/scr_promote/scr_promote.gml
@@ -152,6 +152,8 @@ function setup_promotion_popup() {
             cancel_button = new UnitButtonObject({x1: 1061, y1: 491, style: "pixel", label: "Cancel"});
             main_slate = new DataSlate({style: "decorated", XX: 1006, YY: 143, set_width: true, width: 571, height: 350});
             target_company_radio(min_exp);
+            target_comp = 0;
+            get_unit_promotion_options();
         }
     }
 }

--- a/scripts/scr_purge_world/scr_purge_world.gml
+++ b/scripts/scr_purge_world/scr_purge_world.gml
@@ -132,10 +132,14 @@ function PlayerPurge(action_type, action_score, planet_data) constructor {
     };
 }
 
+/// @self Struct.PlanetData
 function scr_purge_world(action_type, action_score) {
     var _purge = new PlayerPurge(action_type, action_score, self);
 
-    var _isquest = 0, _thequest = "", _questnum = 0;
+    var _isquest = 0;
+    var _thequest = "";
+    var _questnum = 0;
+    var _popup_text = "";
 
     _purge.pop_before = population_as_small();
 
@@ -240,7 +244,7 @@ function scr_purge_world(action_type, action_score) {
             } else {
                 if (nid_influence > 25) {
                     _popup_text += " Scores of mutant offspring from a genestealer infestation are burnt, while we have damaged their influence over this world, the mutants appear to lack the organisation of a true cult";
-                    adjust_influence(eFACTION.TYRANIDS, -10, planet, star);
+                    adjust_influence(eFACTION.TYRANIDS, -10, planet, system);
                 } else if (nid_influence > 0) {
                     _popup_text += " There are signs of a genestealer infestation but the cultists are too unorganized to do any real damage to their influence on this world";
                 }

--- a/scripts/scr_ship_functions/scr_ship_functions.gml
+++ b/scripts/scr_ship_functions/scr_ship_functions.gml
@@ -1,0 +1,28 @@
+/// @param {Id.Instance.obj_p_ship} _ship
+function draw_ship_status_overlay(_ship, _hp_color, _shield_color) {
+    if (!instance_exists(_ship)) {
+        return;
+    }
+
+    var _maxhp = _ship.maxhp;
+    if (_maxhp <= 0) {
+        return;
+    }
+
+    var _shields = _ship.shields;
+    var _maxshields = _ship.maxshields;
+    var _has_shields = _shields > 0 && _maxshields > 0;
+
+    var _display_value = _has_shields ? (_shields / _maxshields) : (_ship.hp / _maxhp);
+    var _color = _has_shields ? _shield_color : _hp_color;
+
+    var _zoomed = false;
+    if (instance_exists(obj_controller)) {
+        _zoomed = obj_controller.zoomed != 0;
+    }
+
+    var _scale = _zoomed ? 2 : 1;
+    var _text = $"{floor(_display_value * 100)}%";
+
+    draw_text_transformed_outline(_ship.x, _ship.y - _ship.sprite_height, _text, _scale, _scale, 0,,_color);
+}

--- a/scripts/scr_ship_functions/scr_ship_functions.yy
+++ b/scripts/scr_ship_functions/scr_ship_functions.yy
@@ -1,0 +1,13 @@
+{
+  "$GMScript":"v1",
+  "%Name":"scr_ship_functions",
+  "isCompatibility":false,
+  "isDnD":false,
+  "name":"scr_ship_functions",
+  "parent":{
+    "name":"Scripts",
+    "path":"folders/Scripts.yy",
+  },
+  "resourceType":"GMScript",
+  "resourceVersion":"2.0",
+}

--- a/scripts/scr_ui_manage/scr_ui_manage.gml
+++ b/scripts/scr_ui_manage/scr_ui_manage.gml
@@ -252,7 +252,7 @@ function reset_manage_unit_constants(unit) {
         unit_manage_constants.damage_res = new LabeledIcon(spr_icon_iron_halo, $"{_damage_res}%", 0, 0, {icon_width: 24, icon_height: 24, tooltip: _res_tool});
         var _hp_val = $"{round(unit.hp())}/{round(unit.max_health())}";
         var _hp_tool = "A measure of how much punishment the creature can take. Marines can go into the negatives and still survive, but they'll require a bionic to become fighting fit once more.\n\nContributing factors:\n";
-        _hp_tool += $"CON: {round(100 * (1 + ((unit.constitution - 40) * 0.025)))}\n";
+        _hp_tool += $"CON: {round(100 * (1 + ((unit.constitution - 40) * 0.05)))}\n";
 
         for (var i = 0; i < array_length(equipment_types); i++) {
             var equipment_type = equipment_types[i];

--- a/scripts/scr_ui_manage/scr_ui_manage.gml
+++ b/scripts/scr_ui_manage/scr_ui_manage.gml
@@ -250,9 +250,9 @@ function reset_manage_unit_constants(unit) {
         _res_tool += $"CON: {round(unit.constitution / 2)}%";
 
         unit_manage_constants.damage_res = new LabeledIcon(spr_icon_iron_halo, $"{_damage_res}%", 0, 0, {icon_width: 24, icon_height: 24, tooltip: _res_tool});
-        var _hp_val = $"{round(unit.hp())}/{round(unit.max_health())}";
+        var _hp_val = $"{round(unit.hp())}/{unit.max_health()}";
         var _hp_tool = "A measure of how much punishment the creature can take. Marines can go into the negatives and still survive, but they'll require a bionic to become fighting fit once more.\n\nContributing factors:\n";
-        _hp_tool += $"CON: {round(100 * (1 + ((unit.constitution - 40) * 0.05)))}\n";
+        _hp_tool += $"CON: {unit.constitution * 3}\n";
 
         for (var i = 0; i < array_length(equipment_types); i++) {
             var equipment_type = equipment_types[i];


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes multiple gameplay bugs and adds a clearer ship status overlay with shield/HP colors and a proper speed toggle in space battles. Also closes the Armamentarium sell-back exploit, hardens Crusade/AI interceptions, and reworks marine max HP to use CON-based scaling with gear modifiers.

- **New Features**
  - Ship status overlay: shields vs HP color with outlined text; scales with zoom via `draw_ship_status_overlay`.
  - Space combat: speed button cycles 1x/2x/3x using `SpriteButton`; replaces the old click zone.

- **Bug Fixes**
  - Armamentarium: reworked buy/sell pricing with per-item `sell_cost`, min buy/sell floors, sell capped at buy; tooltip shows total; safer struct checks and STC defaults.
  - Fleets: block starting space battles for empty enemy fleets; destroy empty fleets when a lost ship fails to return; cancel movement restores orbit and location via `set_fleet_orbiting`; use `action_eta` for navy/Khorne interceptions.
  - UI/Health: max HP now `CON * 3` scaled by gear HP mods, clamped to at least 1; tooltips updated; fleet panel health uses `full_id`; fix space-combat zoom glitch; ship overlay guards missing instances.
  - Promotion: fix HQ role list size/reset, initialize `target_comp`, refresh options when switching companies; safe iteration via `array_length`.
  - Missions/PlanetData/Purge: Necron failure text includes planet name; hide population controls on Space Hulks; fix purge influence by passing `system` to `adjust_influence`.

<sup>Written for commit da49095f7d7be6c39771a827f8650da244d87e66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

