### PR TITLE
fix: Repair warp speeds; refactor ETA function

### DIFF
--- a/objects/obj_fleet_select/Draw_0.gml
+++ b/objects/obj_fleet_select/Draw_0.gml
@@ -101,7 +101,7 @@ if (!instance_exists(obj_drop_select) && !instance_exists(obj_bomb_select)) {
                 draw_set_font(fnt_40k_14b);
                 var eta = 0;
 
-                eta = calculate_fleet_eta(mine.x, mine.y, sys.x, sys.y, selection_travel_speed,,, player_fleet.warp_able);
+                eta = calculate_fleet_eta(mine.x, mine.y, sys.x, sys.y, selection_travel_speed, true, true, player_fleet.warp_able);
 
                 if ((sys.storm > 0) || (instance_nearest(x, y, obj_star).storm > 0)) {
                     eta = "N/A";

--- a/objects/obj_p_fleet/Alarm_4.gml
+++ b/objects/obj_p_fleet/Alarm_4.gml
@@ -1,4 +1,4 @@
-var eta = calculate_fleet_eta(x, y, action_x, action_y, action_spd, false, false, warp_able);
+var eta = calculate_fleet_eta(x, y, action_x, action_y, action_spd, true, true, warp_able);
 
 action_eta = eta;
 

--- a/scripts/scr_fleet_functions/scr_fleet_functions.gml
+++ b/scripts/scr_fleet_functions/scr_fleet_functions.gml
@@ -166,6 +166,7 @@ function get_largest_player_fleet() {
 }
 
 /// @self Asset.GMObject.obj_en_fleet|Asset.GMObject.obj_p_fleet
+/// @return {bool}
 function is_orbiting(fleet = noone) {
     if (fleet == noone) {
         if (action != "") {
@@ -265,43 +266,48 @@ function load_unit_to_fleet(fleet, unit) {
     return loaded;
 }
 
-/// @param {Real} xx
-/// @param {Real} yy
-/// @param {Real} xxx
-/// @param {Real} yyy
+/// @param {Real} self_x
+/// @param {Real} self_y
+/// @param {Real} target_x
+/// @param {Real} target_y
 /// @param {Real} fleet_speed
-/// @param {Id.Instance.obj_star} star1
-/// @param {Id.Instance.obj_star} star2
+/// @param {Bool} from_star
+/// @param {Bool} to_star
 /// @param {Bool} warp_able
-function calculate_fleet_eta(xx, yy, xxx, yyy, fleet_speed, star1 = noone, star2 = noone, warp_able = false) {
-    var warp_lane = 0;
-    if (star1 == noone && star2 == noone) {
-        star1 = instance_nearest(xx, yy, obj_star);
-        star2 = instance_nearest(xxx, yyy, obj_star);
-        warp_lane = determine_warp_join(star1.id, star2.id);
-    } else if (star1 == noone) {
-        star1 = instance_nearest(xx, yy, obj_star);
-    }
-    var eta = floor(point_distance(xx, yy, xxx, yyy) / fleet_speed) + 1;
-    if (!warp_lane) {
-        eta *= 2;
-    }
-    if (warp_lane && warp_able) {
-        eta = ceil(eta / warp_lane);
-    }
-    if (!star2) {
-        return eta;
+function calculate_fleet_eta(self_x, self_y, target_x, target_y, fleet_speed, from_star = true, to_star = true, warp_able = false) {
+    var _eta = floor(point_distance(self_x, self_y, target_x, target_y) / fleet_speed) + 1;
+    var _lane_strength = 0;
+    /// @type {Id.Instance.obj_star}
+    var _departure_star = noone;
+    /// @type {Id.Instance.obj_star}
+    var _destanation_star = noone;
+
+    if (from_star) {
+        _departure_star = instance_nearest(self_x, self_y, obj_star);
     }
 
-    //check end location for warp storm
-    if (instance_exists(star2)) {
-        if (star2.object_index == obj_star) {
-            if (star2.storm) {
-                eta += 10000;
-            }
+    if (to_star) {
+        _destanation_star = instance_nearest(target_x, target_y, obj_star);
+    }
+
+    if (_departure_star != noone && _destanation_star != noone) {
+        _lane_strength = determine_warp_join(_departure_star.id, _destanation_star.id);
+    }
+
+    if (_lane_strength > 0 && warp_able) {
+        _eta = ceil(_eta / _lane_strength);
+    } else {
+        _eta *= 2;
+    }
+
+    if (_destanation_star != noone) {
+        //check end location for warp storm
+        if (_destanation_star.storm) {
+            _eta += 10000;
         }
     }
-    return eta;
+
+    return _eta;
 }
 
 /// @self Asset.GMObject.obj_en_fleet|Asset.GMObject.obj_p_fleet

--- a/scripts/scr_fleet_functions/scr_fleet_functions.gml
+++ b/scripts/scr_fleet_functions/scr_fleet_functions.gml
@@ -294,8 +294,10 @@ function calculate_fleet_eta(self_x, self_y, target_x, target_y, fleet_speed, fr
         _lane_strength = determine_warp_join(_departure_star.id, _destanation_star.id);
     }
 
-    if (_lane_strength > 0 && warp_able) {
-        _eta = ceil(_eta / _lane_strength);
+    if (_lane_strength > 0) {
+        if (warp_able) {
+            _eta = ceil(_eta / _lane_strength);
+        }
     } else {
         _eta *= 2;
     }

--- a/scripts/scr_player_fleet_functions/scr_player_fleet_functions.gml
+++ b/scripts/scr_player_fleet_functions/scr_player_fleet_functions.gml
@@ -109,7 +109,7 @@ function set_new_player_fleet_course(target_array) {
         complex_route = target_array;
         var from_x = from_star ? nearest_planet.x : x;
         var from_y = from_star ? nearest_planet.y : y;
-        action_eta = calculate_fleet_eta(from_x, from_y, target_planet.x, target_planet.y, action_spd, from_star,, warp_able);
+        action_eta = calculate_fleet_eta(from_x, from_y, target_planet.x, target_planet.y, action_spd, from_star, true, warp_able);
         action_x = target_planet.x;
         action_y = target_planet.y;
         action = "move";


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes incorrect warp travel times and refactors the ETA calculation to be clearer and more reliable. Travel time now correctly accounts for warp lanes, warp capability, and storms.

- **Bug Fixes**
  - Apply lane bonus only when `warp_able`; off‑lane travel is 2x; on‑lane without warp uses normal speed.
  - Consistent storm penalty at the destination star.
  - Updated fleet selection and player fleet ETA displays to use the corrected calculation.

- **Refactors**
  - Replaced `calculate_fleet_eta(xx, yy, xxx, yyy, fleet_speed, star1, star2, warp_able)` with `calculate_fleet_eta(self_x, self_y, target_x, target_y, fleet_speed, from_star, to_star, warp_able)`.
  - Updated calls in `obj_fleet_select`, `obj_p_fleet` (Alarm_4), and `scr_player_fleet_functions`.
  - Added `{bool}` return annotation to `is_orbiting`.

<sup>Written for commit f218bbd4413b1e6ef0eb6cd9c8457937ff4067f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

