### PR TITLE
ci: Update Discord message formatting

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -298,7 +298,8 @@ jobs:
           webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL }}
           username: "GitHub Releases"
           content: "<@&1318332223232938014>"
-          embed-title: "${{ steps.create_release.outputs.url }}"
+          embed-title: "${{ steps.create_release.outputs.release_name }}"
           embed-description: |
             ${{ steps.build_changelog.outputs.changelog }}
+            **Download:** ${{ steps.create_release.outputs.url }}
           embed-footer-text: "These builds are auto-generated every 12 hours. Their stability is unpredictable. 20 last builds retained at the same time. You can always revert to an older one."

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -298,7 +298,7 @@ jobs:
           webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL }}
           username: "GitHub Releases"
           content: "<@&1318332223232938014>"
-          embed-title: "${{ steps.create_release.outputs.release_name }}"
+          embed-title: "${{ needs.prepare_release.outputs.release_name }}"
           embed-description: |
             ${{ steps.build_changelog.outputs.changelog }}
             **Download:** ${{ steps.create_release.outputs.url }}

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -297,10 +297,8 @@ jobs:
         with:
           webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL }}
           username: "GitHub Releases"
-          content: |
-            <@&1318332223232938014>
-            -# :warning: These builds are auto-generated. They may be **heavily unstable**, in which case try using an older build (20 exist at the same time). :warning:
-          embed-title: "[${{ needs.prepare_release.outputs.release_name }}](${{ steps.create_release.outputs.url }})"
+          content: "<@&1318332223232938014>"
+          embed-title: "${{ steps.create_release.outputs.url }}"
           embed-description: |
             ${{ steps.build_changelog.outputs.changelog }}
-          embed-footer-text: "Download: ${{ steps.create_release.outputs.url }}"
+          embed-footer-text: "These builds are auto-generated every 12 hours. Their stability is unpredictable. 20 last builds retained at the same time. You can always revert to an older one."


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Streamlined Discord release notifications: keep the role mention in content, set the embed title to the release name, move a bold “Download” link into the description with the changelog, and update the footer to a clearer stability note with a 12-hour cadence and 20-build retention. Messages are shorter and easier to scan in Discord.

<sup>Written for commit 5169a5c1dac71b686350823ed131ba22d38a2822. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

