### PR TITLE
fix: A pack of small fixes

### DIFF
--- a/objects/obj_pnunit/Alarm_3.gml
+++ b/objects/obj_pnunit/Alarm_3.gml
@@ -18,7 +18,7 @@ try {
         if (men > 0) {
             var miss = "", r_lost = 0;
 
-            for (var raar; raar < (men + dreads); raar++) {
+            for (var raar = 0; raar < (men + dreads); raar++) {
                 r_roll = floor(random(1000)) + 1;
                 if (obj_ncombat.player_forces < (obj_ncombat.player_max * 0.75)) {
                     r_roll -= 8;
@@ -42,10 +42,10 @@ try {
                     marine_defense[raar] = 0.75;
                     obj_ncombat.red_thirst += 1;
                     if (r_lost == 1) {
-                        miss += "Battle Brother " + string(obj_ini.name[marine_co[raar]][marine_id[raar]]) + ", ";
+                        miss += "Battle Brother " + string(unit_struct[raar].name()) + ", ";
                     }
                     if (r_lost > 1) {
-                        miss += string(obj_ini.name[marine_co[raar]][marine_id[raar]]) + ", ";
+                        miss += string(unit_struct[raar].name()) + ", ";
                     }
                 }
             }

--- a/objects/obj_temp_build/Create_0.gml
+++ b/objects/obj_temp_build/Create_0.gml
@@ -1,5 +1,5 @@
 target = noone;
-planet = (planet > 0) ? planet : 0;
+planet = noone;
 
 lair = false;
 arsenal = false;

--- a/scripts/scr_zoom/scr_zoom.gml
+++ b/scripts/scr_zoom/scr_zoom.gml
@@ -31,9 +31,10 @@ function set_zoom_to_default() {
 /// @description This script will zoom in and out of the game view based on the keys pressed.
 /// @self obj_controller
 function scr_zoom_keys() {
-    static zoom_speed = 0.1;
     static min_zoom = 0.3;
     static max_zoom = 2.5;
+
+    var zoom_speed = 0.1;
 
     if (keyboard_check(vk_shift)) {
         zoom_speed *= 2;
@@ -64,7 +65,7 @@ function scr_zoom_keys() {
         var old_w = camera_get_view_width(view_camera[0]);
         var old_h = camera_get_view_height(view_camera[0]);
         if (old_w > 0 && old_h > 0) {
-            var zoom_factor = 1 - zoom_speed * zoom_delta;
+            var zoom_factor = max(0.1, 1 - zoom_speed * zoom_delta);
             var new_w = old_w * zoom_factor;
             var new_h = old_h * zoom_factor;
             camera_set_view_size(view_camera[0], new_w, new_h);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes PN unit alarm loop init and name retrieval, sets `planet` to a safe default in temp builds, and prevents Shift-zoom from collapsing the view. Removes crashes and odd zoom jumps.

- **Bug Fixes**
  - obj_pnunit/Alarm_3.gml: Initialize loop counter (`raar = 0`) and use `unit_struct[raar].name()` for safe name access.
  - obj_temp_build/Create_0.gml: Initialize `planet = noone` to avoid stale state across builds.
  - scr_zoom.gml: Make `zoom_speed` local and clamp zoom factor (`max(0.1, ...)`) so Shift doesn't snap or invert the zoom.

<sup>Written for commit a00c67df11bbe3ada0bc161ee92be9a836982e9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

