### PR TITLE
fix: Fable reported typos

### DIFF
--- a/scripts/scr_add_artifact/scr_add_artifact.gml
+++ b/scripts/scr_add_artifact/scr_add_artifact.gml
@@ -832,7 +832,7 @@ function corrupt_artifact_collectors(last_artifact) {
                             _unit.edit_corruption(choose(0, 2, 4, 6, 8));
                         }
                     } else if (obj_controller.man[i] == "vehicle" && is_array(_unit)) {
-                        var _val = get_deep_array(obj_ini.veh_chaos, _unit);
+                        var _val = fetch_deep_array(obj_ini.veh_chaos, _unit);
                         _val += choose(0, 2, 4, 6, 8);
                         alter_deep_array(obj_ini.veh_chaos, _unit, _val);
                     }

--- a/scripts/scr_add_man/scr_add_man.gml
+++ b/scripts/scr_add_man/scr_add_man.gml
@@ -61,7 +61,7 @@ function scr_add_man(man_role, target_company, spawn_exp, spawn_name, corruption
                 case "Ork Sniper":
                     spawn_exp = 20;
                     obj_ini.race[target_company][_company_slot] = eFACTION.ORK;
-                    _unit = new TTRPG_stats("ork", target_company, _company_slot, "ork_Sniper");
+                    _unit = new TTRPG_stats("ork", target_company, _company_slot, "ork_sniper");
                     break;
                 case "Flash Git":
                     spawn_exp = 40;

--- a/scripts/scr_draw_management_unit/scr_draw_management_unit.gml
+++ b/scripts/scr_draw_management_unit/scr_draw_management_unit.gml
@@ -589,7 +589,7 @@ function scr_draw_management_unit(selected, yy = 0, xx = 0, draw = true, click_l
     }
     if (is_man) {
         force_tool = 0;
-        if ((temp[101] == $"{_unit.role()} {_unit.name}") && ((temp[102] != _unit.armour()) || (temp[104] != _unit.gear()) || (temp[106] == _unit.mobility_item()) || (temp[108] != _unit.weapon_one()) || (temp[110] != _unit.weapon_two()))) {
+        if ((temp[101] == $"{_unit.role()} {_unit.name}") && ((temp[102] != _unit.armour()) || (temp[104] != _unit.gear()) || (temp[106] != _unit.mobility_item()) || (temp[108] != _unit.weapon_one()) || (temp[110] != _unit.weapon_two()))) {
             force_tool = 1;
         }
 

--- a/scripts/scr_draw_management_unit/scr_draw_management_unit.gml
+++ b/scripts/scr_draw_management_unit/scr_draw_management_unit.gml
@@ -589,7 +589,7 @@ function scr_draw_management_unit(selected, yy = 0, xx = 0, draw = true, click_l
     }
     if (is_man) {
         force_tool = 0;
-        if ((temp[101] == $"{_unit.role()} {_unit.name}") && ((temp[102] != _unit.armour()) || (temp[104] != _unit.gear()) || (temp[106] == _unit.mobility_item()) || (temp[108] != _unit.weapon_one()) || (temp[110] != _unit.weapon_two()) || (temp[114] == "refresh"))) {
+        if ((temp[101] == $"{_unit.role()} {_unit.name}") && ((temp[102] != _unit.armour()) || (temp[104] != _unit.gear()) || (temp[106] == _unit.mobility_item()) || (temp[108] != _unit.weapon_one()) || (temp[110] != _unit.weapon_two()))) {
             force_tool = 1;
         }
 

--- a/scripts/scr_inquisition_inspection/scr_inquisition_inspection.gml
+++ b/scripts/scr_inquisition_inspection/scr_inquisition_inspection.gml
@@ -509,7 +509,7 @@ function inquisitor_inspection_structure() constructor {
                         scr_alert("red", "inspect", _msg, 0, 0);
                     }
                 }
-                if (finds.daemonic == 0 && !_struct_exists(finds, "xenos_mercs")) {
+                if (finds.daemonic == 0 && !struct_exists(finds, "xenos_mercs")) {
                     scr_alert("red", "inspect", "Inquisitor discovers heretical material in your posession.", 0, 0);
                 }
 

--- a/scripts/scr_mission_functions/scr_mission_functions.gml
+++ b/scripts/scr_mission_functions/scr_mission_functions.gml
@@ -952,7 +952,7 @@ function remove_star_problem(problem, star = noone) {
         }
     } else {
         with (star) {
-            remove_remove_star_problem(problem);
+            remove_star_problem(problem);
         }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes Fable-reported typos and wrong function calls to prevent runtime errors and incorrect management UI behavior.

- **Bug Fixes**
  - Use fetch_deep_array for vehicle chaos lookup in artifact corruption.
  - Correct unit id to "ork_sniper" when creating Ork Sniper stats.
  - Management UI: remove obsolete temp[114] "refresh" check and fix mobility item comparison (use !=) to avoid forced tool state.
  - Replace _struct_exists with struct_exists in Inquisition inspection.
  - Call remove_star_problem (not remove_remove_star_problem) inside star context.

<sup>Written for commit 46325dfcaad4bee5354151ef354178dc00add3ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

