### PR TITLE
fix: A new pack of small fixes

### DIFF
--- a/datafiles/data/armour.json
+++ b/datafiles/data/armour.json
@@ -86,7 +86,7 @@
             "master_crafted": 25,
             "standard": 20
         },
-        "description": "PLACEHOLDER",
+        "description": "Once the standard Dreadnought pattern when Primarchs walked the stars and Legions conquered worlds, now one of the closest-guarded secrets in Mechanicum tech enclaves. With an Atomantic arc-reactor at its heart that gave it superior speed, strength and even shielding capabilities, it was far superior to any other Dreadnought pattern save for its maintenance demands and the possible meltdown of the reactor.",
         "hp_mod": {
             "artifact": 50,
             "master_crafted": 35,

--- a/datafiles/data/weapons.json
+++ b/datafiles/data/weapons.json
@@ -40,7 +40,7 @@
         "spli": 20,
         "tags": [
             "heavy_ranged",
-            "terminator",
+            "terminator_only",
             "dreadnought"
         ],
         "value": 75
@@ -1532,7 +1532,7 @@
         "spli": 20,
         "tags": [
             "heavy_ranged",
-            "terminator",
+            "terminator_only",
             "dreadnought",
             "ancient"
         ]

--- a/datafiles/main/chapters/34.json
+++ b/datafiles/main/chapters/34.json
@@ -139,7 +139,7 @@
     "culture_styles": [],
     "home_planets": 1.0,
     "flagship_name": "Victus",
-    "monastary_name": "",
+    "monastery_name": "",
     "advantages": [
       "",
       "Assault Doctrine",

--- a/objects/obj_bomb_select/Draw_0.gml
+++ b/objects/obj_bomb_select/Draw_0.gml
@@ -82,6 +82,9 @@ if ((max_ships > 0) && instance_exists(obj_star_select)) {
             case 10:
                 t_name = "Chaos";
                 break;
+            case 11:
+                t_name = "Traitors";
+                break;
             case 13:
                 t_name = "Necrons";
                 break;

--- a/objects/obj_drop_select/Create_0.gml
+++ b/objects/obj_drop_select/Create_0.gml
@@ -94,7 +94,7 @@ if (!instance_exists(obj_saveload)) {
     tau = 0;
     traitors = 0;
     tyranids = 0;
-    csm = 0;
+    chaos = 0;
     necrons = 0;
     demons = 0;
 
@@ -165,7 +165,7 @@ if (purge == 0) {
     ork = p_target.p_orks[planet_number];
     tau = p_target.p_tau[planet_number];
     tyranids = p_target.p_tyranids[planet_number];
-    csm = p_target.p_chaos[planet_number];
+    chaos = p_target.p_chaos[planet_number];
     traitors = p_target.p_traitors[planet_number];
     necrons = p_target.p_necrons[planet_number];
     demons = p_target.p_demons[planet_number];
@@ -195,13 +195,13 @@ if (purge == 0) {
         bes = 9;
         bes_score = tyranids;
     }
-    if (traitors > bes_score) {
+    if (chaos > bes_score) {
         bes = 10;
-        bes_score = traitors;
+        bes_score = chaos;
     }
-    if (csm > bes_score) {
+    if (traitors > bes_score) {
         bes = 11;
-        bes_score = csm;
+        bes_score = traitors;
     }
     if (necrons > bes_score) {
         bes = 13;
@@ -246,11 +246,11 @@ if (purge == 0) {
         forces += 1;
         force_present[forces] = 9;
     }
-    if ((traitors > 0) || ((traitors == 0) && (spesh == true))) {
+    if (chaos > 0) {
         forces += 1;
         force_present[forces] = 10;
     }
-    if (csm > 0) {
+    if ((traitors > 0) || ((traitors == 0) && (spesh == true))) {
         forces += 1;
         force_present[forces] = 11;
     }
@@ -271,8 +271,8 @@ if (purge == 0) {
         ork,
         tau,
         tyranids,
+        chaos,
         traitors,
-        csm,
         demons,
         necrons
     ];
@@ -283,8 +283,8 @@ if (purge == 0) {
         "Orks",
         "Tau",
         "Tyranids",
+        "Chaos",
         "Heretics",
-        "CSMs",
         "Daemons",
         "Necrons"
     ];

--- a/objects/obj_en_fleet/Draw_0.gml
+++ b/objects/obj_en_fleet/Draw_0.gml
@@ -144,7 +144,7 @@ if ((within == 1) || (selected > 0)) {
             break;
         case eFACTION.CHAOS:
             fleet_descript = "Heretic Fleet";
-            if (fleet_has_cargo("warband") || fleet_has_cargo("csm")) {
+            if (fleet_has_cargo("warband") || fleet_has_cargo("chaos")) {
                 fleet_descript = string(obj_controller.faction_leader[eFACTION.CHAOS]) + "'s Fleet";
                 if (string_count("s's Fleet", fleet_descript) > 0) {
                     fleet_descript = string_replace(fleet_descript, "s's Fleet", "s' Fleet");

--- a/objects/obj_fleet/Create_0.gml
+++ b/objects/obj_fleet/Create_0.gml
@@ -10,7 +10,7 @@ sel_y1 = 0;
 control = 0;
 ships_selected = 0;
 battle_special = "";
-csm_exp = 0;
+chaos_exp = 0;
 star_name = "";
 
 left_down = 0;

--- a/objects/obj_ncombat/Alarm_5.gml
+++ b/objects/obj_ncombat/Alarm_5.gml
@@ -434,13 +434,13 @@ if (defeat == 0 && _reduce_power) {
         enemy_power = battle_object.p_tyranids[battle_id];
         part10 = "Tyranid";
     } else if (enemy == eFACTION.CHAOS) {
-        enemy_power = battle_object.p_traitors[battle_id];
+        enemy_power = battle_object.p_chaos[battle_id];
         part10 = "Heretic";
         if (threat == 7) {
             part10 = "Daemon";
         }
     } else if (enemy == eFACTION.HERETICS) {
-        enemy_power = battle_object.p_chaos[battle_id];
+        enemy_power = battle_object.p_traitors[battle_id];
         part10 = "Chaos Space Marine";
     } else if (enemy == eFACTION.NECRONS) {
         enemy_power = battle_object.p_necrons[battle_id];
@@ -672,7 +672,7 @@ if (obj_ini.omophagea) {
     if ((enemy == eFACTION.NECRONS) || (enemy == eFACTION.TYRANIDS) || (battle_special == "ship_demon")) {
         eatme += 100;
     }
-    if ((enemy == eFACTION.CHAOS) && (battle_object.p_traitors[battle_id] == 7)) {
+    if ((enemy == eFACTION.CHAOS) && (battle_object.p_chaos[battle_id] == 7)) {
         eatme += 200;
     }
 

--- a/objects/obj_ncombat/Create_0.gml
+++ b/objects/obj_ncombat/Create_0.gml
@@ -57,8 +57,8 @@ instance_create(0, 0, obj_centerline);
 local_forces = 0;
 battle_loc = "";
 battle_climate = "";
-/// @type {Asset.GMObject.obj_star} 
 if (instance_exists(obj_star)) {
+    /// @type {Id.Instance.obj_star} 
     battle_object = instance_nearest(x, y, obj_star);
 } else {
     battle_object = noone;

--- a/objects/obj_p_assra/KeyPress_49.gml
+++ b/objects/obj_p_assra/KeyPress_49.gml
@@ -1,1 +1,1 @@
-obj_fleet.csm_exp = 1;
+obj_fleet.chaos_exp = 1;

--- a/objects/obj_p_assra/KeyPress_50.gml
+++ b/objects/obj_p_assra/KeyPress_50.gml
@@ -1,1 +1,1 @@
-obj_fleet.csm_exp = 2;
+obj_fleet.chaos_exp = 2;

--- a/objects/obj_p_assra/Step_0.gml
+++ b/objects/obj_p_assra/Step_0.gml
@@ -173,16 +173,16 @@ if ((boarding == true) && (board_cooldown >= 0) && instance_exists(target) && in
                         boarding_disadvantage -= 5;
                     }
                 }
-                if ((target.owner == eFACTION.IMPERIUM) || ((target.owner == eFACTION.CHAOS) && (obj_fleet.csm_exp == 0))) {
+                if ((target.owner == eFACTION.IMPERIUM) || ((target.owner == eFACTION.CHAOS) && (obj_fleet.chaos_exp == 0))) {
                     boarding_disadvantage -= 0;
                 } // Cultists/Pirates/Humans
                 if ((target.owner == eFACTION.PLAYER) || (target.owner == eFACTION.ECCLESIARCHY) || (target.owner == eFACTION.ORK) || (target.owner == eFACTION.ELDAR) || (target.owner == eFACTION.NECRONS)) {
                     boarding_disadvantage -= 10;
                 }
-                if ((target.owner == eFACTION.CHAOS) && (obj_fleet.csm_exp == 1)) {
+                if ((target.owner == eFACTION.CHAOS) && (obj_fleet.chaos_exp == 1)) {
                     boarding_disadvantage -= 20;
                 } //       Veteran marines
-                if (((target.owner == eFACTION.CHAOS) && (obj_fleet.csm_exp == 2)) || (target.owner == eFACTION.TYRANIDS)) {
+                if (((target.owner == eFACTION.CHAOS) && (obj_fleet.chaos_exp == 2)) || (target.owner == eFACTION.TYRANIDS)) {
                     boarding_disadvantage -= 30;
                 } // Daemons, veteran CSM, tyranids
 
@@ -226,10 +226,10 @@ if ((boarding == true) && (board_cooldown >= 0) && instance_exists(target) && in
                             if ((target.owner == eFACTION.ECCLESIARCHY) || (target.owner == eFACTION.ORK) || (target.owner == eFACTION.ELDAR) || (target.owner == eFACTION.NECRONS)) {
                                 experience += 1;
                             }
-                            if ((target.owner == eFACTION.CHAOS) && (obj_fleet.csm_exp == 1)) {
+                            if ((target.owner == eFACTION.CHAOS) && (obj_fleet.chaos_exp == 1)) {
                                 experience += 2;
                             }
-                            if ((target.owner == eFACTION.CHAOS) && (obj_fleet.csm_exp == 2)) {
+                            if ((target.owner == eFACTION.CHAOS) && (obj_fleet.chaos_exp == 2)) {
                                 experience += 3;
                             }
                             if (target.owner == eFACTION.TYRANIDS) {

--- a/objects/obj_star/Create_0.gml
+++ b/objects/obj_star/Create_0.gml
@@ -101,6 +101,7 @@ get_sabatours = function(planet){
     return _gar;
 }
 
+/// @returns {Struct.PlanetData}
 get_planet_data = function(planet){
     var _gar = system_datas[planet];
     if (_gar == false){

--- a/objects/obj_star_select/Mouse_50.gml
+++ b/objects/obj_star_select/Mouse_50.gml
@@ -115,7 +115,7 @@ if (!instance_exists(obj_saveload) && !instance_exists(obj_drop_select)) {
 
                     var e = 1;
                     var khorne_count = 0;
-                    var chaos_space_marine_count = 0;
+                    var chaos_count = 0;
                     var en_capitals, en_frigates, en_escorts;
                     repeat (9) {
                         e += 1;
@@ -134,8 +134,8 @@ if (!instance_exists(obj_saveload) && !instance_exists(obj_drop_select)) {
                                     if (fleet_has_cargo("warband")) {
                                         khorne_count++;
                                     }
-                                    if (fleet_has_cargo("csm")) {
-                                        chaos_space_marine_count++;
+                                    if (fleet_has_cargo("chaos")) {
+                                        chaos_count++;
                                     }
                                 }
                             }
@@ -193,11 +193,11 @@ if (!instance_exists(obj_saveload) && !instance_exists(obj_drop_select)) {
                     // Plug in all of the enemies first
                     // And then plug in the allies after then with their status set to positive
 
-                    if (chaos_space_marine_count) {
-                        obj_fleet.csm_exp = 1;
+                    if (chaos_count) {
+                        obj_fleet.chaos_exp = 1;
                     }
                     if (khorne_count) {
-                        obj_fleet.csm_exp = 2;
+                        obj_fleet.chaos_exp = 2;
                     }
 
                     for (var i = 0; i < target.planets; i++) {

--- a/objects/obj_turn_end/Alarm_0.gml
+++ b/objects/obj_turn_end/Alarm_0.gml
@@ -148,6 +148,9 @@ try {
                     tempy = battle_object[current_battle].p_tyranids[battle_world[current_battle]];
                 }
                 if (battle_opponent[current_battle] == 10) {
+                    tempy = battle_object[current_battle].p_chaos[battle_world[current_battle]];
+                }
+                if (battle_opponent[current_battle] == 11) {
                     tempy = battle_object[current_battle].p_traitors[battle_world[current_battle]];
                 }
                 if (battle_opponent[current_battle] == 13) {

--- a/objects/obj_turn_end/Mouse_56.gml
+++ b/objects/obj_turn_end/Mouse_56.gml
@@ -71,11 +71,11 @@ if (!instance_exists(obj_saveload) && !instance_exists(obj_popup) && !instance_e
                 }
             }
 
-            if (battle_special[current_battle] == "csm") {
-                obj_fleet.csm_exp = 1;
+            if (battle_special[current_battle] == "chaos") {
+                obj_fleet.chaos_exp = 1;
             }
             if (battle_special[current_battle] == "BLOOD") {
-                obj_fleet.csm_exp = 2;
+                obj_fleet.chaos_exp = 2;
             }
 
             instance_activate_all();

--- a/scripts/scr_PlanetData/scr_PlanetData.gml
+++ b/scripts/scr_PlanetData/scr_PlanetData.gml
@@ -1520,7 +1520,7 @@ function PlanetData(_planet, _system) constructor {
             strength = strength > 2 ? 2 : 0;
 
             if (system.p_chaos[planet] > 0) {
-                system.p_chaos[planet] = max(0, system.p_traitors[planet] - 1);
+                system.p_chaos[planet] = max(0, system.p_chaos[planet] - 1);
             } else if (system.p_traitors[planet] > 0) {
                 system.p_traitors[planet] = max(0, system.p_traitors[planet] - 2);
             }

--- a/scripts/scr_PlanetData/scr_PlanetData.gml
+++ b/scripts/scr_PlanetData/scr_PlanetData.gml
@@ -310,8 +310,8 @@ function PlanetData(_planet, _system) constructor {
         planet_forces[7] = system.p_orks[planet];
         planet_forces[8] = system.p_tau[planet];
         planet_forces[9] = system.p_tyranids[planet];
-        planet_forces[10] = system.p_traitors[planet];
-        planet_forces[11] = system.p_chaos[planet] + system.p_demons[planet];
+        planet_forces[10] = system.p_chaos[planet] + system.p_demons[planet];
+        planet_forces[11] = system.p_traitors[planet];
 
         planet_forces[13] = system.p_necrons[planet];
     } catch (_exception) {
@@ -1027,7 +1027,7 @@ function PlanetData(_planet, _system) constructor {
             }
         }
         if (planet_forces[eFACTION.CHAOS] > 0) {
-            guard_attack = "csm";
+            guard_attack = "chaos";
         }
         if ((pdf > 0) && (current_owner == eFACTION.TAU)) {
             guard_attack = "pdf";
@@ -1090,7 +1090,7 @@ function PlanetData(_planet, _system) constructor {
 
         if (_pdf_attack == "") {
             if (planet_forces[eFACTION.CHAOS] > 0) {
-                _pdf_attack = "csm";
+                _pdf_attack = "chaos";
             } else if (planet_forces[eFACTION.HERETICS] > 0) {
                 _pdf_attack = "traitors";
             } else if (planet_forces[eFACTION.ORK] > 0) {
@@ -1350,7 +1350,7 @@ function PlanetData(_planet, _system) constructor {
             "Tau",
             "Tyranids",
             "Chaos",
-            "Traitors",
+            "Heretics",
             "Daemons",
             "Necrons",
         ];
@@ -1359,8 +1359,8 @@ function PlanetData(_planet, _system) constructor {
             "p_orks",
             "p_tau",
             "p_tyranids",
-            "p_traitors",
             "p_chaos",
+            "p_traitors",
             "p_demons",
             "p_necrons",
         ];

--- a/scripts/scr_bomb_world/scr_bomb_world.gml
+++ b/scripts/scr_bomb_world/scr_bomb_world.gml
@@ -103,14 +103,10 @@ function scr_bomb_world(bombard_target_faction, bombard_ment_power, target_stren
                     bombard_protection = 2;
                 }
                 break;
-            // case 11:
-            // txt2="##The Chaos Space Marine forces are difficult to bombard; ";
-            // bombard_protection=3;
-            // break;
-            // case 12:
-            // txt2="##The Daemonic forces are incredibly difficult to bombard; ";
-            // bombard_protection=4;
-            // break;
+            case 11:
+                txt2 = "##The Traitor forces are suitably fortified; ";
+                bombard_protection = 3;
+                break;
             case 13:
                 txt2 = "##The Necron forces are incredibly difficult to bombard; ";
                 bombard_protection = 4; // They are a hi-tech faction, so bombing them should be difficult
@@ -170,22 +166,25 @@ function scr_bomb_world(bombard_target_faction, bombard_ment_power, target_stren
         // if (rel>0 && rel<=20 && (target_strength-strength_reduction)>0){
         //	txt2+=" minor losses from the bombardment, decreasing "+string(strength_reduction)+" stages.";
         // ?
-        if ((target_strength - strength_reduction) <= 0) {
-            txt2 += " total annihilation from the bombardment and are wiped clean from the planet.";
-        } else {
-            var _losses_text = "";
-            if (rel > 0 && rel <= 20) {
-                _losses_text = "minor losses";
-            } else if (rel > 20 && rel <= 40) {
-                _losses_text = "moderate losses";
-            } else if (rel > 40 && rel <= 60) {
-                _losses_text = "heavy losses";
-            } else if (rel > 60 && (target_strength - strength_reduction) > 0) {
-                _losses_text = "devastating losses";
+        if (strength_reduction > 0) {
+            if ((target_strength - strength_reduction) <= 0) {
+                txt2 += " total annihilation from the bombardment and are wiped clean from the planet.";
             } else {
-                _losses_text = "some losses";
+                var _losses_text = "";
+                var _damage_pct = 100 - rel;
+                if (_damage_pct > 0 && _damage_pct <= 20) {
+                    _losses_text = "minor losses";
+                } else if (_damage_pct > 20 && _damage_pct <= 40) {
+                    _losses_text = "moderate losses";
+                } else if (_damage_pct > 40 && _damage_pct <= 60) {
+                    _losses_text = "heavy losses";
+                } else if (_damage_pct > 60) {
+                    _losses_text = "devastating losses";
+                } else {
+                    _losses_text = "some losses";
+                }
+                txt2 += $" {_losses_text} from the bombardment, having presence decreased by {strength_reduction}.";
             }
-            txt2 += $" {_losses_text} from the bombardment, having presence decreased by {strength_reduction}.";
         }
 
         // 135; ?
@@ -255,14 +254,16 @@ function scr_bomb_world(bombard_target_faction, bombard_ment_power, target_stren
                     system.p_tyranids[planet] -= strength_reduction;
                     break;
                 case 10:
-                    system.p_traitors[planet] -= strength_reduction;
+                    var _chaos_cut = min(system.p_chaos[planet], strength_reduction);
+                    system.p_chaos[planet] -= _chaos_cut;
+                    var _demon_spill = strength_reduction - _chaos_cut;
+                    if (_demon_spill > 0) {
+                        system.p_demons[planet] = max(0, system.p_demons[planet] - _demon_spill);
+                    }
                     break;
-                // case 11:
-                // system.p_csm[planet]-=strength_reduction;
-                // break;
-                // case 12:
-                // system.p_demons[planet]-=strength_reduction;
-                // break;
+                case 11:
+                    system.p_traitors[planet] = max(0, system.p_traitors[planet] - strength_reduction);
+                    break;
                 case 13:
                     system.p_necrons[planet] -= strength_reduction;
                     break;

--- a/scripts/scr_chapter_new/scr_chapter_new.gml
+++ b/scripts/scr_chapter_new/scr_chapter_new.gml
@@ -30,7 +30,7 @@ function ChapterData() constructor {
     home_planets = 1;
 
     flagship_name = global.name_generator.GenerateFromSet("imperial_ship");
-    monastary_name = "";
+    monastery_name = "";
     advantages = array_create(9);
     disadvantages = array_create(9);
     discipline = "librarius"; // todo convert to enum

--- a/scripts/scr_chapter_new/scr_chapter_new.gml
+++ b/scripts/scr_chapter_new/scr_chapter_new.gml
@@ -224,7 +224,7 @@ function scr_chapter_new(chapter_identifier) {
     load_default_gear(eROLE.VETERAN, "Veteran", "Combiflamer", "Combat Knife", STR_ANY_POWER_ARMOUR, "", "");
     load_default_gear(eROLE.TERMINATOR, "Terminator", "Power Fist", "Storm Bolter", "Terminator Armour", "", "");
     load_default_gear(eROLE.CAPTAIN, "Captain", "Power Sword", "Bolt Pistol", STR_ANY_POWER_ARMOUR, "", "Iron Halo");
-    load_default_gear(eROLE.DREADNOUGHT, "Dreadnought", "Dreadnought Lightning Claw", "Lascannon", "Dreadnought", "", "");
+    load_default_gear(eROLE.DREADNOUGHT, "Dreadnought", "Dreadnought Lightning Claw", "Twin Linked Lascannon", "Dreadnought", "", "");
     load_default_gear(eROLE.CHAMPION, "Champion", "Power Sword", STR_ANY_POWER_ARMOUR, STR_ANY_POWER_ARMOUR, "", "Combat Shield");
     load_default_gear(eROLE.TACTICAL, "Tactical", "Bolter", "Combat Knife", STR_ANY_POWER_ARMOUR, "", "");
     load_default_gear(eROLE.DEVASTATOR, "Devastator", "", "Combat Knife", STR_ANY_POWER_ARMOUR, "", "");

--- a/scripts/scr_chapter_random/scr_chapter_random.gml
+++ b/scripts/scr_chapter_random/scr_chapter_random.gml
@@ -955,7 +955,7 @@ function scr_chapter_random(custom_or_random) {
     if (ran2 == 93) {
         phrase2 = "Wizards";
         col_second = "Purple";
-        name[100][eROLE.LIBRARIAN] = "Wizard";
+        role[100][eROLE.LIBRARIAN] = "Wizard";
         chapter_master_specialty = 3;
     }
     if (ran2 == 94) {

--- a/scripts/scr_cheatcode/scr_cheatcode.gml
+++ b/scripts/scr_cheatcode/scr_cheatcode.gml
@@ -544,8 +544,8 @@ function draw_planet_debug_forces() {
         "Orks",
         "Tau",
         "Tyranids",
-        "Traitors",
-        "CSM",
+        "Chaos",
+        "Heretics",
         "Daemons",
         "Necrons",
         "Sisters"
@@ -554,8 +554,8 @@ function draw_planet_debug_forces() {
         "p_orks",
         "p_tau",
         "p_tyranids",
-        "p_traitors",
         "p_chaos",
+        "p_traitors",
         "p_demons",
         "p_necrons",
         "p_sisters"

--- a/scripts/scr_drop_select_function/scr_drop_select_function.gml
+++ b/scripts/scr_drop_select_function/scr_drop_select_function.gml
@@ -273,7 +273,7 @@ function drop_select_unit_selection() {
                 tau,
                 tyranids,
                 traitors,
-                csm,
+                chaos,
                 demons,
                 necrons
             ];

--- a/scripts/scr_enemy_ai_a/scr_enemy_ai_a.gml
+++ b/scripts/scr_enemy_ai_a/scr_enemy_ai_a.gml
@@ -86,11 +86,11 @@ function scr_enemy_ai_a() {
         var pdf_score = 0;
         var eldar_score = 0;
 
-        var guard_attack = "", pdf_attack = "", ork_attack = "", tau_attack = "", traitors_attack = "", csm_attack = "";
+        var guard_attack = "", pdf_attack = "", ork_attack = "", tau_attack = "", traitors_attack = "", chaos_attack = "";
         var eldar_attack = "", tyranids_attack = "", necrons_attack = "", sisters_attack = "";
 
         var traitors_score = p_traitors[_run];
-        var csm_score = p_chaos[_run];
+        var chaos_score = p_chaos[_run];
         var tyranids_score = p_tyranids[_run];
         var necrons_score = p_necrons[_run];
         var sisters_score = p_sisters[_run];
@@ -167,7 +167,7 @@ function scr_enemy_ai_a() {
                     sisters_attack = "traitors";
                 }
                 if (p_chaos[_run] > 0) {
-                    sisters_attack = "csm";
+                    sisters_attack = "chaos";
                 }
                 if ((p_player[_run] > 0) && (obj_controller.faction_status[5] == "War")) {
                     sisters_attack = "player";
@@ -196,7 +196,7 @@ function scr_enemy_ai_a() {
                 ork_attack = "traitors";
             }
             if ((rand == 4) && (p_chaos[_run] > 0)) {
-                ork_attack = "csm";
+                ork_attack = "chaos";
             }
             if ((rand == 5) && (p_sisters[_run] > 0)) {
                 ork_attack = "sisters";
@@ -227,19 +227,19 @@ function scr_enemy_ai_a() {
         }
         if ((p_chaos[_run] > 0) && (stop != 1)) {
             if ((planet_forces[eFACTION.ORK] == 0) && (planet_forces[eFACTION.TAU] == 0)) {
-                csm_attack = "imp";
+                chaos_attack = "imp";
             }
             if ((planet_forces[eFACTION.ORK] > planet_forces[eFACTION.TAU]) && (planet_forces[eFACTION.ORK] > guard_score) && (planet_forces[eFACTION.ORK] > pdf_score)) {
-                csm_attack = "orks";
+                chaos_attack = "orks";
             }
             if ((sisters_score > planet_forces[eFACTION.TAU]) && (sisters_score > planet_forces[eFACTION.ORK]) && (sisters_score > pdf_score)) {
-                csm_attack = "sisters";
+                chaos_attack = "sisters";
             }
             if ((guard_score > planet_forces[eFACTION.TAU]) && (guard_score > planet_forces[eFACTION.ORK])) {
-                csm_attack = "imp";
+                chaos_attack = "imp";
             }
-            if ((csm_attack == "") && (p_player[_run] > 0)) {
-                csm_attack = "player";
+            if ((chaos_attack == "") && (p_player[_run] > 0)) {
+                chaos_attack = "player";
             }
         }
 
@@ -252,8 +252,8 @@ function scr_enemy_ai_a() {
             if (traitors_score > 0) {
                 tau_attack = "traitors";
             }
-            if (csm_score > 0) {
-                tau_attack = "csm";
+            if (chaos_score > 0) {
+                tau_attack = "chaos";
             }
             if (planet_forces[eFACTION.ORK] > 0) {
                 tau_attack = "ork";
@@ -264,11 +264,11 @@ function scr_enemy_ai_a() {
             if (traitors_score >= 4) {
                 tau_attack = "traitors";
             }
-            if ((csm_score >= 3) && (planet_forces[eFACTION.ORK] <= 2)) {
-                tau_attack = "csm";
+            if ((chaos_score >= 3) && (planet_forces[eFACTION.ORK] <= 2)) {
+                tau_attack = "chaos";
             }
-            if (csm_score >= 4) {
-                tau_attack = "csm";
+            if (chaos_score >= 4) {
+                tau_attack = "chaos";
             }
             if (planet_forces[eFACTION.ORK] >= 4) {
                 tau_attack = "ork";
@@ -295,8 +295,8 @@ function scr_enemy_ai_a() {
             if (traitors_score >= 4) {
                 tau_attack = "traitors";
             }
-            if (csm_score >= 4) {
-                tau_attack = "csm";
+            if (chaos_score >= 4) {
+                tau_attack = "chaos";
             }
             if (planet_forces[eFACTION.ORK] >= 4) {
                 tau_attack = "ork";
@@ -328,7 +328,7 @@ function scr_enemy_ai_a() {
                 tyranids_attack = "orks";
             }
             if ((rand == 5) && (p_chaos[_run] > 0)) {
-                tyranids_attack = "csm";
+                tyranids_attack = "chaos";
             }
             if ((rand == 6) && (p_sisters[_run] > 0)) {
                 tyranids_attack = "sisters";
@@ -358,7 +358,7 @@ function scr_enemy_ai_a() {
                 necrons_attack = "orks";
             }
             if ((rand == 5) && (p_chaos[_run] > 0)) {
-                necrons_attack = "csm";
+                necrons_attack = "chaos";
             }
             if ((rand == 6) && (p_sisters[_run] > 0)) {
                 necrons_attack = "sisters";
@@ -382,8 +382,8 @@ function scr_enemy_ai_a() {
                 traitors_attack = default_imperium_attack;
             }
 
-            if (csm_attack == "imp") {
-                csm_attack = default_imperium_attack;
+            if (chaos_attack == "imp") {
+                chaos_attack = default_imperium_attack;
             }
 
             if (necrons_attack == "imp") {
@@ -410,9 +410,9 @@ function scr_enemy_ai_a() {
             var after_combat_ork_force = planet_forces[eFACTION.ORK];
             var after_combat_tau = planet_forces[eFACTION.TAU];
             var after_combat_traitor = traitors_score;
-            var after_combat_csm = csm_score;
-            if (csm_score == 6.1) {
-                csm_score = 8;
+            var after_combat_chaos = chaos_score;
+            if (chaos_score == 6.1) {
+                chaos_score = 8;
             }
             var after_combat_necrons = necrons_score;
             var after_combat_tyranids = tyranids_score;
@@ -432,8 +432,8 @@ function scr_enemy_ai_a() {
                 if (guard_attack == "traitors") {
                     tempor = choose(1, 2, 3, 4, 5, 6) * traitors_score;
                 }
-                if (guard_attack == "csm") {
-                    tempor = choose(2, 3, 4, 5, 6, 7) * csm_score;
+                if (guard_attack == "chaos") {
+                    tempor = choose(2, 3, 4, 5, 6, 7) * chaos_score;
                 }
                 if (guard_attack == "tyranids") {
                     tempor = choose(2, 3, 4, 5, 6, 7) * tyranids_score;
@@ -450,7 +450,7 @@ function scr_enemy_ai_a() {
                 if ((guard_attack == "traitors") && (traitors_score > guard_score)) {
                     rand1 = 0;
                 }
-                if ((guard_attack == "csm") && (csm_score > guard_score)) {
+                if ((guard_attack == "chaos") && (chaos_score > guard_score)) {
                     rand1 = 0;
                 }
                 if ((guard_attack == "tyranids") && (tyranids_score > guard_score)) {
@@ -511,8 +511,8 @@ function scr_enemy_ai_a() {
                     if (guard_attack == "traitors") {
                         after_combat_traitor -= 1;
                     }
-                    if (guard_attack == "csm") {
-                        after_combat_csm -= 1;
+                    if (guard_attack == "chaos") {
+                        after_combat_chaos -= 1;
                     }
                     if (guard_attack == "tyranids") {
                         after_combat_tyranids -= 1;
@@ -531,8 +531,8 @@ function scr_enemy_ai_a() {
                 if (pdf_attack == "traitors") {
                     tempor = traitors_score;
                 }
-                if (pdf_attack == "csm") {
-                    tempor = csm_score;
+                if (pdf_attack == "chaos") {
+                    tempor = chaos_score;
                 }
                 if (pdf_attack == "guard") {
                     tempor = guard_score;
@@ -553,7 +553,7 @@ function scr_enemy_ai_a() {
                 if ((pdf_attack == "traitors") && (traitors_score >= 6)) {
                     rand2 = 1;
                 }
-                if ((pdf_attack == "csm") && (csm_score >= 3)) {
+                if ((pdf_attack == "chaos") && (chaos_score >= 3)) {
                     rand2 = 1;
                 }
                 if ((pdf_attack == "tyranids") && (tyranids_score >= pdf_score)) {
@@ -579,8 +579,8 @@ function scr_enemy_ai_a() {
                 if (pdf_attack == "traitors") {
                     after_combat_traitor = tempor;
                 }
-                if (pdf_attack == "csm") {
-                    after_combat_csm = tempor;
+                if (pdf_attack == "chaos") {
+                    after_combat_chaos = tempor;
                 }
                 if ((pdf_attack == "tyranids") && (tyranids_score >= 4)) {
                     after_combat_tyranids = tempor;
@@ -628,13 +628,13 @@ function scr_enemy_ai_a() {
                     if (rand1 > rand2) {
                         after_combat_traitor -= 1;
                     }
-                } else if (sisters_attack == "csm") {
-                    rand2 = (choose(2, 3, 4, 5, 6) * csm_score) * choose(1, 1.25);
-                    if (csm_score == 6.1) {
+                } else if (sisters_attack == "chaos") {
+                    rand2 = (choose(2, 3, 4, 5, 6) * chaos_score) * choose(1, 1.25);
+                    if (chaos_score == 6.1) {
                         rand2 = 999;
                     }
                     if (rand1 > rand2) {
-                        after_combat_csm -= 1;
+                        after_combat_chaos -= 1;
                     }
                 } else if (sisters_attack == "necrons") {
                     rand2 = (choose(4, 5, 6, 7) * necrons_score) * choose(1, 1.25);
@@ -649,25 +649,25 @@ function scr_enemy_ai_a() {
                 } else if (sisters_attack == "pdf") {
                     rand2 = (choose(1, 2, 3, 4, 5) * pdf_score) * choose(1, 1.25);
                     if (rand1 > rand2) {
-                        if (csm_score >= 6) {
+                        if (chaos_score >= 6) {
                             p_pdf[_run] = 0;
                         }
-                        if (csm_score <= 3) {
+                        if (chaos_score <= 3) {
                             p_pdf[_run] = floor(p_pdf[_run] * min(0.95, 0.75 + pdf_loss_reduction));
                         }
-                        if (csm_score >= 4) {
+                        if (chaos_score >= 4) {
                             p_pdf[_run] = floor(p_pdf[_run] * min(0.95, 0.65 + pdf_loss_reduction));
                         }
-                        if ((csm_score >= 4) && (p_pdf[_run] < 60000)) {
+                        if ((chaos_score >= 4) && (p_pdf[_run] < 60000)) {
                             p_pdf[_run] = 0;
                         }
-                        if ((csm_score >= 3) && (p_pdf[_run] < 20000)) {
+                        if ((chaos_score >= 3) && (p_pdf[_run] < 20000)) {
                             p_pdf[_run] = 0;
                         }
-                        if ((csm_score >= 2) && (p_pdf[_run] < 3000)) {
+                        if ((chaos_score >= 2) && (p_pdf[_run] < 3000)) {
                             p_pdf[_run] = 0;
                         }
-                        if ((csm_score >= 1) && (p_pdf[_run] < 1000)) {
+                        if ((chaos_score >= 1) && (p_pdf[_run] < 1000)) {
                             p_pdf[_run] = 0;
                         }
                     }
@@ -688,13 +688,13 @@ function scr_enemy_ai_a() {
                     if ((rand1 > rand2) && (traitors_score != 7)) {
                         after_combat_traitor -= 1;
                     }
-                } else if (tau_attack == "csm") {
-                    rand2 = (choose(1, 2, 3, 4, 5, 6) * csm_score) * choose(1, 1.25);
-                    if (csm_score == 6.1) {
+                } else if (tau_attack == "chaos") {
+                    rand2 = (choose(1, 2, 3, 4, 5, 6) * chaos_score) * choose(1, 1.25);
+                    if (chaos_score == 6.1) {
                         rand2 = 999;
                     }
                     if (rand1 > rand2) {
-                        after_combat_csm -= 1;
+                        after_combat_chaos -= 1;
                     }
                 } else if (tau_attack == "guard") {
                     rand2 = (choose(1, 2, 3, 4, 5, 6) * guard_score) * choose(1, 1.25);
@@ -738,10 +738,10 @@ function scr_enemy_ai_a() {
                     if ((rand1 > rand2) && (traitors_score < 6)) {
                         after_combat_traitor -= 1;
                     }
-                } else if (ork_attack == "csm") {
-                    rand2 = (choose(1, 2, 3, 4, 5, 6) * csm_score) * choose(1, 1.25);
-                    if ((rand1 > rand2) && (csm_score != 6)) {
-                        after_combat_csm -= 1;
+                } else if (ork_attack == "chaos") {
+                    rand2 = (choose(1, 2, 3, 4, 5, 6) * chaos_score) * choose(1, 1.25);
+                    if ((rand1 > rand2) && (chaos_score != 6)) {
+                        after_combat_chaos -= 1;
                     }
                 } else if (ork_attack == "guard") {
                     var onc = 0;
@@ -908,73 +908,73 @@ function scr_enemy_ai_a() {
             }
 
             // CSM attack
-            if ((csm_score > 0) && (csm_attack != "") && (csm_attack != "player")) {
-                rand1 = choose(2, 3, 4, 5, 6, 7) * csm_score;
-                if (csm_score >= 5) {
+            if ((chaos_score > 0) && (chaos_attack != "") && (chaos_attack != "player")) {
+                rand1 = choose(2, 3, 4, 5, 6, 7) * chaos_score;
+                if (chaos_score >= 5) {
                     rand1 = choose(30, 36);
                 }
 
-                if (csm_attack == "tau") {
+                if (chaos_attack == "tau") {
                     rand2 = (choose(1, 2, 3, 4, 5) * planet_forces[eFACTION.TAU]) * choose(1, 1.25);
                     if (rand1 > rand2) {
                         after_combat_tau -= 1;
                     }
-                } else if (csm_attack == "ork") {
+                } else if (chaos_attack == "ork") {
                     rand2 = (choose(1, 2, 3, 4, 5) * planet_forces[eFACTION.ORK]) * choose(1, 1.25);
                     if (rand1 > rand2) {
                         after_combat_ork_force -= 1;
                     }
-                } else if (csm_attack == "guard") {
+                } else if (chaos_attack == "guard") {
                     rand2 = (choose(1, 2, 3, 4, 5) * guard_score) * choose(1, 1.25);
                     if (rand1 > rand2) {
-                        if (csm_score <= 3) {
+                        if (chaos_score <= 3) {
                             p_guardsmen[_run] = floor(p_guardsmen[_run] * 0.7);
                         }
-                        if (csm_score >= 4) {
+                        if (chaos_score >= 4) {
                             p_guardsmen[_run] = floor(p_guardsmen[_run] * 0.6);
                         }
-                        if (csm_score >= 6) {
+                        if (chaos_score >= 6) {
                             p_guardsmen[_run] = floor(p_guardsmen[_run] * 0.3);
                         }
-                        if ((csm_score >= 4) && (p_guardsmen[_run] < 15000)) {
+                        if ((chaos_score >= 4) && (p_guardsmen[_run] < 15000)) {
                             p_guardsmen[_run] = 0;
                         }
-                        if ((csm_score >= 3) && (p_guardsmen[_run] < 5000)) {
+                        if ((chaos_score >= 3) && (p_guardsmen[_run] < 5000)) {
                             p_guardsmen[_run] = 0;
                         }
-                        if ((csm_score >= 2) && (p_guardsmen[_run] < 1000)) {
+                        if ((chaos_score >= 2) && (p_guardsmen[_run] < 1000)) {
                             p_guardsmen[_run] = 0;
                         }
-                        if ((csm_score >= 1) && (p_guardsmen[_run] < 500)) {
+                        if ((chaos_score >= 1) && (p_guardsmen[_run] < 500)) {
                             p_guardsmen[_run] = 0;
                         }
                     }
-                } else if (csm_attack == "pdf") {
+                } else if (chaos_attack == "pdf") {
                     rand2 = (choose(1, 2, 3, 4, 5) * pdf_score) * choose(1, 1.25);
                     if (rand1 > rand2) {
-                        if (csm_score >= 6) {
+                        if (chaos_score >= 6) {
                             p_pdf[_run] = 0;
                         }
-                        if (csm_score <= 3) {
+                        if (chaos_score <= 3) {
                             p_pdf[_run] = floor(p_pdf[_run] * min(0.95, 0.75 + pdf_loss_reduction));
                         }
-                        if (csm_score >= 4) {
+                        if (chaos_score >= 4) {
                             p_pdf[_run] = floor(p_pdf[_run] * min(0.95, 0.55 + pdf_loss_reduction));
                         }
-                        if ((csm_score >= 4) && (p_pdf[_run] < 60000)) {
+                        if ((chaos_score >= 4) && (p_pdf[_run] < 60000)) {
                             p_pdf[_run] = 0;
                         }
-                        if ((csm_score >= 3) && (p_pdf[_run] < 20000)) {
+                        if ((chaos_score >= 3) && (p_pdf[_run] < 20000)) {
                             p_pdf[_run] = 0;
                         }
-                        if ((csm_score >= 2) && (p_pdf[_run] < 3000)) {
+                        if ((chaos_score >= 2) && (p_pdf[_run] < 3000)) {
                             p_pdf[_run] = 0;
                         }
-                        if ((csm_score >= 1) && (p_pdf[_run] < 1000)) {
+                        if ((chaos_score >= 1) && (p_pdf[_run] < 1000)) {
                             p_pdf[_run] = 0;
                         }
                     }
-                } else if (csm_attack == "sisters") {
+                } else if (chaos_attack == "sisters") {
                     rand2 = (choose(2, 3, 4, 5, 6) * sisters_score) * choose(1, 1.25);
                     if (rand1 > rand2) {
                         after_combat_sisters -= 1;
@@ -1000,10 +1000,10 @@ function scr_enemy_ai_a() {
                     if (rand1 > rand2) {
                         after_combat_ork_force -= 1;
                     }
-                } else if (tyranids_attack == "csm") {
-                    rand2 = (choose(1, 2, 3, 4, 5) * csm_score) * choose(1, 1.25);
+                } else if (tyranids_attack == "chaos") {
+                    rand2 = (choose(1, 2, 3, 4, 5) * chaos_score) * choose(1, 1.25);
                     if (rand1 > rand2) {
-                        after_combat_csm -= 1;
+                        after_combat_chaos -= 1;
                     }
                 } else if (tyranids_attack == "traitors") {
                     rand2 = (choose(1, 2, 3, 4, 5) * traitors_score) * choose(1, 1.25);
@@ -1095,15 +1095,15 @@ function scr_enemy_ai_a() {
                     if (rand1 > rand2) {
                         after_combat_ork_force -= 1;
                     }
-                } else if (necrons_attack == "csm") {
-                    rand2 = (choose(1, 2, 3, 4, 5) * csm_score) * choose(1, 1.25);
+                } else if (necrons_attack == "chaos") {
+                    rand2 = (choose(1, 2, 3, 4, 5) * chaos_score) * choose(1, 1.25);
                     if (rand1 > rand2) {
-                        after_combat_csm -= 1;
+                        after_combat_chaos -= 1;
                     }
                 } else if (necrons_attack == "traitors") {
                     rand2 = (choose(1, 2, 3, 4, 5) * traitors_score) * choose(1, 1.25);
                     if ((rand1 > rand2) && (traitors_score != 7)) {
-                        after_combat_csm -= 1;
+                        after_combat_chaos -= 1;
                     }
                 } else if (necrons_attack == "imp") {
                     if (p_pdf[_run] > 0) {
@@ -1184,7 +1184,7 @@ function scr_enemy_ai_a() {
             p_orks[_run] = after_combat_ork_force;
             p_tau[_run] = after_combat_tau;
             p_traitors[_run] = after_combat_traitor;
-            p_chaos[_run] = after_combat_csm;
+            p_chaos[_run] = after_combat_chaos;
             p_necrons[_run] = after_combat_necrons;
             if (p_tyranids[_run] != after_combat_tyranids) {
                 p_tyranids[_run] = after_combat_tyranids;

--- a/scripts/scr_enemy_ai_c/scr_enemy_ai_c.gml
+++ b/scripts/scr_enemy_ai_c/scr_enemy_ai_c.gml
@@ -253,7 +253,7 @@ function scr_enemy_ai_c() {
         }
 
         if ((gud != 0) && instance_exists(boat)) {
-            if (fleet_has_cargo("csm", boat)) {
+            if (fleet_has_cargo("chaos", boat)) {
                 if (p_chaos[gud] < 4) {
                     p_chaos[gud] += max(1, floor(boat.image_index * 0.5));
                     if (p_chaos[gud] > 4) {

--- a/scripts/scr_enemy_ai_d/scr_enemy_ai_d.gml
+++ b/scripts/scr_enemy_ai_d/scr_enemy_ai_d.gml
@@ -54,11 +54,11 @@ function scr_enemy_ai_d() {
                 enemy1 = "Tau";
                 enemies += 1;
             }
-            if (p_traitors[i] >= minimum) {
+            if (p_chaos[i] >= minimum) {
                 enemy1 = "Heretic";
                 enemies += 1;
             }
-            if (p_chaos[i] >= minimum) {
+            if (p_traitors[i] >= minimum) {
                 enemy1 = "Chaos Space Marine";
                 enemies += 1;
             }

--- a/scripts/scr_enemy_ai_e/scr_enemy_ai_e.gml
+++ b/scripts/scr_enemy_ai_e/scr_enemy_ai_e.gml
@@ -488,7 +488,7 @@ function scr_enemy_ai_e() {
                                 if (string_count("warband", trade_goods) > 0) {
                                     instance_create(x, y, obj_temp2);
                                 }
-                                if (string_lower(trade_goods) == "csm") {
+                                if (string_lower(trade_goods) == "chaos") {
                                     instance_create(x, y, obj_temp3);
                                 }
                             }
@@ -500,7 +500,7 @@ function scr_enemy_ai_e() {
                             }
                         }
                         if (instance_exists(obj_temp3)) {
-                            obj_turn_end.battle_special[obj_turn_end.battles] = "CSM";
+                            obj_turn_end.battle_special[obj_turn_end.battles] = "CHAOS";
                             with (obj_temp2) {
                                 instance_destroy();
                             }
@@ -632,13 +632,13 @@ function scr_enemy_ai_e() {
                         break;
                     case 10:
                         pause = has_problem_planet(run, "meeting") || has_problem_planet(run, "meeting_trap");
-                        if (p_guardsmen[run] + p_pdf[run] == 0 && p_player[run] > 0 && p_traitors[run] > 0 && !pause && obj_controller.faction_status[10] == "War") {
+                        if (p_guardsmen[run] + p_pdf[run] == 0 && p_player[run] > 0 && p_chaos[run] > 0 && !pause && obj_controller.faction_status[10] == "War") {
                             battle_opponent = 10;
                         }
                         break;
                     case 11:
                         pause = has_problem_planet(run, "meeting") || has_problem_planet(run, "meeting_trap");
-                        if (p_guardsmen[run] + p_pdf[run] == 0 && p_player[run] > 0 && p_chaos[run] > 0 && !pause && obj_controller.faction_status[10] == "War") {
+                        if (p_guardsmen[run] + p_pdf[run] == 0 && p_player[run] > 0 && p_traitors[run] > 0 && !pause && obj_controller.faction_status[10] == "War") {
                             battle_opponent = 11;
                         }
                         break;

--- a/scripts/scr_event_code/scr_event_code.gml
+++ b/scripts/scr_event_code/scr_event_code.gml
@@ -102,7 +102,7 @@ function event_end_turn_action() {
                         flee.capital_number = choose(0, 1);
                         flee.frigate_number = choose(2, 3);
                         flee.escort_number = choose(4, 5, 6);
-                        flee.cargo_data.csm = true;
+                        flee.cargo_data.chaos = true;
                         obj_controller.chaos_fleets += 1;
                         flee.action_x = star_id.x;
                         flee.action_y = star_id.y;

--- a/scripts/scr_fleet_functions/scr_fleet_functions.gml
+++ b/scripts/scr_fleet_functions/scr_fleet_functions.gml
@@ -791,7 +791,7 @@ function fleet_arrival_logic() {
         if (fleet_has_cargo("ork_warboss")) {
             cancel = true;
         }
-        if (fleet_has_cargo("csm")) {
+        if (fleet_has_cargo("chaos")) {
             cancel = true;
         }
 
@@ -932,7 +932,7 @@ function fleet_arrival_logic() {
         mergus = 0;
     }
 
-    if ((owner == eFACTION.CHAOS) && fleet_has_cargo("csm") || fleet_has_cargo("warband")) {
+    if ((owner == eFACTION.CHAOS) && fleet_has_cargo("chaos") || fleet_has_cargo("warband")) {
         mergus = 0;
     }
 
@@ -1031,9 +1031,9 @@ function fleet_arrival_logic() {
     x = old_x;
     y = old_y;
 
-    var _csm = fleet_has_cargo("warband");
+    var _chaos = fleet_has_cargo("warband");
 
-    if ((cur_star.x == old_x) && (cur_star.y == old_y) && (cur_star.owner == self.owner) && (cur_star.action == "") && ((owner == eFACTION.TAU) || (owner == eFACTION.CHAOS)) && (mergus == 10) && (!_csm)) {
+    if ((cur_star.x == old_x) && (cur_star.y == old_y) && (cur_star.owner == self.owner) && (cur_star.action == "") && ((owner == eFACTION.TAU) || (owner == eFACTION.CHAOS)) && (mergus == 10) && (!_chaos)) {
         // Move somewhere new
         var stue2 = noone;
         var goood = 0;

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -192,14 +192,6 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
         load_json_data(global.base_stats[$ class]);
     }
 
-    if (struct_exists(self, "start_gear")) {
-        if (base_group != "marine") {
-            alter_equipment(start_gear, false, false);
-        } else {
-            alter_equipment(start_gear, true, true);
-        }
-    }
-
     var stats = [
         "constitution",
         "strength",
@@ -231,6 +223,14 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
                     variable_struct_set(self, stats[stat_iter], stat_mod);
                 }
             }
+        }
+    }
+
+    if (struct_exists(self, "start_gear")) {
+        if (base_group != "marine") {
+            alter_equipment(start_gear, false, false);
+        } else {
+            alter_equipment(start_gear, true, true);
         }
     }
 

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -1424,7 +1424,7 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
         } else if (base_group == "human") {
             melee_hands_limit = 1;
         }
-        carry_string += "Base: 2#";
+        carry_string += $"Base: {melee_hands_limit}#";
         if (strength >= 50) {
             melee_hands_limit += 0.25;
             carry_string += "STR: +0.25#";

--- a/scripts/scr_planetary_feature/scr_planetary_feature.gml
+++ b/scripts/scr_planetary_feature/scr_planetary_feature.gml
@@ -152,7 +152,7 @@ function NewPlanetFeature(feature_type, other_data = {}) constructor {
             tier = 1;
             break;
         case eP_FEATURES.MONASTERY:
-            planet_display = "Fortress Monastary";
+            planet_display = "Fortress Monastery";
             player_hidden = 0;
             forge = 0;
             name = global.name_generator.GenerateFromSet("imperial_ship");

--- a/scripts/scr_reequip_units/scr_reequip_units.gml
+++ b/scripts/scr_reequip_units/scr_reequip_units.gml
@@ -205,6 +205,39 @@ function reload_items() {
     );
 }
 
+/// @param {Struct.EquipmentStruct} _armour_data
+/// @param {Struct.EquipmentStruct} _mobility_data
+/// @returns {Struct} { valid: bool, warning: string }
+function check_mobility_armour_compatibility(_armour_data, _mobility_data) {
+    var _result = { valid: true, warning: "" };
+    
+    if (is_struct(_armour_data) && is_struct(_mobility_data)) {
+        if (_armour_data.has_tag("terminator") && !_mobility_data.has_tag("terminator") && !_mobility_data.has_tag("terminator_only")) {
+            _result.valid = false;
+            _result.warning = "Cannot use this with Terminator Armour.";
+        } else if (!_armour_data.has_tag("terminator") && _mobility_data.has_tag("terminator_only")) {
+            _result.valid = false;
+            _result.warning = "Cannot use this without Terminator Armour.";
+        } else if (_armour_data.has_tag("dreadnought") && !_mobility_data.has_tag("dreadnought") && !_mobility_data.has_tag("dreadnought_only")) {
+            _result.valid = false;
+            _result.warning = "Cannot use this with Dreadnought Armour.";
+        } else if (!_armour_data.has_tag("dreadnought") && _mobility_data.has_tag("dreadnought_only")) {
+            _result.valid = false;
+            _result.warning = "Cannot use this without Dreadnought Armour.";
+        }
+    } else if (!is_struct(_armour_data) && is_struct(_mobility_data)) {
+        if (_mobility_data.has_tag("terminator") || _mobility_data.has_tag("terminator_only")) {
+            _result.valid = false;
+            _result.warning = "Cannot use this without Terminator Armour.";
+        } else if (_mobility_data.has_tag("dreadnought") || _mobility_data.has_tag("dreadnought_only")) {
+            _result.valid = false;
+            _result.warning = "Cannot use this without Dreadnought Armour.";
+        }
+    }
+    
+    return _result;
+}
+
 /// @self Asset.GMObject.obj_popup
 function draw_popup_equip() {
     main_slate.draw_with_dimensions();
@@ -523,50 +556,55 @@ function draw_popup_equip() {
                     n_good2 = 0;
                     warning = "Only " + string(obj_ini.role[100][6]) + " can use Close Combat Weapons.";
                 }
-                if (((string_count("Terminator", n_armour) > 0) || (string_count("Tartaros", n_armour) > 0) || (string_count("Dreadnought", n_armour) > 0)) && (n_mobi != "")) {
-                    n_good2 = 0;
-                }
-                if (((string_count("Terminator", o_armour) > 0) || (string_count("Tartaros", o_armour) > 0) || (string_count("Dreadnought", o_armour) > 0)) && (n_mobi != "")) {
-                    n_good2 = 0;
-                }
             }
         }
-        if ((equipmet_area == eEQUIPMENT_SLOT.ARMOUR) && is_struct(armour_data)) {
-            // Check numbers
-            req_armour_num = units;
-            have_armour_num = 0;
-            for (var i = 0; i < array_length(obj_controller.display_unit); i++) {
-                if ((vehicle_equipment != -1) && (obj_controller.man_sel[i] == 1) && (obj_controller.ma_armour[i] == n_armour)) {
-                    have_armour_num += 1;
+        if (equipmet_area == eEQUIPMENT_SLOT.ARMOUR) {
+            if (is_struct(armour_data)) {
+                // Check numbers
+                req_armour_num = units;
+                have_armour_num = 0;
+                for (var i = 0; i < array_length(obj_controller.display_unit); i++) {
+                    if ((vehicle_equipment != -1) && (obj_controller.man_sel[i] == 1) && (obj_controller.ma_armour[i] == n_armour)) {
+                        have_armour_num += 1;
+                    }
                 }
-            }
-            have_armour_num += scr_item_count(n_armour);
+                have_armour_num += scr_item_count(n_armour);
 
-            if (have_armour_num >= req_armour_num || n_armour == ITEM_NAME_NONE) {
-                n_good3 = 1;
-            }
-            if (have_armour_num < req_armour_num && (n_armour != ITEM_NAME_ANY && n_armour != ITEM_NAME_NONE)) {
-                n_good3 = 0;
-                warning = $"Not enough {n_armour} : {req_armour_num - have_armour_num} more are required.";
-            }
+                if (have_armour_num >= req_armour_num || n_armour == ITEM_NAME_NONE) {
+                    n_good3 = 1;
+                }
+                if (have_armour_num < req_armour_num && (n_armour != ITEM_NAME_ANY && n_armour != ITEM_NAME_NONE)) {
+                    n_good3 = 0;
+                    warning = $"Not enough {n_armour} : {req_armour_num - have_armour_num} more are required.";
+                }
 
-            if (armour_data.has_tag("terminator")) {
-                if (armour_data.req_exp > 0) {
-                    for (var g = 0; g < array_length(obj_controller.display_unit); g++) {
-                        if (obj_controller.man_sel[g] == 1 && is_struct(obj_controller.display_unit[g])) {
-                            if (obj_controller.display_unit[g].experience < armour_data.req_exp) {
-                                n_good3 = 0;
-                                warning = $"A unit must have {armour_data.req_exp}+ EXP to use a {armour_data.name}.";
-                                break;
+                if (armour_data.has_tag("terminator")) {
+                    if (armour_data.req_exp > 0) {
+                        for (var g = 0; g < array_length(obj_controller.display_unit); g++) {
+                            if (obj_controller.man_sel[g] == 1 && is_struct(obj_controller.display_unit[g])) {
+                                if (obj_controller.display_unit[g].experience < armour_data.req_exp) {
+                                    n_good3 = 0;
+                                    warning = $"A unit must have {armour_data.req_exp}+ EXP to use a {armour_data.name}.";
+                                    break;
+                                }
                             }
                         }
                     }
                 }
+
+                if ((string_count("Dread", o_armour) > 0) && (string_count("Dread", n_armour) == 0)) {
+                    n_good4 = 0;
+                    warning = "Marines may not exit Dreadnoughts.";
+                }
             }
 
-            if ((string_count("Dread", o_armour) > 0) && (string_count("Dread", n_armour) == 0)) {
-                n_good4 = 0;
-                warning = "Marines may not exit Dreadnoughts.";
+            if (is_struct(mobility_data)) {
+                n_good5 = 1;
+                var _compat = check_mobility_armour_compatibility(armour_data, mobility_data);
+                if (!_compat.valid) {
+                    n_good5 = 0;
+                    warning = _compat.warning;
+                }
             }
         }
         if ((equipmet_area == eEQUIPMENT_SLOT.GEAR) && (n_gear != "Assortment") && (n_gear != ITEM_NAME_NONE)) {
@@ -626,27 +664,11 @@ function draw_popup_equip() {
                 warning = "Not enough " + string(n_mobi) + "; " + string(req_mobi_num - have_mobi_num) + " more are required.";
             }
 
-            if (is_struct(armour_data) && is_struct(mobility_data)) {
-                if (armour_data.has_tag("terminator") && !mobility_data.has_tag("terminator") && !mobility_data.has_tag("terminator_only")) {
+            if (is_struct(mobility_data)) {
+                var _compat = check_mobility_armour_compatibility(armour_data, mobility_data);
+                if (!_compat.valid) {
                     n_good5 = 0;
-                    warning = "Cannot use this with Terminator Armour.";
-                } else if (!armour_data.has_tag("terminator") && mobility_data.has_tag("terminator_only")) {
-                    n_good5 = 0;
-                    warning = "Cannot use this without Terminator Armour.";
-                } else if (armour_data.has_tag("dreadnought") && !mobility_data.has_tag("dreadnought") && !mobility_data.has_tag("dreadnought_only")) {
-                    n_good5 = 0;
-                    warning = "Cannot use this with Dreadnought Armour.";
-                } else if (!armour_data.has_tag("dreadnought") && mobility_data.has_tag("dreadnought_only")) {
-                    n_good5 = 0;
-                    warning = "Cannot use this without Dreadnought Armour.";
-                }
-            } else if (!is_struct(armour_data) && is_struct(mobility_data)) {
-                if (mobility_data.has_tag("terminator") || mobility_data.has_tag("terminator_only")) {
-                    n_good5 = 0;
-                    warning = "Cannot use this without Terminator Armour.";
-                } else if (mobility_data.has_tag("dreadnought") || mobility_data.has_tag("dreadnought_only")) {
-                    n_good5 = 0;
-                    warning = "Cannot use this without Dreadnought Armour.";
+                    warning = _compat.warning;
                 }
             }
         }

--- a/scripts/scr_save_chapter/scr_save_chapter.gml
+++ b/scripts/scr_save_chapter/scr_save_chapter.gml
@@ -104,7 +104,7 @@ function scr_save_chapter(chapter_id) {
 
     chap.disposition = disposition;
     if (variable_instance_exists(self.id, "monastery_name")) {
-        chap.monastary_name = monastery_name;
+        chap.monastery_name = monastery_name;
     }
     chap.chapter_master = {
         name: chapter_master_name,

--- a/scripts/scr_specialist_training/scr_specialist_training.gml
+++ b/scripts/scr_specialist_training/scr_specialist_training.gml
@@ -379,26 +379,28 @@ function techmarine_training() {
                     unit.religion = "cult_mechanicus";
                     if (obj_controller.faction_status[eFACTION.MECHANICUS] != "War") {
                         unit.add_trait("mars_trained");
+                        unit.update_weapon_one(obj_ini.wep1[100][eROLE.TECHMARINE], false);
+                        unit.update_weapon_two(obj_ini.wep2[100][eROLE.TECHMARINE], false);
+                        unit.update_mobility_item(obj_ini.mobi[100][eROLE.TECHMARINE], false);
                         scr_alert("green", "recruitment", $"{unit.name()} returns from Mars, a {unit.role()}.", 0, 0);
                     } else {
                         unit.add_trait("chapter_trained_tech");
                         scr_alert("green", "recruitment", $"{unit.name_role()} has finished training.", 0, 0);
-                    }
 
-                    var _warn = "";
-                    if (unit.update_weapon_one(obj_ini.wep1[100][16]) == "no_items") {
-                        _warn += $", {obj_ini.wep1[100][16]}";
-                    }
-                    if (unit.update_weapon_two(obj_ini.wep2[100][16]) == "no_items") {
-                        _warn += $", {obj_ini.wep2[100][16]}";
-                    }
-                    if (unit.update_gear(obj_ini.gear[100][16]) == "no_items") {
-                        _warn += $", {obj_ini.gear[100][16]}";
-                    }
-
-                    if (_warn != "") {
-                        _warn += ".";
-                        scr_alert("red", "recruitment", "Not enough equipment: " + string(_warn), 0, 0);
+                        var _warn = "";
+                        if (unit.update_weapon_one(obj_ini.wep1[100][eROLE.TECHMARINE]) == "no_items") {
+                            _warn += $", {obj_ini.wep1[100][eROLE.TECHMARINE]}";
+                        }
+                        if (unit.update_weapon_two(obj_ini.wep2[100][eROLE.TECHMARINE]) == "no_items") {
+                            _warn += $", {obj_ini.wep2[100][eROLE.TECHMARINE]}";
+                        }
+                        if (unit.update_gear(obj_ini.gear[100][eROLE.TECHMARINE]) == "no_items") {
+                            _warn += $", {obj_ini.gear[100][eROLE.TECHMARINE]}";
+                        }
+    
+                        if (_warn != "") {
+                            scr_alert("red", "recruitment", $"Not enough equipment: {_warn}!", 0, 0);
+                        }
                     }
 
                     if (unit.location_string == "Terra") {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes Chaos vs Heretics mapping across UI, AI, and battles, and tightens equipment logic with clearer checks, accurate defaults, and cleaner warnings. Also improves Techmarine training outcomes, Dreadnought loadouts, and data/text consistency.

- **Bug Fixes**
  - Factions: correct Chaos vs Heretics across selection screens, AI, boarding XP (`chaos_exp`), fleet cargo/flags, labels, and power lookups (Chaos=10, Heretics=11).
  - Bombardment: add Traitors handling and proper protection; show loss text only when damage happens; fix Chaos/Heretics mapping; split Chaos losses with Daemons when applicable.
  - Equipment and UI: fix melee‑hands tooltip to use the real base limit; apply equipment after stat setup; allow a second weapon for Terminator/Tartaros/Dreadnought units; set Dreadnought default to Twin Linked Lascannon; fix random chapter generator to set the Librarian role correctly.
  - Naming and data: unify “monastery” naming and “Fortress Monastery” display; add a full Contemptor Dreadnought armour description; Mars‑trained Techmarines return fully equipped, chapter‑trained still check inventory and warn.

- **Refactors**
  - Centralized mobility–armour compatibility into a helper used in both armour and mobility checks; standardized warnings.
  - Weapons data: replace “terminator” tag with “terminator_only” (no behavior change).

<sup>Written for commit 1fe6071d834ab386e940f7771a2b360a0adf68dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

