### PR TITLE
fix: obj_pnunit cleaning

### DIFF
--- a/objects/obj_ncombat/Create_0.gml
+++ b/objects/obj_ncombat/Create_0.gml
@@ -264,7 +264,7 @@ siege = scr_has_adv("Siege Masters");
 slow = scr_has_adv("Devastator Doctrine");
 melee = scr_has_adv("Assault Doctrine");
 black_rage = scr_has_disadv("Black Rage");
-red_thirst = scr_has_disadv("Black Rage");
+red_thirst = scr_has_disadv("Black Rage") ? 1 : 0; // red_thirst is used as a counter Real so it gets the ternary init
 shitty_luck = scr_has_disadv("Shitty Luck");
 favoured_by_the_warp = scr_has_adv("Favoured By The Warp");
 

--- a/objects/obj_pnunit/Alarm_0.gml
+++ b/objects/obj_pnunit/Alarm_0.gml
@@ -1,4 +1,11 @@
 try {
+    enemy = instance_nearest(0, y, obj_enunit); // Left most enemy
+
+    if (!instance_exists(enemy)) {
+        engaged = false;
+        exit;
+    }
+
     if (instance_number(obj_enunit) != 1) {
         obj_ncombat.flank_x = self.x;
         with (obj_enunit) {
@@ -8,18 +15,11 @@ try {
         }
     }
 
-    enemy = instance_nearest(0, y, obj_enunit); // Left most enemy
-
     if (obj_ncombat.dropping || (!obj_ncombat.defending && obj_ncombat.formation_set != 2)) {
         move_unit_block("east");
     }
 
-    if (!instance_exists(enemy)) {
-        engaged = false;
-        exit;
-    }
-
-    engaged = collision_point(x - 14, y, obj_enunit, 0, 1) || collision_point(x + 14, y, obj_enunit, 0, 1);
+    engaged = collision_point(x - 14, y, obj_enunit, 0, 1) != noone || collision_point(x + 14, y, obj_enunit, 0, 1) != noone;
 
     var once_only = 0;
     var range_shoot = "";
@@ -55,7 +55,6 @@ try {
             if (wep[i] == "") {
                 continue;
             }
-            weapon_data = gear_weapon_data("weapon", wep[i]);
             once_only = 0;
             enemy = instance_nearest(0, y, obj_enunit);
             if (enemy.men + enemy.veh + enemy.medi <= 0) {

--- a/objects/obj_pnunit/Alarm_3.gml
+++ b/objects/obj_pnunit/Alarm_3.gml
@@ -16,27 +16,28 @@ try {
 
     if ((obj_ncombat.red_thirst >= 2) && (obj_ncombat.battle_over == 0)) {
         if (men > 0) {
-            var miss = "", r_lost = 0;
+            var miss = "";
+            var r_lost = 0;
 
             for (var raar = 0; raar < (men + dreads); raar++) {
-                r_roll = floor(random(1000)) + 1;
+                var _r_roll = floor(random(1000)) + 1;
                 if (obj_ncombat.player_forces < (obj_ncombat.player_max * 0.75)) {
-                    r_roll -= 8;
+                    _r_roll -= 8;
                 }
                 if (obj_ncombat.player_forces < (obj_ncombat.player_max / 2)) {
-                    r_roll -= 10;
+                    _r_roll -= 10;
                 }
                 if (obj_ncombat.player_forces < (obj_ncombat.player_max / 4)) {
-                    r_roll -= 24;
+                    _r_roll -= 24;
                 }
                 if (obj_ncombat.player_forces < (obj_ncombat.player_max / 7)) {
-                    r_roll -= 104;
+                    _r_roll -= 104;
                 }
                 if (obj_ncombat.player_forces < (obj_ncombat.player_max / 10)) {
-                    r_roll -= 350;
+                    _r_roll -= 350;
                 }
 
-                if ((marine_dead[raar] == 0) && (marine_type[raar] != "Death Company") && (marine_type[raar] != obj_ini.role[100][eROLE.CHAPTERMASTER]) && (r_roll <= 4)) {
+                if ((marine_dead[raar] == 0) && (marine_type[raar] != "Death Company") && (marine_type[raar] != obj_ini.role[100][eROLE.CHAPTERMASTER]) && (_r_roll <= 4)) {
                     r_lost += 1;
                     marine_type[raar] = "Death Company";
                     marine_defense[raar] = 0.75;
@@ -50,7 +51,7 @@ try {
                 }
             }
             if (r_lost > 1) {
-                string_replace(miss, "Battle Brother", "Battle Brothers");
+                miss = string_replace(miss, "Battle Brother", "Battle Brothers");
             }
 
             var woo = string_length(miss);
@@ -96,7 +97,7 @@ try {
     // Right here execute some sort of check- if left is open, and engaged, and enemy is only vehicles, and no weapons to hurt them...
 
     if (instance_exists(obj_enunit)) {
-        if (collision_point(x + 10, y, obj_enunit, 0, 1) && (!collision_point(x - 10, y, obj_pnunit, 0, 1))) {
+        if (collision_point(x + 10, y, obj_enunit, 0, 1) != noone && collision_point(x - 10, y, obj_pnunit, 0, 1)  == noone) {
             var neares = instance_nearest(x + 10, y, obj_enunit);
 
             if ((neares.men == 0) && (neares.veh > 0)) {

--- a/objects/obj_pnunit/Create_0.gml
+++ b/objects/obj_pnunit/Create_0.gml
@@ -2,13 +2,14 @@ unit = "";
 men = 0;
 veh = 0;
 charge = 0;
-engaged = 0;
+engaged = false;
 owner = eFACTION.PLAYER;
 medi = 0;
 attacked_dudes = 0;
 dreads = 0;
 jetpack_destroy = 0;
 defenses = 0;
+enemy = instance_nearest(x, y, obj_enunit);
 
 unit_count = 0;
 unit_count_old = 0;
@@ -24,10 +25,6 @@ y1 = 450 - (draw_size / 2);
 x2 = pos + (centerline_offset * 2) + 10;
 y2 = 450 + (draw_size / 2);
 
-// let="";let=string_delete(obj_ini.psy_powers,2,string_length(obj_ini.psy_powers)-1);let=string_upper(let);
-// LET might be different for each marine; need a way of determining this
-
-// show_message(let);
 // x determines column; maybe every 10 or so?
 // For fortified locations maybe create a wall unit for the player?
 

--- a/objects/obj_pnunit/Destroy_0.gml
+++ b/objects/obj_pnunit/Destroy_0.gml
@@ -1,1 +1,0 @@
-// if (marine_type[1]!="") then show_message(marine_type[1]);


### PR DESCRIPTION
Just a few variable type definitions and checks, and checking against the correct type of result of that function and yeah bot summarize for me

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes engagement logic and type issues in player unit alarms to prevent bad states and early errors when no enemies exist. Also makes `red_thirst` a numeric counter in combat init.

- **Bug Fixes**
  - Look up nearest enemy on create; in Alarm_0, exit early and set engaged=false if none exist.
  - Use explicit collision checks (`collision_point(...) != noone`) for engagement and gap logic.
  - Initialize `engaged` as false; adjust right-side check to compare against `noone` and the correct object.
  - Make `red_thirst` a 1/0 Real counter instead of a Bool.
  - Assign the result of `string_replace` correctly; localize the roll variable; remove an unused `weapon_data` read and old debug comments.

<sup>Written for commit 2ab1c8781c14e8db17f794f7021b7478a0b0264e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

