### PR TITLE
fix: Armamentarium inconsistencies

### DIFF
--- a/datafiles/data/weapons.json
+++ b/datafiles/data/weapons.json
@@ -211,32 +211,6 @@
         ],
         "value": 90
     },
-    "CCW Heavy Flamer": {
-        "abbreviation": "CCWHvyFlmr",
-        "ammo": 6,
-        "arp": 2,
-        "attack": {
-            "artifact": 600,
-            "master_crafted": 550,
-            "standard": 500
-        },
-        "description": "A powerful close combat weapon integrated with a flamer. Enemeies rarely expect a dreadnough claw to spew promethium.",
-        "melee_hands": 1,
-        "range": 2.1,
-        "ranged_hands": 0,
-        "requires_to_forge": [
-            "vehicle_armaments_1",
-            "flame_1"
-        ],
-        "spli": 20,
-        "tags": [
-            "vehicle",
-            "dreadnought",
-            "heavy_ranged",
-            "flame"
-        ],
-        "value": 55
-    },
     "Chainaxe": {
         "abbreviation": "ChAxe",
         "ammo": 0,
@@ -336,13 +310,16 @@
             "master_crafted": 450,
             "standard": 350
         },
-        "description": "While a variety of melee weapons are used by dreadnoughts, this power fist with an integrated flamer is the most common.",
+        "description": "While a variety of melee weapons are used by dreadnoughts, this power fist with an integrated Heavy Flamer is the most common.",
         "maintenance": 0.1,
         "melee_hands": 5,
         "range": 1,
         "requires_to_forge": [
             "vehicle_armaments_1",
             "flame_1"
+        ],
+        "second_profiles": [
+            "Heavy Flamer"
         ],
         "spli": 10,
         "tags": [
@@ -528,6 +505,9 @@
         "range": 1,
         "ranged_hands": 0,
         "spli": 15,
+        "second_profiles": [
+            "Twin Linked Bolters"
+        ],
         "tags": [
             "vehicle",
             "power",
@@ -1354,7 +1334,7 @@
     },
     "Inferno Cannon": {
         "abbreviation": "InfCann",
-        "ammo": 0,
+        "ammo": 10,
         "arp": 2,
         "attack": {
             "artifact": 1000,
@@ -1972,7 +1952,7 @@
     },
     "Plasma Cutter": {
         "abbreviation": "PlsmCt",
-        "ammo": 0,
+        "ammo": 8,
         "arp": 3,
         "attack": {
             "artifact": 320,
@@ -3064,7 +3044,7 @@
     },
     "Underslung Bolter": {
         "abbreviation": "UndBltr",
-        "ammo": 0,
+        "ammo": 8,
         "arp": 1,
         "attack": {
             "artifact": 300,


### PR DESCRIPTION
Fixes issues in the weapons present in game as well as drops CCW Heavy Flamer from the shop and forge due to its redundancy.

**Changes**
 - Deleted the "CCW Heavy Flamer" 
 - Increased the ammo count on the "Inferno Cannon", "Underslung Bolter", and "Plasma Cutter" 
 - Added the "Heavy Flamer" profile to the "Close Combat Weapon"
 - Added the "Twin Linked Bolters" profile to the "Contemptor CCW"
<!--- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. --->
Compiled the project, checked the armamentarium, exited
<!--- "Inspired" by the CDDA PR template -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes weapon data inconsistencies by removing a redundant item, adding missing secondary profiles, and correcting ammo counts for several weapons.

- **Bug Fixes**
  - Removed "CCW Heavy Flamer" from the armory (shop/forge).
  - Added "Heavy Flamer" secondary profile to "Close Combat Weapon".
  - Added "Twin Linked Bolters" secondary profile to "Contemptor CCW".
  - Set ammo: "Inferno Cannon" 10, "Plasma Cutter" 8, "Underslung Bolter" 8.

<sup>Written for commit d122600b5008ac89685abad1b5c34c6e0a35a056. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

