### PR TITLE
feat: Genestealer cultist range refresh

### DIFF
--- a/objects/obj_enunit/Alarm_1.gml
+++ b/objects/obj_enunit/Alarm_1.gml
@@ -1141,7 +1141,13 @@ if (obj_ncombat.enemy == eFACTION.TYRANIDS || obj_ncombat.enemy == eFACTION.GENE
             dudes_hp[j] = 25;
             men += dudes_num[j];
         }
-
+        if (dudes[j] == "Aberrant") {
+            scr_en_weapon("Heavy Maul", true, dudes_num[j], dudes[j], j);
+            dudes_ac[j] = 5;
+            dudes_hp[j] = 80;
+            dudes_dr[j] = 0.75;
+            men += dudes_num[j];
+        }
         if (dudes[j] == "Cultist") {
             scr_en_weapon("Autogun", true, dudes_num[j], dudes[j], j);
             scr_en_weapon("Melee Weapon", true, dudes_num[j], dudes[j], j);
@@ -1149,25 +1155,77 @@ if (obj_ncombat.enemy == eFACTION.TYRANIDS || obj_ncombat.enemy == eFACTION.GENE
             dudes_hp[j] = 35;
             men += dudes_num[j];
         }
+        if (dudes[j] == "Hybrid") {
+            scr_en_weapon("Autogun", true, dudes_num[j] * 2, dudes[j], j);
+            scr_en_weapon("Hand Flamer", true, dudes_num[j], dudes[j], j);
+            scr_en_weapon("Hybrid Claws", true, dudes_num[j], dudes[j], j);
+            dudes_ac[j] = 10;
+            dudes_hp[j] = 50;
+            men += dudes_num[j];
+        }
         if (dudes[j] == "Genestealer") {
-            scr_en_weapon("Genestealer Claws", true, dudes_num[j], dudes[j], j);
+            scr_en_weapon("Genestealer Claws", true, dudes_num[j] * 2, dudes[j], j);
             dudes_ac[j] = 10;
             dudes_hp[j] = 75;
             men += dudes_num[j];
         }
+                if (dudes[j] == "Magus") {
+            scr_en_weapon("Autogun", true, dudes_num[j], dudes[j], j);
+            scr_en_weapon("Force Staff", true, dudes_num[j], dudes[j], j);
+            dudes_ac[j] = 10;
+            dudes_hp[j] = 100;
+            men += dudes_num[j];
+        }
+                if (dudes[j] == "Primus") {
+            scr_en_weapon("Autogun", true, dudes_num[j], dudes[j], j);
+            scr_en_weapon("Bonesword", true, dudes_num[j], dudes[j], j);
+            dudes_ac[j] = 10;
+            dudes_hp[j] = 125;
+            dudes_dr[j] = 0.90;
+            men += dudes_num[j];
+        }
         if (dudes[j] == "Genestealer Patriarch") {
-            scr_en_weapon("Genestealer Claws", true, dudes_num[j], dudes[j], j);
-            scr_en_weapon("Witchfire", true, dudes_num[j], dudes[j], j);
+            scr_en_weapon("Genestealer Claws", true, dudes_num[j] * 4, dudes[j], j);
             dudes_ac[j] = 15;
             dudes_hp[j] = 300;
             dudes_dr[j] = 0.65;
             men += dudes_num[j];
         }
-        if (dudes[j] == "Armoured Limousine") {
-            scr_en_weapon("Autogun", false, dudes_num[j] * 4, dudes[j], j);
+        if (dudes[j] == "Jackal") {
+            scr_en_weapon("Autogun", true, dudes_num[j] * 2, dudes[j], j);
+            scr_en_weapon("Melee Weapon", true, dudes_num[j], dudes[j], j);
+            dudes_ac[j] = 10;
+            dudes_hp[j] = 80;
+            dudes_dr[j] = 0.90;
+            men += dudes_num[j];
+        }
+        if (dudes[j] == "Ridgerunner") {
+            scr_en_weapon("Heavy Mining Laser", false, dudes_num[j], dudes[j], j);
+            scr_en_weapon("Heavy Stubber", false, dudes_num[j] * 2, dudes[j], j);
             dudes_ac[j] = 20;
-            dudes_hp[j] = 150;
+            dudes_hp[j] = 175;
             dudes_dr[j] = 0.75;
+            veh += dudes_num[j];
+            dudes_vehicle[j] = 1;
+        }
+        if (dudes[j] == "Goliath Truck") {
+            scr_en_weapon("Autocannon", false, dudes_num[j] * 2, dudes[j], j);
+            scr_en_weapon("Heavy Stubber", false, dudes_num[j], dudes[j], j);
+            scr_en_weapon("Demolition Charges", false, dudes_num[j], dudes[j], j);
+            dudes_ac[j] = 30;
+            dudes_hp[j] = 225;
+            dudes_dr[j] = 0.70;
+            veh += dudes_num[j];
+            dudes_vehicle[j] = 1;
+        }
+        if (dudes[j] == "Goliath Rockgrinder") {
+            scr_en_weapon("Drilldozer Blade", false, dudes_num[j] * 3, dudes[j], j);
+            scr_en_weapon("Heavy Mining Laser", false, dudes_num[j], dudes[j], j);
+            scr_en_weapon("Heavy Stubber", false, dudes_num[j], dudes[j], j);
+            scr_en_weapon("Demolition Charges", false, dudes_num[j] * 2, dudes[j], j);
+            dudes_ac[j] = 30;
+            dudes_hp[j] = 250;
+            dudes_dr[j] = 0.50;
             veh += dudes_num[j];
             dudes_vehicle[j] = 1;
         }

--- a/objects/obj_ncombat/Alarm_0.gml
+++ b/objects/obj_ncombat/Alarm_0.gml
@@ -1818,59 +1818,94 @@ try {
         u.dudes_num[1] = 40;
         u.dudes[2] = "Hormagaunt";
         u.dudes_num[2] = 40;
-        // Small Genestealer Group
+        // Small Genestealer Cult Group
         if (threat == 1) {
-            u = instance_nearest(xxx, 240, obj_enunit);
-            enemy_dudes = "11";
-
-            u.dudes[1] = "Genestealer";
-            u.dudes_num[1] = 10;
-
-            u = instance_create(0, 240, obj_enunit);
-            u.dudes[1] = "Lictor";
-            u.dudes_num[1] = 1;
-            u.flank = 1;
-        }
-        // Medium Genestealer Group
-        if (threat == 2) {
             u = instance_nearest(xxx, 240, obj_enunit);
             enemy_dudes = "100";
 
-            u.dudes[1] = "Genestealer Patriarch";
+            u.dudes[1] = "Cultist";
+            u.dudes_num[1] = 50;
+            u.dudes[2] = "Hybrid";
+            u.dudes_num[2] = 25;
+
+            u = instance_create(0, 240, obj_enunit);
+            u.dudes[1] = "Jackal";
+            u.dudes_num[1] = 25;
+            u.flank = 1;
+        }
+        // Medium Genestealer Cult Group
+        if (threat == 2) {
+            u = instance_nearest(xxx, 240, obj_enunit);
+            enemy_dudes = "460";
+
+            u.dudes[1] = "Magus";
             u.dudes_num[1] = 1;
-            u.dudes[2] = "Genestealer";
-            u.dudes_num[2] = 30;
+            u.dudes[2] = "Primus";
+            u.dudes_num[2] = 1;
+            u.dudes[3] = "Aberrant";
+            u.dudes_num[3] = 30;
+            u.dudes[4] = "Goliath Truck";
+            u.dudes_num[4] = 5;
 
             instance_deactivate_object(u);
             u = instance_nearest(xxx + 10, 240, obj_enunit);
             u.dudes[1] = "Cultist";
-            u.dudes_num[1] = 150;
+            u.dudes_num[1] = 300;
+            u.dudes[2] = "Hybrid";
+            u.dudes_num[2] = 75;
+            u.dudes[3] = "Goliath Rockgrinder";
+            u.dudes_num[3] = 5;
 
             u = instance_create(0, 240, obj_enunit);
-            u.dudes[1] = "Lictor";
-            u.dudes_num[1] = 1;
+            u.dudes[1] = "Jackal";
+            u.dudes_num[1] = 40;
+            u.flank = 1;
+            u.dudes[2] = "Ridgerunner";
+            u.dudes_num[2] = 3;
             u.flank = 1;
         }
         // Large Genestealer Group
         if (threat == 3) {
             u = instance_nearest(xxx, 240, obj_enunit);
-            enemy_dudes = "100";
+            enemy_dudes = "969";
 
-            u.dudes[1] = "Genestealer Patriarch";
-            u.dudes_num[1] = 1;
-            u.dudes[2] = "Genestealer";
-            u.dudes_num[2] = 120;
-            u.dudes[3] = "Armoured Limousine";
-            u.dudes_num[3] = 20;
+            u.dudes[1] = "Magus";
+            u.dudes_num[1] = 3;
+            u.dudes[2] = "Aberrant";
+            u.dudes_num[2] = 60;
+            u.dudes[3] = "Primus";
+            u.dudes_num[3] = 3;
+            u.dudes[4] = "Goliath Truck";
+            u.dudes_num[4] = 8;
 
             instance_deactivate_object(u);
             u = instance_nearest(xxx + 10, 240, obj_enunit);
             u.dudes[1] = "Cultist";
-            u.dudes_num[1] = 600;
+            u.dudes_num[1] = 300;
+            u.dudes[2] = "Hybrid";
+            u.dudes_num[2] = 100;
+            u.dudes[3] = "Goliath Truck";
+            u.dudes_num[3] = 8;
+            u.dudes[4] = "Primus";
+            u.dudes_num[4] = 3;
+
+            instance_deactivate_object(u);
+            u = instance_nearest(xxx + 20, 240, obj_enunit);
+            u.dudes[1] = "Cultist";
+            u.dudes_num[1] = 300;
+            u.dudes[2] = "Hybrid";
+            u.dudes_num[2] = 100;
+            u.dudes[3] = "Goliath Rockgrinder";
+            u.dudes_num[3] = 10;
+            u.dudes[4] = "Primus";
+            u.dudes_num[4] = 3;
 
             u = instance_create(0, 240, obj_enunit);
-            u.dudes[1] = "Lictor";
-            u.dudes_num[1] = 6;
+            u.dudes[1] = "Jackal";
+            u.dudes_num[1] = 60;
+            u.flank = 1;
+            u.dudes[2] = "Ridgerunner";
+            u.dudes_num[2] = 8;
             u.flank = 1;
         }
         // Small Tyranid Army

--- a/scripts/scr_en_weapon/scr_en_weapon.gml
+++ b/scripts/scr_en_weapon/scr_en_weapon.gml
@@ -643,6 +643,11 @@ function scr_en_weapon(name, is_man, man_number, man_type, group) {
                 arp = 3;
                 rang = 1;
                 break;
+            case "Hybrid Claws":
+                atta = 50;
+                arp = 2;
+                rang = 1;
+                break;
             case "Witchfire":
                 atta = 100;
                 arp = 3;
@@ -665,6 +670,57 @@ function scr_en_weapon(name, is_man, man_number, man_type, group) {
                 arp = 2;
                 rang = 2;
                 amm = 1;
+                break;
+            case "Hand Flamer":
+                atta = 40;
+                arp = 1;
+                rang = 2;
+                amm = 5;
+                break;
+            case "Force Staff":
+                atta = 100;
+                arp = 3;
+                rang = 1;
+                break;
+            case "Heavy Maul":
+                atta = 80;
+                arp = 2;
+                rang = 1;
+                break;
+            case "Heavy Mining Laser":
+                atta = 100;
+                arp = 4;
+                rang = 4;
+                amm = 6;
+                break;
+            case "Heavy Stubber":
+                atta = 100;
+                arp = 1;
+                rang = 6;
+                amm = 8;
+                break;
+            case "Demolition Charges":
+                atta = 100;
+                arp = 3;
+                rang = 2;
+                amm = 3;
+                break;
+            case "Drilldozer Blade":
+                atta = 120;
+                arp = 3;
+                rang = 1;
+                spli = 2;
+                break;
+            case "Autocannon":
+                atta = 80;
+                arp = 3;
+                rang = 12;
+                amm = 10;
+                break;
+            case "Melee Weapon":
+                atta = 50;
+                arp = 1;
+                rang = 1;
                 break;
             default:
                 break;


### PR DESCRIPTION
Updates Tyranid force levels 1-3 to reflect modern Genestealer Cult (GSC) tabletop ranges


<!--- Explain why and what your changes do in simple terms. --->
**Changes**
- Added Aberrants, Hybrids, Magus, Primus, Jackals, Ridgerunners, Goliath trucks and Rockgrinders to the GSC forces
- Added several new weapons for the GSC.
- Adjusted Tyrand forces 1-3 composition to use the new entries without bloating existing layouts.

**Testing**
- Compiled
- Engaged level 3 Tyranids to test balance
- Findings: semi-durable but weak, acceptable
