### PR TITLE
feat: Fix/refine buttons/drop screen

### DIFF
--- a/objects/obj_drop_select/Create_0.gml
+++ b/objects/obj_drop_select/Create_0.gml
@@ -146,8 +146,8 @@ y1 = 0;
 x2 = 0;
 y2 = 0;
 
-formation = new InteractiveButton();
-target = new InteractiveButton();
+btn_formation = new InteractiveButton();
+btn_target = new InteractiveButton();
 
 btn_attack = new InteractiveButton();
 btn_attack.text_color = CM_GREEN_COLOR;

--- a/objects/obj_drop_select/Draw_64.gml
+++ b/objects/obj_drop_select/Draw_64.gml
@@ -8,8 +8,8 @@ try {
     draw_set_font(fnt_40k_14b);
     draw_set_color(CM_GREEN_COLOR);
 
-    w = 660;
-    h = 520;
+    w = 720;
+    h = 580;
     // Center of the screen
     //setup
     var _x_center = (display_get_gui_width() / 2) - (w / 2);
@@ -17,7 +17,7 @@ try {
     //draw main_slate
     if (purge != eDROP_TYPE.PURGESELECT && (local_content_slate.XX <= _x_center - local_content_slate.width)) {
         main_slate.inside_method = drop_select_draw;
-        main_slate.draw(_x_center, _y_center, (660 / 860), (520 / 850));
+        main_slate.draw(_x_center, _y_center, (w / 860), (h / 850));
     }
 
     //left hand slate
@@ -26,10 +26,12 @@ try {
         var _yy = local_content_slate.YY + 40;
         var _width = local_content_slate.width;
         var _heigth = local_content_slate.height;
+    
         if (purge == 0) {
             draw_set_halign(fa_left);
             draw_text_ext(_xx + 15, _yy, roster.roster_local_string, -1, local_content_slate.width - 40);
         }
+    
         if (purge != eDROP_TYPE.RAIDATTACK) {
             if (purge == eDROP_TYPE.PURGESELECT) {
                 draw_set_halign(fa_center);
@@ -55,6 +57,7 @@ try {
     };
 
     draw_set_halign(fa_center);
+
     if (purge == eDROP_TYPE.RAIDATTACK) {
         local_content_slate.draw(_x_center - local_content_slate.width, _y_center, (300 / 860), (520 / 850));
     } else if (purge == 1) {
@@ -67,6 +70,7 @@ try {
             local_content_slate.draw(local_content_slate.XX, _y_center, (300 / 860), (520 / 850));
         }
     }
+
     roster_slate.inside_method = function() {
         var _xx = roster_slate.XX + (roster_slate.width / 2);
         var _yy = roster_slate.YY + 40;
@@ -98,11 +102,13 @@ try {
             }
         }
     };
+
     var _draw_x = _x_center + main_slate.width;
     var _draw_y = _y_center;
+
     if (purge > eDROP_TYPE.PURGESELECT) {
-        if (roster_slate.XX < _x_center + 660) {
-            _draw_x = min(roster_slate.XX + 15, _x_center + 660);
+        if (roster_slate.XX < _x_center + w) {
+            _draw_x = min(roster_slate.XX + 15, _x_center + w);
         } else {
             _draw_x = roster_slate.XX;
         }

--- a/objects/obj_ncombat/Alarm_5.gml
+++ b/objects/obj_ncombat/Alarm_5.gml
@@ -941,8 +941,6 @@ if (defeat == 1) {
     }
 }
 
-obj_ini.gene_slaves = [];
-
 instance_deactivate_object(obj_star);
 instance_deactivate_object(obj_ground_mission);
 

--- a/objects/obj_ncombat/Alarm_7.gml
+++ b/objects/obj_ncombat/Alarm_7.gml
@@ -508,8 +508,8 @@ try {
 
             if (battle_special != "ChaosWarband") {
                 with (obj_star) {
-                    if (string_count("WL" + string(enemy), p_feature[battle_id]) > 0) {
-                        p_feature[battle_id] = string_replace(p_feature[battle_id], "WL" + string(enemy) + "|", "");
+                    if (string_count("WL" + string(other.enemy), p_feature[other.battle_id]) > 0) {
+                        p_feature[other.battle_id] = string_replace(p_feature[other.battle_id], "WL" + string(other.enemy) + "|", "");
                     }
                 }
             }

--- a/scripts/scr_buttons/scr_buttons.gml
+++ b/scripts/scr_buttons/scr_buttons.gml
@@ -1377,8 +1377,9 @@ function ToggleButton(data = {}) constructor {
                 h *= 1 + (text_padding * 2);
             }
         } else if (style == "box") {
-            w = max(32, string_width(str1) * (1 + (text_padding * 2))) + 6;
-            h = 32 + (string_height(str1) * (1 + (text_padding * 2)));
+            var _text_w = string_width(str1) * (1 + (text_padding * 2));
+            w = max(32, _text_w) + 12; 
+            h = 32 + 4 + (string_height(str1) * (1 + (text_padding * 2)));
         }
         x2 = x1 + w;
         y2 = y1 + h;
@@ -1450,20 +1451,25 @@ function ToggleButton(data = {}) constructor {
         if (style == "default") {
             draw_rectangle_color_simple(x1, y1, x1 + w, y1 + h, 1, button_color, total_alpha);
             draw_set_halign(text_halign);
-            draw_set_valign(fa_top);
+            draw_set_valign(fa_middle);
+            var text_y = y1 + (h / 2);
             draw_text_color_simple(text_x, text_y, str1, text_color, total_alpha);
             draw_set_alpha(1);
             draw_set_halign(fa_left);
         } else if (style == "box") {
-            // Icon with alpha
+            var _center_x = x1 + (w / 2);
+            var _sprite_x = _center_x - 16; 
+            
             draw_set_halign(fa_left);
-            draw_sprite_ext(spr_creation_check, active, x1 + 2, y1, 1, 1, 0, c_white, total_alpha);
-            // Label centred below icon
-            draw_set_alpha(total_alpha);
             draw_set_valign(fa_top);
+            draw_sprite_ext(spr_creation_check, active, _sprite_x, y1, 1, 1, 0, c_white, total_alpha);
+            
+            draw_set_alpha(total_alpha);
             draw_set_halign(fa_center);
-            var _label_y = y1 + 32 + 2;
-            draw_text_transformed(x1 + 18, _label_y, str1, 1, 1, 0);
+            draw_set_valign(fa_middle);
+            
+            var _label_y = y1 + 32 + ((h - 32) / 2);
+            draw_text_transformed(_center_x, _label_y, str1, 1, 1, 0);
             draw_set_alpha(1);
         }
 

--- a/scripts/scr_buttons/scr_buttons.gml
+++ b/scripts/scr_buttons/scr_buttons.gml
@@ -36,6 +36,7 @@ function pop_draw_return_values() {
     }
 }
 
+/// @mixin
 /// @function standard_loc_data()
 /// @category Draw Helpers
 /// @description Acts as an initializer for UI elements positions and size
@@ -1019,83 +1020,132 @@ function MultiSelect(options_array, title_param, data = {}) constructor {
     inactive_col = c_gray;
     max_width = 0;
     max_height = 0;
-    /// @type {Array<Struct.ToggleButton>} 
+    /// @type {Array<Struct.ToggleButton>}
     toggles = [];
     changed = false;
-    draw_alighn = "horizontal";
+    is_horizontal = true; // If more than 2 types needed, convert to an enum
+    allow_changes = true;
+
     for (var i = 0; i < array_length(options_array); i++) {
         var _next_tog = new ToggleButton(options_array[i]);
         _next_tog.active = false;
         array_push(toggles, _next_tog);
     }
-    
+
+    update(data);
+
     static update = function(data = {}) {
         move_data_to_current_scope(data);
-    };
-
-    update(data)
-
-    static draw_toggle = function(index) {
-        var _cur_opt = toggles[index];
-        _cur_opt.x1 = next_draw.x1;
-        _cur_opt.y1 = next_draw.y1;
-        _cur_opt.update();
-        if (_cur_opt.clicked() && allow_changes) {
-            changed = true;
-        }
-        _cur_opt.button_color = _cur_opt.active ? active_col : inactive_col;
-        _cur_opt.draw();
-        next_draw.row_or_column_draw_count++;
-        //TODO probably set an enum up for this later
-        if (draw_alighn == "horizontal") {
-            next_draw.x1 = _cur_opt.x2 + x_gap;
-            x2 = next_draw.x1 > x2 ? next_draw.x1 : x2;
-            y2 = next_draw.y1 + _cur_opt.h;
-            if (max_width > 0) {
-                if (next_draw.x1 - x1 > max_width) {
-                    next_draw.x1 = x1;
-                    next_draw.y1 += _cur_opt.h + y_gap;
-                    next_draw.row_or_column_draw_count = 0;
-                }
-            }
-        } else {
-            next_draw.y1 = _cur_opt.y2 + y_gap;
-            y2 = next_draw.y1 > y2 ? next_draw.y1 : y2;
-            x2 = next_draw.x1 + _cur_opt.w;
-            if (max_height > 0) {
-                if (next_draw.y1 - y1 > max_height) {
-                    next_draw.y1 = y1;
-                    next_draw.x1 += _cur_opt.w + x_gap;
-                    next_draw.row_or_column_draw_count = 0;
-                }
-            }
-        }
-    };
-
-    static reset_next_draw = function() {
-        next_draw = {
-            x1: x1,
-            y1: y1,
-            row_or_column_draw_count: 0,
-        };
     };
 
     static draw = function(allow_changes_param = true) {
         changed = false;
         allow_changes = allow_changes_param;
-        has_change_method = is_callable(on_change);
-
-        reset_next_draw();
-
+        var _has_change_method = is_callable(on_change);
+    
+        var _start_y = y1;
         if (title != "") {
             draw_text(x1, y1, title);
-            next_draw.y1 += string_height(title) + 10;
+            _start_y += string_height(title) + 10;
         }
-
-        for (var i = 0; i < array_length(toggles); i++) {
-            draw_toggle(i);
+    
+        var _count = array_length(toggles);
+    
+        var _max_main = is_horizontal ? max_width : max_height;
+        var _main_gap = is_horizontal ? x_gap : y_gap;
+        var _cross_gap = is_horizontal ? y_gap : x_gap;
+        var _start_main = is_horizontal ? x1 : _start_y;
+    
+        var _lines = [];
+        var _current_line = [];
+        var _cur_main = _start_main;
+        var _line_max_cross = 0;
+    
+        // Pass 1: Pack items into lines (rows or columns) based on orientation boundaries
+        for (var i = 0; i < _count; i++) {
+            var _cur_opt = toggles[i];
+            _cur_opt.update();
+    
+            var _opt_main = is_horizontal ? _cur_opt.w : _cur_opt.h;
+            var _opt_cross = is_horizontal ? _cur_opt.h : _cur_opt.w;
+    
+            if (_max_main > 0 && (_cur_main + _opt_main - _start_main) > _max_main && array_length(_current_line) > 0) {
+                array_push(_lines, {toggles: _current_line, max_c: _line_max_cross});
+                _current_line = [];
+                _line_max_cross = 0;
+                _cur_main = _start_main;
+            }
+    
+            array_push(_current_line, _cur_opt);
+            if (_opt_cross > _line_max_cross) {
+                _line_max_cross = _opt_cross;
+            }
+    
+            _cur_main += _opt_main + _main_gap;
         }
-        if (changed && has_change_method) {
+    
+        if (array_length(_current_line) > 0) {
+            array_push(_lines, {toggles: _current_line, max_c: _line_max_cross});
+        }
+    
+        // Pass 2: Position, calculate boundaries, evaluate input, and draw
+        var _cur_cross = is_horizontal ? _start_y : x1;
+        var _total_max_main = _start_main;
+        var _lines_count = array_length(_lines);
+    
+        for (var l = 0; l < _lines_count; l++) {
+            var _line = _lines[l];
+            _cur_main = _start_main;
+            var _line_toggles_count = array_length(_line.toggles);
+    
+            for (var t = 0; t < _line_toggles_count; t++) {
+                var _cur_opt = _line.toggles[t];
+                var _orig_w = _cur_opt.w;
+    
+                if (is_horizontal) {
+                    _cur_opt.x1 = _cur_main;
+                    _cur_opt.y1 = _cur_cross;
+                    _cur_opt.x2 = _cur_main + _cur_opt.w;
+                    _cur_opt.y2 = _cur_cross + _cur_opt.h;
+                    if (_cur_opt.x2 > _total_max_main) {
+                        _total_max_main = _cur_opt.x2;
+                    }
+    
+                    _cur_main += _cur_opt.w + x_gap;
+                } else {
+                    _cur_opt.x1 = _cur_cross;
+                    _cur_opt.y1 = _cur_main;
+                    _cur_opt.w = _line.max_c;
+                    _cur_opt.x2 = _cur_cross + _cur_opt.w;
+                    _cur_opt.y2 = _cur_main + _cur_opt.h;
+                    if (_cur_opt.y2 > _total_max_main) {
+                        _total_max_main = _cur_opt.y2;
+                    }
+    
+                    _cur_main += _cur_opt.h + y_gap;
+                }
+    
+                if (_cur_opt.clicked() && allow_changes) {
+                    changed = true;
+                }
+    
+                _cur_opt.button_color = _cur_opt.active ? active_col : inactive_col;
+                _cur_opt.draw();
+                _cur_opt.w = _orig_w;
+            }
+    
+            _cur_cross += _line.max_c + _cross_gap;
+        }
+    
+        if (is_horizontal) {
+            x2 = _total_max_main;
+            y2 = _cur_cross - y_gap;
+        } else {
+            x2 = _cur_cross - x_gap;
+            y2 = _total_max_main;
+        }
+    
+        if (changed && _has_change_method) {
             on_change();
         }
     };
@@ -1106,23 +1156,31 @@ function MultiSelect(options_array, title_param, data = {}) constructor {
             for (var i = 0; i < array_length(toggles); i++) {
                 var _cur_opt = toggles[i];
                 _cur_opt.active = _cur_opt.str1 == _setter;
-                if (_cur_opt.str1 == _setter) {}
             }
         }
     };
 
     static deselect_all = function() {
         for (var i = 0; i < array_length(toggles); i++) {
-            var _cur_opt = toggles[i];
-            _cur_opt.active = false;
+            toggles[i].active = false;
         }
     };
 
     static select_all = function() {
-        for (var i = 0; i < array_length(toggles); i++) {
-            var _cur_opt = toggles[i];
-            _cur_opt.active = true;
+        var _all_selected = true;
+        var _count = array_length(toggles);
+        
+        for (var i = 0; i < _count; i++) {
+            if (!toggles[i].active) {
+                _all_selected = false;
+                break;
+            }
         }
+
+        for (var i = 0; i < _count; i++) {
+            toggles[i].active = !_all_selected;
+        }
+
         changed = true;
     };
 
@@ -1134,6 +1192,7 @@ function MultiSelect(options_array, title_param, data = {}) constructor {
                 array_push(_selecs, _cur_opt.str1);
             }
         }
+
         return _selecs;
     };
 }

--- a/scripts/scr_drop_select_function/scr_drop_select_function.gml
+++ b/scripts/scr_drop_select_function/scr_drop_select_function.gml
@@ -9,8 +9,8 @@ enum eDROP_TYPE {
 
 /// @self Asset.GMObject.obj_drop_select
 function drop_select_unit_selection() {
-    w = 660;
-    h = 520;
+    w = 720;
+    h = 580;
     // Center of the screen
     var _x_center = main_slate.XX;
     var _y_center = main_slate.YY;
@@ -23,7 +23,7 @@ function drop_select_unit_selection() {
     if (purge == eDROP_TYPE.RAIDATTACK) {
         draw_set_font(fnt_40k_30b);
         draw_set_halign(fa_left);
-        draw_set_color(c_gray);
+        draw_set_color(CM_GREEN_COLOR);
         var attack_type = attack ? "Attacking" : "Raiding";
         draw_text_transformed(x1 + 40, y1 + 38, $"{attack_type} ({planet_numeral_name(planet_number, p_target)} )", 0.6, 0.6, 0);
         var _offset = x1 + 40;
@@ -31,7 +31,7 @@ function drop_select_unit_selection() {
         for (var i = 0; i < array_length(roster.company_buttons); i++) {
             var _button = roster.company_buttons[i];
             _button.x1 = _offset;
-            _button.y1 = y1 + 60;
+            _button.y1 = y1 + 70;
             _button.update();
             _button.draw();
             if (_button.company_present) {
@@ -39,7 +39,7 @@ function drop_select_unit_selection() {
                     roster.update_roster();
                 }
             }
-            _offset += _button.width;
+            _offset += _button.w + 8;
         }
 
         // Planet icon here
@@ -47,11 +47,13 @@ function drop_select_unit_selection() {
 
         // Formation
         var _formation_str = $"Formation: {obj_controller.bat_formation[formation_possible[formation_current]]}";
-        formation.x1 = x2 - 40 - (string_width(_formation_str) + 4);
-        formation.y1 = y1 + 80;
-        formation.update({str1: _formation_str});
-        formation.draw();
-        if (formation.clicked()) {
+        btn_formation.x1 = x2 - 50 - (string_width(_formation_str));
+        btn_formation.y1 = y1 + 80;
+        btn_formation.button_color = CM_GREEN_COLOR;
+        btn_formation.text_color = CM_GREEN_COLOR;
+        btn_formation.update({str1: _formation_str});
+        btn_formation.draw();
+        if (btn_formation.clicked()) {
             formation_current++;
             if (formation_current >= array_length(formation_possible)) {
                 formation_current = 0;
@@ -59,14 +61,19 @@ function drop_select_unit_selection() {
         }
 
         // Ships Are Up, Fuck Me
-        draw_set_color(c_gray);
+        draw_set_color(CM_GREEN_COLOR);
         draw_text(x1 + 40, 273, "Available Forces:");
     }
-    var _buttons_x = 552;
+
+    var _buttons_x = x1 + 40;
     var _buttons_y = 299;
 
-    // Local force button;
+    roster.select_all_ships.update({x1: x1 + 200, y1: 273});
+    if (roster.select_all_ships.draw()) {
+        roster.ship_multi_selector.select_all();
+    }
 
+    // Local force button;
     if (purge != eDROP_TYPE.PURGEBOMBARD) {
         var _local_button = roster.local_button;
         _local_button.x1 = _buttons_x;
@@ -77,23 +84,18 @@ function drop_select_unit_selection() {
             roster.update_roster();
         }
     }
-    _buttons_y += 21;
+
+    _buttons_y += 30;
 
     // Ship buttons;
-    roster.ship_multi_selector.update({x1: _buttons_x, y1: _buttons_y});
-
-    roster.ship_multi_selector.draw();
-
-    if (roster.select_all_ships.draw()) {
-        roster.ship_multi_selector.select_all();
-    }
-
     if (roster.ship_multi_selector.changed) {
         roster.update_roster();
     }
+    roster.ship_multi_selector.update({x1: _buttons_x, y1: _buttons_y});
+    roster.ship_multi_selector.draw();
 
     draw_set_font(fnt_40k_14);
-    draw_set_color(c_gray);
+    draw_set_color(CM_GREEN_COLOR);
     draw_set_alpha(1);
     draw_set_halign(fa_left);
 
@@ -101,7 +103,7 @@ function drop_select_unit_selection() {
     var _squads_box = {
         header: "Selected Squads:",
         x1: x1 + 40,
-        y1: y2 - 180,
+        y1: y2 - 220,
     };
     draw_text(_squads_box.x1, _squads_box.y1, _squads_box.header);
     var _x_offset = 0;
@@ -119,7 +121,7 @@ function drop_select_unit_selection() {
             _button = roster.vehicle_buttons[i - _squad_length];
         }
 
-        if (_x_offset + _button.width > 590) {
+        if (_x_offset + _button.w > 590) {
             _row++;
             _x_offset = 0;
         }
@@ -132,7 +134,7 @@ function drop_select_unit_selection() {
             roster.update_roster();
         }
 
-        _x_offset += _button.width + 10;
+        _x_offset += _button.w + 10;
     }
 
     // Target
@@ -140,6 +142,7 @@ function drop_select_unit_selection() {
     if (purge == eDROP_TYPE.RAIDATTACK) {
         var target_race = "";
         var target_threat = "";
+        var _target_str = "No Target";
 
         if (attacking >= 5 && attacking <= 13) {
             race_quantity = race_quantities[attacking - 4];
@@ -151,27 +154,44 @@ function drop_select_unit_selection() {
         } else if (race_quantity >= 6) {
             target_threat = threat_levels[6];
         }
-        var _target_str = "Target: ";
+
         if (race_quantity != 0) {
-            _target_str += $"{target_race} ({target_threat} Threat)";
-        } else {
-            _target_str += "None";
+            _target_str = $"{target_race} ({target_threat})";
         }
-        target.x1 = x2 - 40 - (string_width(_target_str) + 4);
-        target.y1 = formation.y2 + 10;
-        target.update({str1: _target_str});
-        target.draw();
-        draw_sprite(spr_faction_icons, attacking, x2 - 100, y1 + 40);
-        var q = 0;
-        repeat (20) {
-            q += 1;
-            if (target.clicked() && force_present[q] != 0) {
-                if (attacking != force_present[q] && force_present[q] > 0) {
-                    attacking = force_present[q];
+
+        btn_target.x1 = x2 - 50 - (string_width(_target_str));
+        btn_target.y1 = btn_formation.y2 + 10;
+        btn_target.button_color = CM_GREEN_COLOR;
+        btn_target.text_color = CM_GREEN_COLOR;
+        btn_target.update({str1: _target_str});
+        btn_target.draw();
+        btn_target.active = force_present[1] != 0;
+
+        if (btn_target.clicked()) {
+            var _current_i = 0;
+            for (var i = 1; i <= 20; i++) {
+                if (force_present[i] == attacking) {
+                    _current_i = i;
+                    break;
+                }
+            }
+            for (var i = _current_i + 1; i <= 20; i++) {
+                if (force_present[i] != 0) {
+                    attacking = force_present[i];
+                    break;
+                }
+            }
+            if (attacking == force_present[_current_i]) {
+                for (var i = 1; i <= 20; i++) {
+                    if (force_present[i] != 0) {
+                        attacking = force_present[i];
+                        break;
+                    }
                 }
             }
         }
-        target.locked = force_present[q] == 0;
+
+        draw_sprite(spr_faction_icons, attacking, x2 - 100, y1 + 20);
     }
 
     // Back / Purge buttons

--- a/scripts/scr_roster/scr_roster.gml
+++ b/scripts/scr_roster/scr_roster.gml
@@ -3,11 +3,14 @@ function Roster() constructor {
     selected_units = [];
     full_roster = {};
     selected_roster = {};
+    /// @type {Array<Struct.ToggleButton>}
     ships = [];
     roster_location = "";
     roster_planet = 0;
     roster_string = "";
+    /// @type {Array<Struct.ToggleButton>}
     squad_buttons = [];
+    /// @type {Array<Struct.ToggleButton>}
     company_buttons = [];
     roster_local_string = "";
     local_button = new ToggleButton({str1: "Local Forces", text_halign: fa_center, text_color: CM_GREEN_COLOR, button_color: CM_GREEN_COLOR, active: false});
@@ -165,13 +168,13 @@ function Roster() constructor {
         _button.text_halign = fa_center;
         _button.text_color = CM_GREEN_COLOR;
         _button.button_color = CM_GREEN_COLOR;
-        _button.width = string_width(display) + 10;
+        _button.w = string_width(display) + 10;
         _button.active = true;
         _button.squad = squad_id;
         array_push(squad_buttons, _button);
     };
 
-    ship_multi_selector = new MultiSelect([], "", {draw_alighn: "vertical", max_height: 200});
+    ship_multi_selector = new MultiSelect([], "", {is_horizontal: false, max_height: 160});
 
     static new_ship_button = function(display, ship_id) {
         var _button = new ToggleButton();
@@ -243,7 +246,7 @@ function Roster() constructor {
         _button.text_halign = fa_center;
         _button.text_color = CM_GREEN_COLOR;
         _button.button_color = CM_GREEN_COLOR;
-        _button.width = string_width(display) + 10;
+        _button.w = string_width(display) + 10;
         _button.active = true;
         _button.vehic_id = vehicle_type;
         array_push(vehicle_buttons, _button);
@@ -340,7 +343,7 @@ function Roster() constructor {
             _button.text_halign = fa_center;
             _button.text_color = _col;
             _button.button_color = _col;
-            _button.width = string_width(_display) + 10;
+            _button.w = max(30, string_width(_display) + 10);
             _button.active = _company_present;
             _button.company_id = co;
             _button.company_present = _company_present;

--- a/scripts/scr_ui_settings/scr_ui_settings.gml
+++ b/scripts/scr_ui_settings/scr_ui_settings.gml
@@ -253,7 +253,7 @@ function setup_ui_chapter_settings(){
         _tog_buttons, 
         "Company Command Structure", 
         {
-            draw_alighn : "vertical",
+            is_horizontal : false,
             x1 : 75,
             y1 : 300,
         }

--- a/scripts/scr_ui_settings/scr_ui_settings.gml
+++ b/scripts/scr_ui_settings/scr_ui_settings.gml
@@ -129,7 +129,8 @@ function setup_ui_chapter_settings(){
         110,
         570, 
         {
-            tooltip : "Boarding Objective\nThe objective of your Astartes once they board an enemy ship."
+            tooltip : "Boarding Objective\nThe objective of your Astartes once they board an enemy ship.",
+            font: fnt_40k_14
         }
     );
 
@@ -306,7 +307,7 @@ function setup_ui_chapter_settings(){
         ], 
         "Automatic Boarding", 
         {
-            x1 : 400,
+            x1 : 420,
             y1 : 710,
         }
     );


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refines the drop selection screen with a larger layout, consistent green styling, and sturdier controls. Adds smarter ship/squad selectors, rebuilt formation/target buttons, and fixes crashes and unintended state wipes.

- **New Features**
  - Expanded drop screen to 720x580; updated slate scaling and unified `CM_GREEN_COLOR` across labels/buttons.
  - Rebuilt Formation and Target controls (`btn_formation`, `btn_target`): target cycles available forces, shows faction + threat, icon repositioned.
  - Ship selection: “Select all ships”; vertical ship MultiSelect (160px) that wraps; roster updates only when selection changes.
  - MultiSelect rewrite: orientation via `is_horizontal` (replaces `draw_alighn`), proper width/height wrapping and bounds; ToggleButton text now truly centered, box layout refined; consistent `w`/`h` and minimum widths; UI settings get font/position tweaks.

- **Bug Fixes**
  - Fixed Ork stronghold combat crash by correcting `obj_star` string operations to use `other` scope.
  - Prevented Test‑Slave Incubators from wiping after battle by removing the unintended `gene_slaves` reset.
  - Removed the last hardcoded 660 and eliminated ToggleButton width drift; layouts now honor dynamic `w`/`h`.

<sup>Written for commit eadb64eef169de5f151a93686ac824cc92d471a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

