### PR TITLE
fix: Restore alarm[3] needed for the instant log

### DIFF
--- a/scripts/scr_flavor/scr_flavor.gml
+++ b/scripts/scr_flavor/scr_flavor.gml
@@ -5,6 +5,7 @@
 function add_battle_log_message(_message, _message_color = eMSG_COLOR.WHITE) {
     if (instance_exists(obj_ncombat)) {
         obj_ncombat.combat_log.push(_message, _message_color);
+        obj_ncombat.alarm[3] = 2;
         return true;
     }
     return false;


### PR DESCRIPTION
I hate alarms.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the alarm[3] trigger when adding a battle log message so the instant log refreshes immediately during combat. Prevents delayed or missing log updates by setting obj_ncombat.alarm[3] = 2 after pushing to the log.

<sup>Written for commit ce202bb9aee33ea8dfc958b35281f934a8296a34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

