### PR TITLE
fix: Broken planet missions

### DIFF
--- a/scripts/scr_UnitGroup/scr_UnitGroup.gml
+++ b/scripts/scr_UnitGroup/scr_UnitGroup.gml
@@ -667,7 +667,7 @@ function SearchConditions(data) constructor {
             array_push(checks_order, stat_valuate);
         }
         if (struct_exists(self, "job")) {
-            array_push(checks_order, oposite_switch);
+            array_push(checks_order, job_valuate);
         }
 
         if (allegiance != "") {

--- a/scripts/scr_mission_functions/scr_mission_functions.gml
+++ b/scripts/scr_mission_functions/scr_mission_functions.gml
@@ -257,7 +257,7 @@ function problem_end_turn_checks(){
     for (var i = 0; i <array_length(problems);i++){
         var _problem = problems[i];
         if (_problem == ""){
-            return;
+            continue;
         }
 
         if (struct_exists(problem_functions, _problem)){
@@ -608,7 +608,7 @@ function complete_train_forces_mission(targ_planet, problem_index) {
             "max": 1,
         };
         var _mission_string = "";
-        var _trainer = collect_role_group("all", [name, targ_planet, 0], false, man_conditions);
+        var _trainer = collect_role_group("all", [planet.system.name, targ_planet, 0], false, man_conditions);
         if (array_length(_trainer)) {
             var _unit_report_string = "";
             var _tester = global.character_tester;
@@ -714,7 +714,7 @@ function complete_beast_hunt_mission(targ_planet, problem_index) {
             "job": "hunt_beast",
             "max": 3,
         };
-        var _hunters = collect_role_group("all", [name, targ_planet, 0], false, man_conditions);
+        var _hunters = collect_role_group("all", [planet.system.name, targ_planet, 0], false, man_conditions);
         var _success = false;
         var _tester = global.character_tester;
         var _unit_pass;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes mission processing bugs that caused missed end-of-turn checks and incorrect unit selection for training and beast hunts. Improves reliability of job-based filtering and system-scoped role collection.

- **Bug Fixes**
  - End-turn checks: skip empty entries instead of stopping the loop.
  - Unit search: when a job filter exists, use `job_valuate` (not `oposite_switch`).
  - Missions: use `planet.system.name` in `collect_role_group` to pick trainers/hunters from the correct system.

<sup>Written for commit 8cc70806d10ec62dc6ec10022a9e67c5c3f24d8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

