### PR TITLE
refactor: collapse formation bar code

### DIFF
--- a/objects/obj_formation_bar/Create_0.gml
+++ b/objects/obj_formation_bar/Create_0.gml
@@ -6,7 +6,8 @@ old_y = 0;
 
 unit_type = "";
 unit_id = 0;
-for_arr = undefined; // reference to the controller's bat_*_for array, injected via move_data_to_current_scope in init_combat_bars
+/// @desc Reference to the controller's bat_*_for array, injected via move_data_to_current_scope in init_combat_bars
+bat_for = undefined;
 
 size = 0;
 col_parent = 0;
@@ -136,9 +137,7 @@ mouse_release = function(){
 	    if (_in_drop_zone && (obj_controller.temp[te] + size <= 10)) {
 	        obj_controller.temp[4800 + col_parent] -= size;
 	        obj_controller.click = 1;
-	        // [@ ] accessor: write through the reference — plain assignment would trigger a
-	        // copy-on-write duplicate (legacy COW arrays are enabled in this project)
-	        for_arr[@ obj_controller.formating] = mah_target.col_parent;
+	        bat_for[@ obj_controller.formating] = mah_target.col_parent;
 	        obj_cursor.dragging = 0;
 	        obj_cursor.image_index = 0;
 

--- a/objects/obj_formation_bar/Create_0.gml
+++ b/objects/obj_formation_bar/Create_0.gml
@@ -6,6 +6,7 @@ old_y = 0;
 
 unit_type = "";
 unit_id = 0;
+for_arr = undefined; // reference to the controller's bat_*_for array, injected via move_data_to_current_scope in init_combat_bars
 
 size = 0;
 col_parent = 0;
@@ -91,7 +92,6 @@ drag_logic = function(){
 	    rel_mousey = 0;
 	    old_x = 0;
 	    old_y = 0;
-	    col_parent = 0;
 	    col_target = 0;
 	    above_neighbor = 0;
 	    nearest_col = 0;
@@ -130,102 +130,35 @@ mouse_release = function(){
 	}
 
 	if ((dragging == true) && instance_exists(mah_target)) {
-	    if ((x >= mah_target.x - 5) && (x <= mah_target.x + 42) && (mouse_consts[1] >= 222) && (mouse_consts[1] <= 688)) {
-	        var himcol, te;
-	        himcol = mah_target.col_parent;
-	        te = 0;
-	        te = 4800 + himcol;
-	        nexti = false;
+	    var _in_drop_zone = (x >= mah_target.x - 5) && (x <= mah_target.x + 42) && (mouse_consts[1] >= 222) && (mouse_consts[1] <= 688);
+	    var te = 4800 + mah_target.col_parent;
 
-	        if (obj_controller.temp[te] + size <= 10) {
-	            obj_controller.temp[4800 + col_parent] -= size;
-	            obj_controller.click = 1;
-	            if (unit_id == 1) {
-	                obj_controller.bat_comm_for[obj_controller.formating] = mah_target.col_parent;
-	            }
-	            if (unit_id == 2) {
-	                obj_controller.bat_hono_for[obj_controller.formating] = mah_target.col_parent;
-	            }
-	            if (unit_id == 3) {
-	                obj_controller.bat_libr_for[obj_controller.formating] = mah_target.col_parent;
-	            }
-	            if (unit_id == 4) {
-	                obj_controller.bat_tech_for[obj_controller.formating] = mah_target.col_parent;
-	            }
-	            if (unit_id == 5) {
-	                obj_controller.bat_term_for[obj_controller.formating] = mah_target.col_parent;
-	            }
-	            if (unit_id == 6) {
-	                obj_controller.bat_vete_for[obj_controller.formating] = mah_target.col_parent;
-	            }
-	            if (unit_id == 7) {
-	                obj_controller.bat_tact_for[obj_controller.formating] = mah_target.col_parent;
-	            }
-	            if (unit_id == 8) {
-	                obj_controller.bat_deva_for[obj_controller.formating] = mah_target.col_parent;
-	            }
-	            if (unit_id == 9) {
-	                obj_controller.bat_assa_for[obj_controller.formating] = mah_target.col_parent;
-	            }
-	            if (unit_id == 10) {
-	                obj_controller.bat_scou_for[obj_controller.formating] = mah_target.col_parent;
-	            }
-	            if (unit_id == 11) {
-	                obj_controller.bat_drea_for[obj_controller.formating] = mah_target.col_parent;
-	            }
-	            if (unit_id == 12) {
-	                obj_controller.bat_hire_for[obj_controller.formating] = mah_target.col_parent;
-	            }
-	            if (unit_id == 13) {
-	                obj_controller.bat_rhin_for[obj_controller.formating] = mah_target.col_parent;
-	            }
-	            if (unit_id == 14) {
-	                obj_controller.bat_pred_for[obj_controller.formating] = mah_target.col_parent;
-	            }
-	            if (unit_id == 15) {
-	                obj_controller.bat_landraid_for[obj_controller.formating] = mah_target.col_parent;
-	            }
-	            if (unit_id == 16) {
-	                obj_controller.bat_landspee_for[obj_controller.formating] = mah_target.col_parent;
-	            }
-	            if (unit_id == 17) {
-	                obj_controller.bat_whirl_for[obj_controller.formating] = mah_target.col_parent;
-	            }
-	            obj_cursor.dragging = 0;
-	            obj_cursor.image_index = 0;
+	    if (_in_drop_zone && (obj_controller.temp[te] + size <= 10)) {
+	        obj_controller.temp[4800 + col_parent] -= size;
+	        obj_controller.click = 1;
+	        // [@ ] accessor: write through the reference — plain assignment would trigger a
+	        // copy-on-write duplicate (legacy COW arrays are enabled in this project)
+	        for_arr[@ obj_controller.formating] = mah_target.col_parent;
+	        obj_cursor.dragging = 0;
+	        obj_cursor.image_index = 0;
 
-	            // show_message("-> slot "+string(mah_target.col_parent)+", now "+string(obj_controller.temp[te]+size)+"/10 full, old slot is "+string(obj_controller.temp[4800+col_parent])+"/10");
-
-	            with (obj_temp8) {
-	                instance_destroy();
-	            }
-            with (obj_controller) {
-                bar_fix = true;
-            }
-	            exit;
+	        with (obj_temp8) {
+	            instance_destroy();
 	        }
-	        if (obj_controller.temp[te] + size > 10) {
-	            dragging = false;
-	            x = old_x;
-	            y = old_y;
-	            obj_cursor.dragging = 0;
-	            obj_cursor.image_index = 0;
-	            if ((global.settings.master_volume > 0) && (global.settings.sfx_volume > 0)) {
-	                audio_play_sound(snd_error, -80, false);
-	            }
+	        with (obj_controller) {
+	            bar_fix = true;
 	        }
+	        exit;
 	    }
-	    if (instance_exists(mah_target)) {
-	        if ((x < mah_target.x - 5) || (x > mah_target.x + 42) || ( 222) || (mouse_consts[1] >  688)) {
-	            dragging = false;
-	            x = old_x;
-	            y = old_y;
-	            obj_cursor.dragging = 0;
-	            obj_cursor.image_index = 0;
-	            if ((global.settings.master_volume > 0) && (global.settings.sfx_volume > 0)) {
-	                audio_play_sound(snd_error, -80, false);
-	            }
-	        }
+
+	    // Column full, or dropped outside the drop zone: snap back
+	    dragging = false;
+	    x = old_x;
+	    y = old_y;
+	    obj_cursor.dragging = 0;
+	    obj_cursor.image_index = 0;
+	    if ((global.settings.master_volume > 0) && (global.settings.sfx_volume > 0)) {
+	        audio_play_sound(snd_error, -80, false);
 	    }
 	}
 

--- a/objects/obj_formation_bar/Draw_64.gml
+++ b/objects/obj_formation_bar/Draw_64.gml
@@ -51,7 +51,6 @@ if (dragging == false) {
     rel_mousey = 0;
     old_x = 0;
     old_y = 0;
-    col_parent = 0;
     col_target = 0;
     above_neighbor = 0;
     nearest_col = 0;

--- a/scripts/scr_ui_formation_bars/scr_ui_formation_bars.gml
+++ b/scripts/scr_ui_formation_bars/scr_ui_formation_bars.gml
@@ -18,25 +18,25 @@ function scr_ui_formation_bars() {
     }
 
     var _bar_configs = [
-        { unit_id: 1,  for_arr: bat_comm_for, size: 2, image_index: 0,  unit_type: "HQ",           tooltip: "Headquarters",  tooltip2: "You and your advisors will be placed within this section.  It is strongly advisable you give them backup in this same column." },
-        { unit_id: 2,  for_arr: bat_hono_for, size: 1, image_index: 1,  unit_type: "Hono",         tooltip: "Honour Guard",  tooltip2: "Any Honour Guard within your Headquarters will be placed here.  The best place for them within the formation depends on loadout." },
-        { unit_id: 3,  for_arr: bat_libr_for, size: 1, image_index: 8,  unit_type: "Lib",          tooltip: "Librarians",    tooltip2: "Epistolary, Lexicanum, and Codiciery make up this section.  They tend to deal decent damage and offer useful buffs for other units." },
-        { unit_id: 4,  for_arr: bat_tech_for, size: 1, image_index: 9,  unit_type: "Tech",         tooltip: "Techmarines",   tooltip2: "Techmarines and their servitors are placed within this block.  It is advisable that they are placed near your vehicles and armour." },
-        { unit_id: 5,  for_arr: bat_term_for, size: 1, image_index: 10, unit_type: "Term",         tooltip: "Terminators",   tooltip2: "Any Terminators that you may have will be placed here.  They can very easily soak lots of damage and dish it back in return." },
-        { unit_id: 6,  for_arr: bat_vete_for, size: 2, image_index: 6,  unit_type: "Veteran",      tooltip: "Veterans",      tooltip2: "Veterans, the most experienced tacticals of your Chapter, are placed here.  Their best position in the formation depends on loadout." },
-        { unit_id: 7,  for_arr: bat_tact_for, size: 6, image_index: 3,  unit_type: "Tactical",     tooltip: "Tacticals",     tooltip2: "The greater bulk of your Chapter, the tactical marines, go here.  Tactical marines may be situated nearly anywhere.  Note that Apothecaries and Chaplains without jump-packs will also be placed here." },
-        { unit_id: 8,  for_arr: bat_deva_for, size: 3, image_index: 2,  unit_type: "Devastator",   tooltip: "Devastators",   tooltip2: "Devastators offer much long ranged firepower.  As a result they are best placed in the rear of your formation." },
-        { unit_id: 9,  for_arr: bat_assa_for, size: 3, image_index: 5,  unit_type: "Assault",      tooltip: "Assaults",      tooltip2: "Assault marines are damage powerhouses, but tend to be squisher.  You may or may not wish for them to be on the front lines.  Note that Apothecaries and Chaplains with jump-packs will be placed here." },
-        { unit_id: 10, for_arr: bat_scou_for, size: 1, image_index: 4,  unit_type: "Sco",          tooltip: "Scouts",        tooltip2: "Scouts are not-yet full fledged Astartes.  Striking a balance between exposure to the enemy, for experience, and safety is key." },
-        { unit_id: 11, for_arr: bat_drea_for, size: 2, image_index: 11, unit_type: "Dread",        tooltip: "Dreadnoughts",  tooltip2: "Dreadnoughts are the most durable and tough marines within your chapter.  They are best suited for the front lines." },
-        { unit_id: 12, for_arr: bat_hire_for, size: 1, image_index: 7,  unit_type: "???",          tooltip: "Hirelings",     tooltip2: "Any and all units that you recieve from other factions are placed within this block." },
-        { unit_id: 16, for_arr: bat_landspee_for, size: 2, image_index: 14, unit_type: "Land Speeder", tooltip: "Land Speeders", tooltip2: "Land Speeders are incredibly agile attack vehicles that offer a light highly mobile heavy weapon platform." },
+        { unit_id: 1,  bat_for: bat_comm_for, size: 2, image_index: 0,  unit_type: "HQ",           tooltip: "Headquarters",  tooltip2: "You and your advisors will be placed within this section.  It is strongly advisable you give them backup in this same column." },
+        { unit_id: 2,  bat_for: bat_hono_for, size: 1, image_index: 1,  unit_type: "Hono",         tooltip: "Honour Guard",  tooltip2: "Any Honour Guard within your Headquarters will be placed here.  The best place for them within the formation depends on loadout." },
+        { unit_id: 3,  bat_for: bat_libr_for, size: 1, image_index: 8,  unit_type: "Lib",          tooltip: "Librarians",    tooltip2: "Epistolary, Lexicanum, and Codiciery make up this section.  They tend to deal decent damage and offer useful buffs for other units." },
+        { unit_id: 4,  bat_for: bat_tech_for, size: 1, image_index: 9,  unit_type: "Tech",         tooltip: "Techmarines",   tooltip2: "Techmarines and their servitors are placed within this block.  It is advisable that they are placed near your vehicles and armour." },
+        { unit_id: 5,  bat_for: bat_term_for, size: 1, image_index: 10, unit_type: "Term",         tooltip: "Terminators",   tooltip2: "Any Terminators that you may have will be placed here.  They can very easily soak lots of damage and dish it back in return." },
+        { unit_id: 6,  bat_for: bat_vete_for, size: 2, image_index: 6,  unit_type: "Veteran",      tooltip: "Veterans",      tooltip2: "Veterans, the most experienced tacticals of your Chapter, are placed here.  Their best position in the formation depends on loadout." },
+        { unit_id: 7,  bat_for: bat_tact_for, size: 6, image_index: 3,  unit_type: "Tactical",     tooltip: "Tacticals",     tooltip2: "The greater bulk of your Chapter, the tactical marines, go here.  Tactical marines may be situated nearly anywhere.  Note that Apothecaries and Chaplains without jump-packs will also be placed here." },
+        { unit_id: 8,  bat_for: bat_deva_for, size: 3, image_index: 2,  unit_type: "Devastator",   tooltip: "Devastators",   tooltip2: "Devastators offer much long ranged firepower.  As a result they are best placed in the rear of your formation." },
+        { unit_id: 9,  bat_for: bat_assa_for, size: 3, image_index: 5,  unit_type: "Assault",      tooltip: "Assaults",      tooltip2: "Assault marines are damage powerhouses, but tend to be squisher.  You may or may not wish for them to be on the front lines.  Note that Apothecaries and Chaplains with jump-packs will be placed here." },
+        { unit_id: 10, bat_for: bat_scou_for, size: 1, image_index: 4,  unit_type: "Sco",          tooltip: "Scouts",        tooltip2: "Scouts are not-yet full fledged Astartes.  Striking a balance between exposure to the enemy, for experience, and safety is key." },
+        { unit_id: 11, bat_for: bat_drea_for, size: 2, image_index: 11, unit_type: "Dread",        tooltip: "Dreadnoughts",  tooltip2: "Dreadnoughts are the most durable and tough marines within your chapter.  They are best suited for the front lines." },
+        { unit_id: 12, bat_for: bat_hire_for, size: 1, image_index: 7,  unit_type: "???",          tooltip: "Hirelings",     tooltip2: "Any and all units that you recieve from other factions are placed within this block." },
+        { unit_id: 16, bat_for: bat_landspee_for, size: 2, image_index: 14, unit_type: "Land Speeder", tooltip: "Land Speeders", tooltip2: "Land Speeders are incredibly agile attack vehicles that offer a light highly mobile heavy weapon platform." },
     ];
     var _attack_only_options = [
-        { unit_id: 13, for_arr: bat_rhin_for, size: 4, image_index: 12, unit_type: "Rhino",      tooltip: "Rhinos",       tooltip2: "Rhinos offer protection for units behind them but are not well armoured and lacking in firepower." },
-        { unit_id: 14, for_arr: bat_pred_for, size: 2, image_index: 13, unit_type: "Predator",   tooltip: "Predators",    tooltip2: "Predators offer protection for units behind them and have a decent amount of long ranged firepower." },
-        { unit_id: 15, for_arr: bat_landraid_for, size: 2, image_index: 14, unit_type: "Land Raider",tooltip: "Land Raiders", tooltip2: "Land Raiders are incredibly tanky war machines that protect rear columns and offer tremendous amounts of firepower.  Other super-heavy vehicles will also be placed here." },
-        { unit_id: 17, for_arr: bat_whirl_for, size: 2, image_index: 14, unit_type: "Whirlwind",  tooltip: "Whirlwinds",   tooltip2: "Whirlwinds are armoured fire-support capable of supporting assaults from a long range safe from enemy retaliation." },
+        { unit_id: 13, bat_for: bat_rhin_for, size: 4, image_index: 12, unit_type: "Rhino",      tooltip: "Rhinos",       tooltip2: "Rhinos offer protection for units behind them but are not well armoured and lacking in firepower." },
+        { unit_id: 14, bat_for: bat_pred_for, size: 2, image_index: 13, unit_type: "Predator",   tooltip: "Predators",    tooltip2: "Predators offer protection for units behind them and have a decent amount of long ranged firepower." },
+        { unit_id: 15, bat_for: bat_landraid_for, size: 2, image_index: 14, unit_type: "Land Raider",tooltip: "Land Raiders", tooltip2: "Land Raiders are incredibly tanky war machines that protect rear columns and offer tremendous amounts of firepower.  Other super-heavy vehicles will also be placed here." },
+        { unit_id: 17, bat_for: bat_whirl_for, size: 2, image_index: 14, unit_type: "Whirlwind",  tooltip: "Whirlwinds",   tooltip2: "Whirlwinds are armoured fire-support capable of supporting assaults from a long range safe from enemy retaliation." },
     ];
 
     for (var bar = 1; bar <= 10; bar++) {
@@ -52,7 +52,7 @@ function scr_ui_formation_bars() {
 
             for (var _i = 0; _i < array_length(_bar_configs); _i++) {
                 var _cfg = _bar_configs[_i];
-                if ((_cfg.unit_id == unit_id) && (_cfg.for_arr[_formatting] == bar)) {
+                if ((_cfg.unit_id == unit_id) && (_cfg.bat_for[_formatting] == bar)) {
                     init_combat_bars(bar, ui_formations_data, _cfg);
                     break;
                 }
@@ -60,7 +60,7 @@ function scr_ui_formation_bars() {
             if (bat_formation_type[_formatting] != 2) {
                 for (var _i = 0; _i < array_length(_attack_only_options); _i++) {
                     var _cfg = _attack_only_options[_i];
-                    if ((_cfg.unit_id == unit_id) && (_cfg.for_arr[_formatting] == bar)) {
+                    if ((_cfg.unit_id == unit_id) && (_cfg.bat_for[_formatting] == bar)) {
                         init_combat_bars(bar, ui_formations_data, _cfg);
                         break;
                     }


### PR DESCRIPTION
# Contents
- collapses an if spam into a lookup into controller array
- failed drop simplified from three to two options [since whether the bar was full or you missed a bar it's the same outcome] and fixed a condition bug
- zeroing col_parent on drag reset removed [it bugged the drop logic out]

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored formation bar drag-drop to use a single `bat_for` array reference and simplified drop outcomes. This reduces code and fixes edge cases for more reliable behavior.

- **Refactors**
  - Use `bat_for` reference to the controller `bat_*_for` array; replace the 17-case `unit_id` mapping with a direct `[@]` write-through.
  - Simplified drop flow: if in zone and capacity allows, commit and set `bar_fix`; else snap back and play error sound.
  - Renamed config key `for_arr` → `bat_for`; added `@desc` doc and removed a noisy comment.

- **Bug Fixes**
  - Fixed out-of-zone check so “column full” and “outside zone” both snap back.
  - Stopped resetting `col_parent` on drag end in Create/Draw.

<sup>Written for commit 1deeba89c1d5ce831f49bef894397a67618b2429. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

