### PR TITLE
docs(CODE_STYLE): Clarify loop precalc rule

### DIFF
--- a/docs/CODE_STYLE.md
+++ b/docs/CODE_STYLE.md
@@ -108,7 +108,7 @@ All variable names, function names, etc., should use `snake_case` unless stated 
 
 ### Performance
 
-- **Precalculate array length for loops.** `for (var i = 0, l = array_length(array); i < l; i++)`.
+- **Precalculate array length for loops in hotpaths.** `for (var i = 0, l = array_length(array); i < l; i++)` if the loop runs somewhere where loop speed matters.
 - **Keep heavy logic (loops, allocations) out of Draw and Step events**. These events run every frame and can destroy performance.
 - **Prefer `arrays` and `structs` over `ds_*` structures** (`ds_map`, `ds_list`, `ds_grid`, `ds_stack`, `ds_queue`). If you must use a `ds_*` structure, always pair it with a corresponding `ds_destroy` call to avoid memory leaks.
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarified the performance rule to precalculate array length only in hot paths, not in all loops. Updated the example to say it applies when loop speed matters.

<sup>Written for commit dab4cf774752b4f295e2ce844442cf5dc8a560b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

