### PR TITLE
feat: Max kills won't affect enemy armor calc

### DIFF
--- a/scripts/scr_shoot/scr_shoot.gml
+++ b/scripts/scr_shoot/scr_shoot.gml
@@ -315,13 +315,9 @@ function scr_shoot(weapon_index_position, target_object, target_type, damage_dat
 
                     attack_count_mod = max(1, splash[weapon_index_position]);
 
-                    final_hit_damage_value = damage_per_weapon - (target_armour_value * attack_count_mod); //damage armour reduction
+                    final_hit_damage_value = max(0, damage_per_weapon - target_armour_value); //damage armour reduction
 
                     final_hit_damage_value *= target_object.dudes_dr[target_type]; //damage_resistance mod
-
-                    if (final_hit_damage_value <= 0) {
-                        final_hit_damage_value = 0;
-                    } // Average after armour
 
                     c = shots_fired * final_hit_damage_value; // New damage
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stop multiplying enemy armor by the splash/attack count during damage calculation. Damage after armor is now max(0, damage − armor), so “max kills” buffs no longer inflate armor reduction or cause negative damage.

<sup>Written for commit f5d771cac7adbfabd7d6360171a2ed8658b2336e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

