### PR TITLE
feat: A bunch of stuff

### DIFF
--- a/datafiles/data/weapons.json
+++ b/datafiles/data/weapons.json
@@ -1268,7 +1268,7 @@
     "HK Missile": {
         "abbreviation": "HKMssl",
         "ammo": 1,
-        "arp": 1,
+        "arp": 4,
         "attack": {
             "artifact": 450,
             "master_crafted": 400,

--- a/datafiles/data/weapons.json
+++ b/datafiles/data/weapons.json
@@ -2739,8 +2739,7 @@
         "tags": [
             "vehicle",
             "heavy_ranged",
-            "pintle",
-            "dreadnought"
+            "pintle"
         ],
         "value": 60
     },
@@ -2833,7 +2832,6 @@
         "spli": 21,
         "tags": [
             "vehicle",
-            "dreadnought",
             "heavy_ranged",
             "bolt"
         ],
@@ -2862,7 +2860,6 @@
             "flame",
             "heavy_ranged",
             "vehicle",
-            "dreadnought",
             "sponson"
         ],
         "value": 150
@@ -2911,8 +2908,7 @@
             "las",
             "energy",
             "vehicle",
-            "heavy_ranged",
-            "dreadnought"
+            "heavy_ranged"
         ]
     },
     "Twin Linked Lascannon Sponsons": {

--- a/objects/obj_mass_equip/Step_0.gml
+++ b/objects/obj_mass_equip/Step_0.gml
@@ -263,7 +263,10 @@ try {
         }
 
         // Add up messages
-        all_equip = $"In total they are equipped with: {_total_role_gear.get_total_string()}.";
+        var _totals_string = _total_role_gear.get_custom_string(function(_key, _count, _i, _keys) {
+            return $"{_count}x {_key}{smart_delimeter_sign(_keys, _i, false)}";
+        });
+        all_equip = $"In total they are equipped with: {_totals_string}.";
 
         refresh = false;
 

--- a/objects/obj_mass_equip/Step_0.gml
+++ b/objects/obj_mass_equip/Step_0.gml
@@ -266,7 +266,9 @@ try {
         var _totals_string = _total_role_gear.get_custom_string(function(_key, _count, _i, _keys) {
             return $"{_count}x {_key}{smart_delimeter_sign(_keys, _i, false)}";
         });
-        all_equip = $"In total they are equipped with: {_totals_string}.";
+        if (_totals_string != "") {
+            all_equip = $"In total they are equipped with: {_totals_string}.";
+        }
 
         refresh = false;
 

--- a/scripts/scr_controller_helpers/scr_controller_helpers.gml
+++ b/scripts/scr_controller_helpers/scr_controller_helpers.gml
@@ -476,6 +476,7 @@ function scr_end_turn() {
                     }
 
                     player_forge_data.player_forges = 0;
+                    player_forge_data.vehicle_hanger = [];
                     requisition += income;
                     scr_income();
                     gene_tithe -= 1;

--- a/scripts/scr_get_item_names/scr_get_item_names.gml
+++ b/scripts/scr_get_item_names/scr_get_item_names.gml
@@ -148,22 +148,20 @@ function push_marine_mobility_item_names(_item_names) {
 /// @param {array} _item_names - The list to append to.
 /// @returns {void}
 function push_dreadnought_ranged_weapons_item_names(_item_names) {
-    var item_count = 11;
+    var item_count = 9;
     var initial_size = array_length(_item_names);
     array_resize(_item_names, initial_size + item_count);
 
     var index = initial_size;
     _item_names[@ index++] = "Multi-Melta";
-    _item_names[@ index++] = "Twin Linked Heavy Flamer Sponsons";
     _item_names[@ index++] = "Plasma Cannon";
     _item_names[@ index++] = "Assault Cannon";
     _item_names[@ index++] = "Autocannon";
     _item_names[@ index++] = "Missile Launcher";
     _item_names[@ index++] = "Twin Linked Lascannon";
-    _item_names[@ index++] = "Twin Linked Assault Cannon Mount";
     _item_names[@ index++] = "Twin Linked Heavy Bolter";
     _item_names[@ index++] = "Heavy Conversion Beam Projector";
-    _item_names[@ index++] = "Twin-linked Volkite Culverins"; // 10
+    _item_names[@ index++] = "Twin-linked Volkite Culverins"; // 8
 }
 
 /// @description This function appends the list of dreadnought melee weapons to the given list.

--- a/scripts/scr_specialist_point_handler/scr_specialist_point_handler.gml
+++ b/scripts/scr_specialist_point_handler/scr_specialist_point_handler.gml
@@ -463,12 +463,12 @@ function SpecialistPointHandler() constructor {
         if (master_craft_count > 0) {
             scr_add_item(_item.name, master_craft_count, "master_crafted");
             var numerical_string = master_craft_count == 1 ? "was" : "were";
-            quality_string = $"X{master_craft_count} {numerical_string} Completed to a Master Crafted standard";
+            quality_string = $"x{master_craft_count} {numerical_string} completed to a Master Crafted standard!";
         } else {
-            quality_string = $"all were completed to a standard STC compliant quality";
+            quality_string = $"All were completed to a standard STC compliant quality!";
         }
 
-        scr_popup("Forge Completed", $"{_item.display_name} X{_forge_order.count} construction finished {quality_string}", "", "");
+        scr_popup("Forge Completed", $"Construction of x{_forge_order.count} {_item.display_name} is finished! {quality_string}", "", "");
     };
 
     static scr_evaluate_forge_item_completion = function(_forge_order) {
@@ -481,18 +481,25 @@ function SpecialistPointHandler() constructor {
                 if (!is_vehicle) {
                     scr_forge_item(_forge_order);
                 } else {
-                    var _build_locs = [];
-
+                    var _loc_counts = new CountingMap();
+                
                     repeat (_forge_order.count) {
                         var vehicle = scr_add_vehicle(_item.name, obj_controller.new_vehicles);
                         var build_loc = array_random_element(obj_controller.player_forge_data.vehicle_hanger);
                         obj_ini.veh_loc[vehicle[0]][vehicle[1]] = build_loc[0];
                         obj_ini.veh_wid[vehicle[0]][vehicle[1]] = build_loc[1];
                         obj_ini.veh_lid[vehicle[0]][vehicle[1]] = -1;
-                        array_push(_build_locs, $"{build_loc[0]} {build_loc[1]}");
+                        _loc_counts.add($"{build_loc[0]} {build_loc[1]}");
                     }
-
-                    scr_popup("Forge Completed", $"{_item.display_name} x{_forge_order.count} construction finished! Vehicles waiting at hanger(s) on {string_join_ext(", ", _build_locs)}", "", "");
+                
+                    var _loc_summary = _loc_counts.get_custom_string(function(_key, _count) {
+                        return $"{_count} at {_key}\n";
+                    });
+                    
+                    var _company = obj_controller.new_vehicles;
+                    var _company_name = (_company >= 1 && _company <= 10) ? $"{int_to_roman(_company)} Company" : "Reserve";
+                    
+                    scr_popup("Forge Completed", $"Construction of x{_forge_order.count} {_item.display_name} is finished!\n\nAssigned to: {_company_name}\n\nReady at:\n{_loc_summary}", "", "");
                 }
             } else if (_item.forge_type == "research") {
                 scr_advance_research(_item.name);

--- a/scripts/scr_struct_functions/scr_struct_functions.gml
+++ b/scripts/scr_struct_functions/scr_struct_functions.gml
@@ -56,8 +56,12 @@ function gc_struct(vari) {
     delete vari;
 }
 
-function CountingMap() constructor {
+function CountingMap(_initial_array = undefined) constructor {
     map = {};
+
+    if (_initial_array != undefined) {
+        add_all(_initial_array);
+    }
 
     static add = function(_key, number = 1) {
         if (_key == "") {
@@ -75,16 +79,30 @@ function CountingMap() constructor {
         }
     };
 
-    static get_total_string = function() {
-        var result = "";
-        var keys = struct_get_names(map);
-
-        for (var i = 0; i < array_length(keys); i++) {
-            var key = keys[i];
-            result += $"{map[$ key]}x {key}{smart_delimeter_sign(keys, i, false)}";
+    static add_all = function(_array) {
+        if (!is_array(_array)) {
+            return;
         }
+        var _len = array_length(_array);
+        for (var _i = 0; _i < _len; _i++) {
+            add(_array[_i]);
+        }
+    };
 
-        return result;
+    static get_custom_string = function(_callback) {
+        var _keys = struct_get_names(map);
+        var _len = array_length(_keys);
+        if (_len == 0) {
+            return "";
+        }
+        
+        var _parts = array_create(_len);
+        for (var _i = 0; _i < _len; _i++) {
+            var _key = _keys[_i];
+            _parts[_i] = _callback(_key, map[$ _key], _i, _keys);
+        }
+        
+        return string_join_ext("", _parts);
     };
 
     static get_string = function(_key) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refines forge completion popups with company assignment and grouped hangar locations. Updates weapons: HK Missile AP set to 4 and removes incorrect "dreadnought" tags.

- **New Features**
  - `CountingMap` now supports custom callbacks and faster joins; used to format equipment totals and forge location summaries.

- **Bug Fixes**
  - Forge: clear `player_forge_data.vehicle_hanger` on end turn and hide empty "In total..." equipment summary.
  - Armory: dreadnought ranged list no longer shows non-dread weapons.

<sup>Written for commit a8d7c3a8f9205abe99befffbeca2c7d575365755. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

