### PR TITLE
Pack of things

### DIFF
--- a/objects/obj_enunit/Alarm_0.gml
+++ b/objects/obj_enunit/Alarm_0.gml
@@ -48,7 +48,7 @@ if (!engaged) {
 
         if (range[i] >= dist) {
             // The weapon is in range;
-            var _target_vehicles = apa[i] > 0 ? true : false; // AP weapons target vehicles
+            var _target_vehicles = apa[i] > 2 ? true : false; // AP weapons target vehicles
 
             // Weird alpha strike mechanic, that changes target unit index to CM;
             if (((wep[i] == "Power Fist") || (wep[i] == "Bolter")) && (obj_ncombat.alpha_strike > 0) && (wep_num[i] > 5)) {
@@ -209,7 +209,7 @@ if (!engaged) {
 
         if ((range[i] <= 2) || (floor(range[i]) != range[i])) {
             // Weapon meets preliminary checks
-            if (apa[i] > 0) {
+            if (apa[i] > 2) {
                 _armour_piercing = true;
             } // Determines if it is _armour_piercing or not
             if (_armour_piercing && instance_exists(obj_nfort) && (!flank)) {

--- a/objects/obj_enunit/Alarm_0.gml
+++ b/objects/obj_enunit/Alarm_0.gml
@@ -80,7 +80,7 @@ if (!engaged) {
                     if (block_has_armour(enemy) || (enemy.veh_type[1] == "Defenses")) {
                         scr_shoot(i, enemy, target_unit_index, "arp", "ranged");
                         continue;
-                    } else if ((instance_number(obj_pnunit) > 1) && (obj_ncombat.enemy != eFACTION.ORK)) {
+                    } else if ((instance_number(obj_pnunit) > 1)) {
                         var x2 = enemy.x;
                         repeat (instance_number(obj_pnunit) - 1) {
                             x2 += flank == 0 ? -10 : 10;
@@ -157,7 +157,7 @@ if (!engaged) {
                         if (block_has_armour(enemy) || (enemy.veh_type[1] == "Defenses")) {
                             scr_shoot(i, enemy, target_unit_index, "att", "ranged");
                             continue;
-                        } else if ((instance_number(obj_pnunit) > 1) && (obj_ncombat.enemy != eFACTION.ORK)) {
+                        } else if ((instance_number(obj_pnunit) > 1)) {
                             var x2 = enemy.x;
                             repeat (instance_number(obj_pnunit) - 1) {
                                 x2 += flank == 0 ? -10 : 10;

--- a/objects/obj_ncombat/Alarm_3.gml
+++ b/objects/obj_ncombat/Alarm_3.gml
@@ -88,19 +88,7 @@ if ((combat_log.pending_count == 0) && ((timer_stage == 4) || (timer_stage == 5)
         }
     }
     if (enemy == eFACTION.ELDAR) {
-        if (enemy_forces > 0) {
-            _newline = "Enemy Forces at " + string(max(1, round((enemy_forces / enemy_max) * 100))) + "%";
-            combat_log.push(_newline, _newline_color);
-        }
-        if (((enemy_forces <= 0) || (!instance_exists(obj_enunit))) && (defeat_message == 0)) {
-            defeat_message = 1;
-            _newline = "Enemy Forces Defeated";
-            combat_log.push(_newline, _newline_color);
-            timer_maxspeed = 0;
-            timer_speed = 0;
-            started = 2;
-            instance_activate_object(obj_pnunit);
-        }
+        combat_emit_enemy_status();
     }
     done = 1;
     timer_stage = 5;

--- a/objects/obj_ncombat/Step_0.gml
+++ b/objects/obj_ncombat/Step_0.gml
@@ -86,13 +86,7 @@ if ((((timer_stage == 2) && (fugg >= 60)) || (((timer_stage == 4) || (timer_stag
         }
         if (enemy == eFACTION.ELDAR) {
             if (((enemy_forces <= 0) || (!instance_exists(obj_enunit))) && (defeat_message == 0)) {
-                defeat_message = 1;
-                _newline = "Enemy Forces Defeated";
-                combat_log.push(_newline, _newline_color);
-                timer_maxspeed = 0;
-                timer_speed = 0;
-                started = 2;
-                instance_activate_object(obj_pnunit);
+                combat_emit_enemy_status();
             }
         }
         done = 1;

--- a/objects/obj_pnunit/Alarm_3.gml
+++ b/objects/obj_pnunit/Alarm_3.gml
@@ -40,7 +40,6 @@ try {
                 if ((marine_dead[raar] == 0) && (marine_type[raar] != "Death Company") && (marine_type[raar] != obj_ini.role[100][eROLE.CHAPTERMASTER]) && (_r_roll <= 4)) {
                     r_lost += 1;
                     marine_type[raar] = "Death Company";
-                    marine_defense[raar] = 0.75;
                     obj_ncombat.red_thirst += 1;
                     if (r_lost == 1) {
                         miss += "Battle Brother " + string(unit_struct[raar].name()) + ", ";

--- a/objects/obj_pnunit/Create_0.gml
+++ b/objects/obj_pnunit/Create_0.gml
@@ -44,7 +44,6 @@ marine_powers = [];
 marine_dead = [];
 marine_attack = [];
 marine_ranged = [];
-marine_defense = [];
 marine_casting = [];
 marine_casting_cooldown = [];
 marine_local = [];

--- a/scripts/Logger/Logger.gml
+++ b/scripts/Logger/Logger.gml
@@ -11,10 +11,10 @@ enum eLOG_LEVEL {
 /// @function Logger() constructor
 /// @description A Python-inspired logger that traces the callsite and timestamp for every message.
 function Logger() constructor {
-    static active_level = eLOG_LEVEL.DEBUG;
-    static file_logging = true;
-    static file_logging_level = eLOG_LEVEL.INFO;
-    static log_filename = PATH_LAST_MESSAGES;
+    active_level = eLOG_LEVEL.DEBUG;
+    file_logging = true;
+    file_logging_level = eLOG_LEVEL.INFO;
+    log_filename = PATH_LAST_MESSAGES;
 
     /// @description Physically writes the queue to the file.
     /// @param {Any} _message

--- a/scripts/scr_clean/scr_clean.gml
+++ b/scripts/scr_clean/scr_clean.gml
@@ -130,7 +130,7 @@ function check_dead_marines(unit_struct, unit_index) {
 
 /// @self Id.Instance.obj_pnunit
 /// @param {Id.Instance.obj_pnunit} target_object
-function scr_clean(target_object, target_is_infantry, hostile_shots, hostile_damage, hostile_weapon, hostile_range, hostile_splash, weapon_index_position) {
+function scr_clean(target_object, target_is_infantry, hostile_shots, hostile_damage, hostile_weapon, hostile_range, hostile_splash, hostile_armour_pierce) {
     // Converts enemy scr_shoot damage into player marine or vehicle casualties.
     //
     // Parameters:
@@ -156,23 +156,23 @@ function scr_clean(target_object, target_is_infantry, hostile_shots, hostile_dam
 
             // ### Vehicle Damage Processing ###
             if (!target_is_infantry && veh > 0) {
-                damage_vehicles(damage_data, hostile_shots, hostile_damage, weapon_index_position);
+                damage_vehicles(damage_data, hostile_shots, hostile_damage, hostile_armour_pierce);
             }
 
             // ### Marine + Dreadnought Processing ###
             if (target_is_infantry && (men + dreads > 0)) {
-                damage_infantry(damage_data, hostile_shots, hostile_damage, weapon_index_position);
+                damage_infantry(damage_data, hostile_shots, hostile_damage, hostile_armour_pierce);
             }
 
             if (damage_data.hits < hostile_shots) {
                 // ### Vehicle Damage Processing ###
                 if (target_is_infantry && veh > 0) {
-                    damage_vehicles(damage_data, hostile_shots, hostile_damage, weapon_index_position);
+                    damage_vehicles(damage_data, hostile_shots, hostile_damage, hostile_armour_pierce);
                 }
 
                 // ### Marine + Dreadnought Processing ###
                 if (!target_is_infantry && (men + dreads > 0)) {
-                    damage_infantry(damage_data, hostile_shots, hostile_damage, weapon_index_position);
+                    damage_infantry(damage_data, hostile_shots, hostile_damage, hostile_armour_pierce);
                 }
             }
 
@@ -191,10 +191,9 @@ function scr_clean(target_object, target_is_infantry, hostile_shots, hostile_dam
 }
 
 /// @self Asset.GMObject.obj_pnunit
-function damage_infantry(_damage_data, _shots, _damage, _weapon_index) {
-    var _armour_pierce = apa[_weapon_index];
+function damage_infantry(_damage_data, _shots, _damage, _hostile_armour_pierce) {
     var _armour_mod = 0;
-    switch (_armour_pierce) {
+    switch (_hostile_armour_pierce) {
         case 4:
             _armour_mod = 0;
             break;
@@ -294,10 +293,9 @@ function damage_infantry(_damage_data, _shots, _damage, _weapon_index) {
 }
 
 /// @self Asset.GMObject.obj_pnunit
-function damage_vehicles(_damage_data, _shots, _damage, _weapon_index) {
-    var _armour_pierce = apa[_weapon_index];
+function damage_vehicles(_damage_data, _shots, _damage, _hostile_armour_pierce) {
     var _armour_mod = 0;
-    switch (_armour_pierce) {
+    switch (_hostile_armour_pierce) {
         case 4:
             _armour_mod = 0;
             break;

--- a/scripts/scr_en_weapon/scr_en_weapon.gml
+++ b/scripts/scr_en_weapon/scr_en_weapon.gml
@@ -1125,7 +1125,6 @@ function scr_en_weapon(name, is_man, man_number, man_type, group) {
     }
 
     atta = round(atta * obj_ncombat.global_defense);
-    arp = round(arp * obj_ncombat.global_defense);
 
     if (obj_ncombat.enemy == eFACTION.PLAYER) {
         // more attack crap here
@@ -1150,7 +1149,7 @@ function scr_en_weapon(name, is_man, man_number, man_type, group) {
     for (var b = 0; b < 30; b++) {
         if ((wep[b] == name) && (goody == 0)) {
             att[b] += atta * man_number;
-            apa[b] += arp;
+            apa[b] = arp;
             range[b] = rang;
             wep_num[b] += man_number;
             if (obj_ncombat.started == 0) {
@@ -1173,7 +1172,7 @@ function scr_en_weapon(name, is_man, man_number, man_type, group) {
         wep[first] = name;
         splash[first] = spli;
         att[first] += atta * man_number;
-        apa[first] += arp;
+        apa[first] = arp;
         range[first] = rang;
         wep_num[first] += man_number;
         if (obj_ncombat.started == 0) {

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -1256,9 +1256,10 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
     };
 
     static ranged_attack = function(weapon_slot = 0) {
+        var ranged_damage_data = [];
         encumbered_ranged = false;
         //base modifyer based on unit skill set
-        ranged_att = 100 * ((ballistic_skill / 50) + (dexterity / 400) + (experience / 500));
+        var ranged_att = 100 * ((ballistic_skill / 50) + (dexterity / 400) + (experience / 500));
         var final_range_attack = 0;
         var explanation_string = $"Stat Mod: x{ranged_att / 100}#  BS: x{ballistic_skill / 50}#  DEX: x{dexterity / 400}#  EXP: x{experience / 500}#";
         //determine capavbility to weild bulky weapons
@@ -1624,14 +1625,14 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
             }
         }
 
-        melee_damage_data = [
+        var _melee_damage_data = [
             final_attack,
             explanation_string,
             melee_carrying,
             primary_weapon,
             secondary_weapon
         ];
-        return melee_damage_data;
+        return _melee_damage_data;
     };
 
     static has_force_weapon = function() {
@@ -1650,9 +1651,9 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
     };
 
     //TODO just did this so that we're not loosing featuring but this porbably needs a rethink
-    static hammer_of_wrath = function() {
-        var _melee_attack = melee_damage_data[0];
-        var _melee_weapon = melee_damage_data[3];
+    static hammer_of_wrath = function(_melee_damage_data = melee_attack()) {
+        var _melee_attack = _melee_damage_data[0];
+        var _melee_weapon = _melee_damage_data[3];
 
         var wrath = new EquipmentStruct({attack: _melee_attack * 0.75, name: "Hammer of Wrath", range: 2, ammo: 6, spli: _melee_weapon.spli, arp: _melee_weapon.arp}, "weapon");
 
@@ -1664,22 +1665,22 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
     };
 
     static armour_calc = function() {
-        armour_rating = 0;
-        armour_rating += get_armour_data("armour_value");
-        armour_rating += get_weapon_one_data("armour_value");
-        armour_rating += get_mobility_data("armour_value");
-        armour_rating += get_gear_data("armour_value");
-        armour_rating += get_weapon_two_data("armour_value");
+        var _armour_rating = 0;
+        _armour_rating += get_armour_data("armour_value");
+        _armour_rating += get_weapon_one_data("armour_value");
+        _armour_rating += get_mobility_data("armour_value");
+        _armour_rating += get_gear_data("armour_value");
+        _armour_rating += get_weapon_two_data("armour_value");
         if (armour() != "" && allegiance == global.chapter_name) {
             // STC Bonuses
             if (obj_controller.stc_bonus[1] == 5) {
-                armour_rating *= 1.05;
+                _armour_rating *= 1.05;
             }
             if (obj_controller.stc_bonus[2] == 3) {
-                armour_rating *= 1.05;
+                _armour_rating *= 1.05;
             }
         }
-        return armour_rating;
+        return _armour_rating;
     };
 
     static in_squad = function() {

--- a/scripts/scr_player_combat_weapon_stacks/scr_player_combat_weapon_stacks.gml
+++ b/scripts/scr_player_combat_weapon_stacks/scr_player_combat_weapon_stacks.gml
@@ -174,7 +174,7 @@ function scr_player_combat_weapon_stacks() {
                         if (mobi_item.has_tag("jump")) {
                             var stack_index = find_stack_index("Hammer of Wrath", head_role, unit);
                             if (stack_index > -1) {
-                                add_data_to_stack(stack_index, unit.hammer_of_wrath(), false, head_role, unit);
+                                add_data_to_stack(stack_index, unit.hammer_of_wrath(marine_attack[g]), false, head_role, unit);
                                 if (head_role) {
                                     player_head_role_stack(stack_index, unit);
                                 }
@@ -230,23 +230,23 @@ function scr_player_combat_weapon_stacks() {
                     }
                 }
                 if (marine_casting[g] == false) {
-                    var primary_ranged = unit.ranged_damage_data[3]; //collect unit ranged data
+                    var primary_ranged = marine_ranged[g][3]; //collect unit ranged data
                     var weapon_stack_index = find_stack_index(primary_ranged.name, head_role, unit);
                     if (weapon_stack_index > -1) {
-                        add_data_to_stack(weapon_stack_index, primary_ranged, unit.ranged_damage_data[0], head_role, unit);
+                        add_data_to_stack(weapon_stack_index, primary_ranged, marine_ranged[g][0], head_role, unit);
                         if (head_role) {
                             player_head_role_stack(weapon_stack_index, unit);
                         }
                     }
 
-                    var primary_melee = unit.melee_damage_data[3]; //collect unit melee data
+                    var primary_melee = marine_attack[g][3]; //collect unit melee data
                     weapon_stack_index = find_stack_index(primary_melee.name, head_role, unit);
                     if (weapon_stack_index > -1) {
                         if (range[weapon_stack_index] > 1.9) {
                             continue;
                         } //creates secondary weapon stack for close combat ranged weaponry use
                         primary_melee.range = 1;
-                        add_data_to_stack(weapon_stack_index, primary_melee, unit.melee_damage_data[0], head_role, unit);
+                        add_data_to_stack(weapon_stack_index, primary_melee, marine_attack[g][0], head_role, unit);
                         if (head_role) {
                             player_head_role_stack(weapon_stack_index, unit);
                         }

--- a/scripts/scr_player_combat_weapon_stacks/scr_player_combat_weapon_stacks.gml
+++ b/scripts/scr_player_combat_weapon_stacks/scr_player_combat_weapon_stacks.gml
@@ -379,7 +379,6 @@ function scr_add_unit_to_roster(unit, is_local = false, is_ally = false) {
     array_push(marine_local, is_local);
     array_push(marine_casting, false);
     array_push(marine_casting_cooldown, 0);
-    array_push(marine_defense, 1);
 
     array_push(marine_dead, 0);
     array_push(marine_mshield, 0);

--- a/scripts/scr_powers/scr_powers.gml
+++ b/scripts/scr_powers/scr_powers.gml
@@ -195,8 +195,7 @@ function scr_powers(caster_id, _psy_log = undefined) {
                 _marine_index = _target_data.index;
                 _marine_column = _target_data.column;
                 if (_marine_index != -1) {
-                    marine_attack[_marine_index] += 1.5 * _total_psychic_amplification;
-                    marine_defense[_marine_index] -= 0.15 * _total_psychic_amplification;
+                    marine_attack[_marine_index][0] *= 1.5 * _total_psychic_amplification;
                 }
             }
         } else if (_power_id == "regenerate") {

--- a/scripts/scr_shoot/scr_shoot.gml
+++ b/scripts/scr_shoot/scr_shoot.gml
@@ -95,7 +95,7 @@ function scr_shoot(weapon_index_position, target_object, target_type, damage_dat
                     hostile_range = range[weapon_index_position];
                     hostile_splash = attack_count_mod;
 
-                    scr_clean(target_object, hostile_type, hit_number, hostile_damage, hostile_weapon, hostile_range, hostile_splash, weapon_index_position);
+                    scr_clean(target_object, hostile_type, hit_number, hostile_damage, hostile_weapon, hostile_range, hostile_splash, armour_pierce);
                 }
             } else if ((damage_type == "att") && (aggregate_damage > 0) && (stop == 0) && (shots_fired > 0)) {
                 var damage_per_weapon, hit_number;
@@ -131,7 +131,7 @@ function scr_shoot(weapon_index_position, target_object, target_type, damage_dat
                     hostile_range = range[weapon_index_position];
                     hostile_splash = attack_count_mod;
 
-                    scr_clean(target_object, hostile_type, hit_number, hostile_damage, hostile_weapon, hostile_range, hostile_splash, weapon_index_position);
+                    scr_clean(target_object, hostile_type, hit_number, hostile_damage, hostile_weapon, hostile_range, hostile_splash, armour_pierce);
                 }
             } else if (((damage_type == "arp") || (damage_type == "dread")) && (armour_pierce > 0) && (stop == 0) && (shots_fired > 0)) {
                 var damage_per_weapon, hit_number;
@@ -182,7 +182,7 @@ function scr_shoot(weapon_index_position, target_object, target_type, damage_dat
                         target_object.hostile_shooters = (wep_owner[weapon_index_position] == "assorted") ? 999 : 1;
                         hostile_type = 0;
 
-                        scr_clean(target_object, hostile_type, hit_number, hostile_damage, hostile_weapon, hostile_range, hostile_splash, weapon_index_position);
+                        scr_clean(target_object, hostile_type, hit_number, hostile_damage, hostile_weapon, hostile_range, hostile_splash, armour_pierce);
                     }
                 }
             }

--- a/scripts/scr_shoot/scr_shoot.gml
+++ b/scripts/scr_shoot/scr_shoot.gml
@@ -51,7 +51,6 @@ function scr_shoot(weapon_index_position, target_object, target_type, damage_dat
             }
             if (obj_ncombat.enemy == eFACTION.HERETICS) {
                 aggregate_damage = round(aggregate_damage * 1.15);
-                armour_pierce = round(armour_pierce * 1.15);
             }
             if ((obj_ncombat.enemy == eFACTION.CHAOS) && (obj_ncombat.threat == 7)) {
                 doom = 1;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes Ork retargeting and broken armour‑pierce tiers, and corrects the Hysterical Frenzy buff. Also refactors logging and unit stat handling, and consolidates Eldar enemy status updates.

- **Bug Fixes**
  - Orks now retarget/flank when multiple player units are present (removed faction check).
  - Enemy AP no longer accumulates across identical weapons; `apa` is set per weapon to prevent inflated values.
  - Armour pierce is applied correctly to infantry and vehicles by passing AP through `scr_shoot -> scr_clean -> damage_*`; removed Heretic AP scaling that broke tiers.
  - Hysterical Frenzy now multiplies `marine_attack[index][0]` (no defense side effect).
  - Localized marine stat/equipment calculations prevent stale data from persisting across saves.

- **Refactors**
  - Logger is fully instanced; level, file logging, and filename are per instance (no static fields).
  - `scr_clean` now accepts `hostile_armour_pierce`; updated `scr_shoot` and damage helpers; centralized Eldar status/defeat logs via `combat_emit_enemy_status()`.
  - Weapon stacks use `marine_attack`/`marine_ranged`; `hammer_of_wrath` takes melee data; removed unused `marine_defense` state and its Death Company side-effect.

<sup>Written for commit 2560bf2f97dba9d79288308435d0372f967073d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

