### PR TITLE
fix: Raidable invaders, dead world Bombard

### DIFF
--- a/objects/obj_star_select/Draw_64.gml
+++ b/objects/obj_star_select/Draw_64.gml
@@ -170,22 +170,12 @@ try {
                     }
                 }
                 if (target.present_fleet[1] > 0) {
-                    if (is_enemy) {
-                        button1 = "Attack";
-                        button2 = "Raid";
+                    button1 = "Attack";
+                    button2 = "Raid";
+                    if (is_enemy || p_data.xenos_and_heretics() > 0) {
                         button3 = "Bombard";
-                    } else {
-                        button1 = "Attack";
-                        if (p_data.xenos_and_heretics() > 0) {
-                            button2 = "Raid";
-                            if (p_data.planet_type == "Dead") {
-                                button3 = "Bombard";
-                            }
-                        } else if (p_data.population) {
-                            button2 = "Purge";
-                        } else {
-                            button2 = "Raid";
-                        }
+                    } else if (p_data.population > 0) {
+                        button3 = "Purge";
                     }
 
                     if (torpedo > 0) {

--- a/objects/obj_star_select/Draw_64.gml
+++ b/objects/obj_star_select/Draw_64.gml
@@ -176,9 +176,15 @@ try {
                         button3 = "Bombard";
                     } else {
                         button1 = "Attack";
-                        button2 = "Raid";
-                        if (p_data.population) {
+                        if (p_data.xenos_and_heretics() > 0) {
+                            button2 = "Raid";
+                            if (p_data.planet_type == "Dead") {
+                                button3 = "Bombard";
+                            }
+                        } else if (p_data.population) {
                             button2 = "Purge";
+                        } else {
+                            button2 = "Raid";
                         }
                     }
 


### PR DESCRIPTION
- A non-enemy fleet orbiting an imperial/unowned world was offered Purge as soon as the world had any population, making a landed enemy force unraidable.
- Dead worlds never register as enemy-owned, so an enemy-occupied dead world never offered Bombard.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes action button logic so invaders can be raided and enemy-held dead worlds allow Bombard, even if the world isn’t marked enemy-owned. Also ensures Raid isn’t hidden by Purge.

- **Bug Fixes**
  - In `objects/obj_star_select/Draw_64.gml`, always set Attack and Raid; set Bombard when `is_enemy` or `p_data.xenos_and_heretics() > 0`, else set Purge when `p_data.population > 0`.
  - Enable Bombard on "Dead" planets with invaders, regardless of ownership state.

- **Refactors**
  - Simplified action button branching to reduce duplication and make state handling clearer.

<sup>Written for commit 7c612c24fbf31fa1770ae9ce5a2bb2e36e787e05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

