### PR TITLE
refactor: End Turn AI logic script cleanups

### DIFF
--- a/objects/obj_star/Alarm_0.gml
+++ b/objects/obj_star/Alarm_0.gml
@@ -1,11 +1,10 @@
 // This will create a system, with all the planet setup. It also does naming of stars, eldar craft worlds and space hulks
 if ((obj_controller.craftworld == 0) && (space_hulk == 0)) {
-    var test, oldx, oldy;
-    oldx = x;
-    oldy = y;
+    var oldx = x;
+    var oldy = y;
     x -= 5000;
     y -= 5000;
-    test = instance_nearest(oldx + choose(random(200), 1 * -random(200)), oldy + choose(random(200), 1 * -random(200)), obj_star);
+    var test = instance_nearest(oldx + choose(random(200), 1 * -random(200)), oldy + choose(random(200), 1 * -random(200)), obj_star);
     x2 = test.x;
     y2 = test.y;
     x = oldx;
@@ -196,7 +195,12 @@ switch (name) {
         break;
 }
 
-var a = 99, b = 99, c = 99, d = 99, e = "", f = 0, g = "", h = 0;
+var a = 99;
+var b = 99;
+var c = 99;
+var d = 99;
+var e = "";
+var f = 0;
 // Sets up points value for each planet on the system
 // TODO in here the map generation should be called for each planet
 for (var i = 0; i < 10; i++) {

--- a/objects/obj_star/Alarm_1.gml
+++ b/objects/obj_star/Alarm_1.gml
@@ -70,7 +70,7 @@ for (var i = 1; i <= 4; i++) {
             break;
         case "Craftworld":
             p_population[i] = irandom_range(150000, 300000);
-            p_station = 6;
+            p_station[i] = 6;
             p_max_population[i] = p_population[i];
             break;
     }
@@ -120,14 +120,17 @@ for (var i = 1; i <= 4; i++) {
         warp_lanes = [];
         x2 = 0;
     }
-    // p_guardsmen[i]=0;
 }
 
 for (var i = 1; i <= 4; i++) {
     p_guardsmen[i] = 0;
 }
 
-var fleet, system_fleet = 0, capital = 0, frigate = 0, escort = 0;
+var fleet;
+var system_fleet = 0;
+var capital = 0;
+var frigate = 0;
+var escort = 0;
 // Create Imperium Fleet
 if (owner == eFACTION.IMPERIUM || owner == eFACTION.ORK || owner == eFACTION.MECHANICUS) {
     for (var g = 1; g <= 4; g++) {
@@ -314,7 +317,6 @@ if (owner == eFACTION.TYRANIDS) {
                     p_tyranids[i] = choose(4, 5, 5);
                     break;
             }
-            //array_push(p_feature[i], new NewPlanetFeature(eP_FEATURES.GENE_STEALER_CULT));
         }
         p_owner[i] = eFACTION.IMPERIUM;
     }
@@ -346,9 +348,8 @@ for (var i = 1; i <= planets; i++) {
         p_owner[i] = 5;
         p_first[i] = 5;
         p_sisters[i] = 4;
-        adjust_influence(eFACTION.ECCLESIARCHY, (p_sisters[i] * 10) - irandom(5), i, self);
+        adjust_influence(eFACTION.ECCLESIARCHY, (p_sisters[i] * 10) - irandom(5), i, id);
     }
-    // if (p_owner[i]=3) or (p_owner[i]=5){p_feature[i]="Artifact|";}Testing ; 137
 }
 
 if ((name == "Kim Jong") && (owner == eFACTION.CHAOS)) {
@@ -404,7 +405,7 @@ if ((choose(0, 1) == 1) && (planets > 0)) {
                                     p_heresy[_ran_num] -= 10;
                                 }
                                 p_sisters[_ran_num] = choose(2, 2, 3);
-                                adjust_influence(eFACTION.ECCLESIARCHY, (p_sisters[_ran_num] * 10) - irandom(3), _ran_num, self);
+                                adjust_influence(eFACTION.ECCLESIARCHY, (p_sisters[_ran_num] * 10) - irandom(3), _ran_num, id);
                                 goo = 1;
                                 break;
                             case 2:

--- a/objects/obj_star/Alarm_2.gml
+++ b/objects/obj_star/Alarm_2.gml
@@ -1,9 +1,7 @@
 // Assigns the income to the player system based on its neighbours
 if (instance_exists(obj_temp1)) {
-    var tempy = 0, tempy_d = 9999, biggy = 0;
-
-    tempy = instance_nearest(x, y, obj_temp1);
-    tempy_d = point_distance(x, y, tempy.x, tempy.y);
+    var tempy = instance_nearest(x, y, obj_temp1);
+    var tempy_d = point_distance(x, y, tempy.x, tempy.y);
 
     // Nearby star system
     if ((tempy_d > 10) && (tempy_d <= 180)) {
@@ -16,8 +14,8 @@ if (instance_exists(obj_temp1)) {
             }
         }
     }
-    biggy = instance_nearest(obj_temp1.x, obj_temp1.y, obj_star);
-    var connected = determine_warp_join(biggy, self.id);
+    var biggy = instance_nearest(obj_temp1.x, obj_temp1.y, obj_star);
+    var connected = determine_warp_join(biggy, id);
     if ((biggy.owner == eFACTION.PLAYER) && (tempy_d > 180) && connected) {
         for (var i = 1; i <= planets; i++) {
             if ((p_type[i] == "Forge") && (p_owner[i] == 3)) {

--- a/objects/obj_star/Alarm_3.gml
+++ b/objects/obj_star/Alarm_3.gml
@@ -1,18 +1,14 @@
 // Checks if player selects a system/star and then assigns the matching values to obj_controller
 if (obj_controller.zoomed == 1) {
-    obj_controller.x = self.x;
-    obj_controller.y = self.y;
+    obj_controller.x = x;
+    obj_controller.y = y;
 }
 obj_controller.popup = 3; // 3: star system
 obj_controller.sel_system_x = x;
 obj_controller.sel_system_y = y;
 
-selected = 1;
-
-var xx = x, yy = y;
-
-obj_controller.selected = self.id;
-obj_controller.sel_owner = self.owner;
+obj_controller.selected = id;
+obj_controller.sel_owner = owner;
 obj_controller.cooldown = 8;
 obj_controller.selecting_planet = 0;
 
@@ -29,12 +25,11 @@ with (obj_star_select) {
     instance_destroy();
 }
 instance_create(x, y, obj_star_select);
-obj_star_select.owner = self.owner;
-obj_star_select.target = self.id;
+obj_star_select.owner = owner;
+obj_star_select.target = id;
 
 try {
     if (obj_controller.selection_data != false) {
-        loading = false;
         var _data = obj_controller.selection_data;
         if (!struct_exists(_data, "system")) {
             _data.system = id;

--- a/objects/obj_star/Create_0.gml
+++ b/objects/obj_star/Create_0.gml
@@ -71,16 +71,16 @@ p_problem = array_create_advanced(_planet_array_size, array_create(8, ""));
 p_problem_other_data = array_create_advanced(_planet_array_size, array_create_advanced(8, {}));
 p_timer = array_create_advanced(_planet_array_size, array_create(8, -1));
 
-system_datas = array_create(8, false);
-system_garrison = array_create(8, false);
-system_sabatours = array_create(8, false);
+system_datas = array_create(8, undefined);
+system_garrison = array_create(8, undefined);
+system_sabatours = array_create(8, undefined);
 
 get_garrison = function(planet){
     var _gar = system_garrison[planet];
-    if (_gar == false){
-        system_garrison[planet] = new GarrisonForce(self, planet);
+    if (is_undefined(_gar)){
+        system_garrison[planet] = new GarrisonForce(id, planet);
         _gar = system_garrison[planet];
-        _gar.star = self;
+        _gar.star = id;
         _gar.planet = planet;
     } else  {
         _gar.update();
@@ -90,10 +90,10 @@ get_garrison = function(planet){
 
 get_sabatours = function(planet){
     var _gar = system_sabatours[planet];
-    if (_gar == false){
-        system_sabatours[planet] = new GarrisonForce(self, planet, "sabotage");
+    if (is_undefined(_gar)){
+        system_sabatours[planet] = new GarrisonForce(id, planet, "sabotage");
         _gar = system_sabatours[planet];
-        _gar.star = self;
+        _gar.star = id;
         _gar.planet = planet;
     } else  {
         _gar.update();
@@ -104,8 +104,8 @@ get_sabatours = function(planet){
 /// @returns {Struct.PlanetData}
 get_planet_data = function(planet){
     var _gar = system_datas[planet];
-    if (_gar == false){
-        system_datas[planet] = new PlanetData(planet, self);
+    if (is_undefined(_gar)){
+        system_datas[planet] = new PlanetData(planet, id);
         _gar = system_datas[planet];
     } else  {
         _gar.refresh_data();
@@ -135,8 +135,7 @@ ai_e = -1;
 
 /// Called from save function to take all object variables and convert them to a json savable format and return it
 serialize = function() {
-    var object_star = self;
-
+    var object_star = id;
     var planet_data = [];
 
     for (var p = 1; p <= object_star.planets; p++) {
@@ -144,7 +143,7 @@ serialize = function() {
             dispo: object_star.dispo[p],
             planet: object_star.planet[p],
         };
-        var var_names = variable_struct_get_names(object_star);
+        var var_names = variable_instance_get_names(object_star);
         for (var n = 0; n < array_length(var_names); n++) {
             var var_name = var_names[n];
             if (string_starts_with(var_name, "p_")) {
@@ -162,7 +161,7 @@ serialize = function() {
         planet_data: planet_data,
     };
 
-    if (struct_exists(object_star, "p_governor")) {
+    if (!is_undefined(object_star.p_governor)) {
         save_data.p_governor = object_star.p_governor;
     }
 
@@ -198,15 +197,14 @@ function deserialize(save_data) {
             continue;
         }
         var loaded_value = struct_get(save_data, var_name);
-        variable_struct_set(self, var_name, loaded_value);
+        variable_instance_set(id, var_name, loaded_value);
     }
 
     // Set explicit vars here
     if (struct_exists(save_data, "present_fleet")) {
-        variable_struct_set(self, "present_fleet", save_data.present_fleet);
+        variable_instance_set(id, "present_fleet", save_data.present_fleet);
     }
 
-    var _temp_features = false;
     if (struct_exists(save_data, "planet_data")) {
         var planet_arr = save_data.planet_data;
         for (var p = 1; p < array_length(planet_arr); p++) {
@@ -227,7 +225,7 @@ function deserialize(save_data) {
 
                         _new_feat.load_json_data(_feat);
 
-                        array_push(self.p_feature[p], _new_feat);
+                        array_push(p_feature[p], _new_feat);
                     }
                      continue;
                 }
@@ -238,7 +236,7 @@ function deserialize(save_data) {
     }
 
     if (struct_exists(save_data, "p_governor")) {
-        variable_struct_set(self, "p_governor", save_data.p_governor);
+        variable_instance_set(id, "p_governor", save_data.p_governor);
     }
 }
 

--- a/objects/obj_star/Draw_0.gml
+++ b/objects/obj_star/Draw_0.gml
@@ -46,31 +46,19 @@ if (global.load == -1 && (obj_controller.zoomed || in_camera_view(star_box_shape
     if (point_in_rectangle(mouse_x, mouse_y, x - 128, y, x + 128, y + 80) && obj_controller.zoomed) {
         scale *= 1.5;
     }
-    var _reset = false;
-    if (stored_owner != owner) {
-        _reset = true;
-    }
-
-    if (ds_map_exists(global.star_sprites, name)) {
-        var _old_sprite = ds_map_find_value(global.star_sprites, name);
-        if (sprite_exists(_old_sprite)) {
-            if (_reset) {
+    if (stored_owner != owner || !ds_map_exists(global.star_sprites, name)) {
+        if (ds_map_exists(global.star_sprites, name)) {
+            var _old_sprite = ds_map_find_value(global.star_sprites, name);
+            if (sprite_exists(_old_sprite)) {
                 sprite_delete(_old_sprite);
             }
-        } else {
-            _reset = true;
-        }
-        if (_reset) {
             ds_map_delete(global.star_sprites, name);
         }
-    } else {
-        _reset = true;
-    }
-    if (_reset) {
-        star_tag_surface = surface_create(256, 128);
+        
+        var _star_tag_surface = surface_create(256, 128);
         var xx = 64;
         var yy = 0;
-        surface_set_target(star_tag_surface);
+        surface_set_target(_star_tag_surface);
         var panel_width = string_width(name) + 60;
         if (owner != eFACTION.PLAYER) {
             var _faction_index = owner;
@@ -88,17 +76,16 @@ if (global.load == -1 && (obj_controller.zoomed || in_camera_view(star_box_shape
             } else {
                 LOGGER.error($"{global.chapter_icon.name} chapter icon not found in any icon directory. Chapter icon will not render.");
             }
-            //context.set_vertical_gradient(main_color, right_pauldron);
-            //draw_text_ext_transformed_color(gx + xoffset,gy + yoffset,text,sep,owner.width,xscale,yscale,angle ,col1, col2, col3, col4, alpha);
         }
         draw_set_color(c_white);
         draw_text(xx, yy + 33, name);
         surface_reset_target();
         stored_owner = owner;
-        var _new_sprite = sprite_create_from_surface(star_tag_surface, 0, 0, surface_get_width(star_tag_surface), surface_get_height(star_tag_surface), false, false, 0, 0);
+        var _new_sprite = sprite_create_from_surface(_star_tag_surface, 0, 0, surface_get_width(_star_tag_surface), surface_get_height(_star_tag_surface), false, false, 0, 0);
         ds_map_set(global.star_sprites, name, _new_sprite);
-        surface_clear_and_free(star_tag_surface);
+        surface_clear_and_free(_star_tag_surface);
     }
+
     var _sprite = ds_map_find_value(global.star_sprites, name);
     draw_sprite_ext(_sprite, 0, x - (64 * scale), y, scale, scale, 1, c_white, 1);
 }

--- a/objects/obj_star/Mouse_50.gml
+++ b/objects/obj_star/Mouse_50.gml
@@ -6,9 +6,6 @@ if (instances_exist_any([obj_drop_select, obj_saveload, obj_bomb_select])) {
     exit;
 }
 if (!global.ui_click_lock) {
-    var m_dist = point_distance(x, y, mouse_x, mouse_y);
-    var allow_click_distance = 20 * scale;
-
     if (obj_controller.location_viewer.is_entered) {
         exit;
     }
@@ -21,12 +18,14 @@ if (!global.ui_click_lock) {
     if (!scr_void_click()) {
         exit;
     }
+    var m_dist = point_distance(x, y, mouse_x, mouse_y);
+    var allow_click_distance = 20 * scale;
 
     if (((obj_controller.zoomed == 0) && (m_dist < allow_click_distance)) || ((obj_controller.zoomed == 1) && (m_dist < 60)) && (obj_controller.cooldown <= 0)) {
         // This should prevent overlap with fleet object
         if (obj_controller.zoomed == 1) {
-            obj_controller.x = self.x;
-            obj_controller.y = self.y;
+            obj_controller.x = x;
+            obj_controller.y = y;
         }
         alarm[3] = 1;
     }

--- a/scripts/scr_PlanetData/scr_PlanetData.gml
+++ b/scripts/scr_PlanetData/scr_PlanetData.gml
@@ -89,11 +89,11 @@ function PlanetData(_planet, _system) constructor {
 
         player_disposition = system.dispo[planet];
         garrisons = system.system_garrison[planet];
-        if (garrisons == 0) {
+        if (is_undefined(garrisons)) {
             garrisons = system.get_garrison(planet);
         }
         sabatours = system.system_sabatours[planet];
-        if (sabatours == 0) {
+        if (is_undefined(sabatours)) {
             sabatours = system.get_sabatours(planet);
         }
         system.system_datas[planet] = self;

--- a/scripts/scr_battle_sort/scr_battle_sort.gml
+++ b/scripts/scr_battle_sort/scr_battle_sort.gml
@@ -1,23 +1,17 @@
 function scr_battle_sort() {
-    var i;
-    i = 50;
-
     // This is ran in order to sort the battles that have been quened up
     // Space battles are placed in front whenever possible
 
-    repeat (50) {
-        i -= 1;
-
+    for (var i = 49; i >= 0; i--) {
         if ((battles <= i) && (i >= 2) && (battles > 0)) {
             if ((battle[i] != 0) && (battle[i - 1] != 0) && (battle_world[i] == 0) && (battle_world[i - 1] > 0)) {
-                var tem1, tem2, tem3, tem4, tem5, tem6, tem7;
-                tem1 = battle[i - 1];
-                tem2 = battle_location[i - 1];
-                tem3 = battle_world[i - 1];
-                tem4 = battle_opponent[i - 1];
-                tem5 = battle_object[i - 1];
-                tem6 = battle_pobject[i - 1];
-                tem7 = battle_special[i - 1];
+                var tem1 = battle[i - 1];
+                var tem2 = battle_location[i - 1];
+                var tem3 = battle_world[i - 1];
+                var tem4 = battle_opponent[i - 1];
+                var tem5 = battle_object[i - 1];
+                var tem6 = battle_pobject[i - 1];
+                var tem7 = battle_special[i - 1];
 
                 battle[i - 1] = battle[i];
                 battle_location[i - 1] = battle_location[i];

--- a/scripts/scr_enemy_ai_a/scr_enemy_ai_a.gml
+++ b/scripts/scr_enemy_ai_a/scr_enemy_ai_a.gml
@@ -8,11 +8,8 @@ function scr_enemy_ai_a() {
         get_planet_data(i);
     }
     // guardsmen hop from planet to planet
-    //not sure we really need this as it's handled with tht navy fleet functions but fuck it updated it and leaving it fot the sec
+    // not sure we really need this as it's handled with tht navy fleet functions but fuck it updated it and leaving it fot the sec
     if (system_guard_total() > 0 && present_fleet[eFACTION.IMPERIUM]) {
-        LOGGER.debug($"system_has_guard {p_guardsmen}");
-        var cur_planet = 0, most_enemies_found = 0, current_guard_planet = 0, most_enemies_planet = 0;
-
         var _guard_planets = guard_find_planet_with_most_enemy_forces(self);
 
         if (_guard_planets[0] > 0 && _guard_planets[1] > 0) {
@@ -21,13 +18,10 @@ function scr_enemy_ai_a() {
             p_guardsmen[_next] = p_guardsmen[_current];
             p_guardsmen[_current] = 0;
         }
-        LOGGER.debug($"system_has_guard {p_guardsmen}");
     }
 
     if ((obj_controller.faction_defeated[10] > 0) && (obj_controller.faction_gender[10] == 2)) {
-        var cur_planet = 0;
-        repeat (planets) {
-            cur_planet += 1;
+        for (var cur_planet = 1; cur_planet <= planets; cur_planet++) {
             if (array_length(p_feature[cur_planet]) != 0) {
                 if ((planet_feature_bool(p_feature[cur_planet], eP_FEATURES.CHAOSWARBAND) == 1) && (p_chaos[cur_planet] <= 0)) {
                     delete_features(p_feature[cur_planet], eP_FEATURES.CHAOSWARBAND);
@@ -41,18 +35,14 @@ function scr_enemy_ai_a() {
         inquisitor_inspect_base();
     }
 
-    var stop;
     var rand = 0;
-    var  total_garrison = 0;
-    var _planet_data;
     for (var _run = 1; _run <= planets; _run++) {
         /// @type {Struct.PlanetData}
-        _planet_data = system_datas[_run];
+        var _planet_data = system_datas[_run];
         _garrison = _planet_data.garrisons;
-        _sabatours = _planet_data.sabatours;
         var _garrison_force = _garrison.garrison_force;
 
-        stop = 0;
+        var stop = 0;
         ensure_no_planet_negatives(_run);
 
         planet_forces = _planet_data.planet_forces;
@@ -81,29 +71,26 @@ function scr_enemy_ai_a() {
                 continue;
             }
         }
-        var large = 0;
         var guard_score = 0;
         var pdf_score = 0;
-        var eldar_score = 0;
 
-        var guard_attack = "", pdf_attack = "", ork_attack = "", tau_attack = "", traitors_attack = "", chaos_attack = "";
-        var eldar_attack = "", tyranids_attack = "", necrons_attack = "", sisters_attack = "";
+        var guard_attack = "";
+        var pdf_attack = "";
+        var ork_attack = "";
+        var tau_attack = "";
+        var traitors_attack = "";
+        var chaos_attack = "";
+        var tyranids_attack = "";
+        var necrons_attack = "";
+        var sisters_attack = "";
 
         var traitors_score = p_traitors[_run];
         var chaos_score = p_chaos[_run];
         var tyranids_score = p_tyranids[_run];
         var necrons_score = p_necrons[_run];
         var sisters_score = p_sisters[_run];
-        // if (p_eldar[_run]>0) then eldar_score=p_eldar[_run]+1;
 
         if ((p_tyranids[_run] > 0) && (stop != 1) && (p_owner[_run] != eFACTION.TYRANIDS)) {
-            // This might have been causing the problem
-            /*if (p_tyranids[_run]<5) and (p_guardsmen[_run]>0){
-	            if (p_tyranids[_run]=4) then p_guardsmen[_run]=max(0,p_guardsmen[_run]-100000);
-	            if (p_tyranids[_run]=3) then p_guardsmen[_run]=max(0,p_guardsmen[_run]-20000);
-	            if (p_tyranids[_run]=2) then p_guardsmen[_run]=max(0,p_guardsmen[_run]-5000);
-	            if (p_tyranids[_run]=1) then p_guardsmen[_run]=max(0,p_guardsmen[_run]-500);
-	        }*/
             if (p_tyranids[_run] >= 5) {
                 tyranids_score = 7;
             }
@@ -125,9 +112,6 @@ function scr_enemy_ai_a() {
             // Eldar don't get into pitched battles so nyuck nyuck nyuck
         }
         if (_planet_data.pdf > 0 && !stop) {
-            var pdf_mod;
-            var defence_mult = _planet_data.fortification_level * 0.1;
-
             try {
                 if (pdf_with_player && _garrison_force) {
                     //if player supports give _garrison bonus
@@ -138,8 +122,6 @@ function scr_enemy_ai_a() {
             } catch (_exception) {
                 ERROR_HANDLER.handle_exception(_exception, "Pdf defence error",, $"{_run}");
             }
-            //
-            // if (p_eldar[_run]>0) and (p_owner[_run]!=6) then pdf_attack="eldar";
             pdf_attack = _planet_data.pdf_attack_matrix();
         }
 
@@ -184,7 +166,6 @@ function scr_enemy_ai_a() {
                 ork_attack = "imp";
             }
             rand = choose(1, 2, 3, 4, 5);
-            // if (rand=1) and (ork_attack="imp") then ork_attack="imp";
             if ((ork_attack == "imp") && (p_guardsmen[_run] > 0)) {
                 ork_attack = "guard";
             }
@@ -201,8 +182,6 @@ function scr_enemy_ai_a() {
             if ((rand == 5) && (p_sisters[_run] > 0)) {
                 ork_attack = "sisters";
             }
-            // if (rand=5) and (p_necrons[_run]>0) then ork_attack="necrons";
-
             if ((ork_attack == "") && (p_player[_run] > 0)) {
                 ork_attack = "player";
             }
@@ -245,7 +224,6 @@ function scr_enemy_ai_a() {
 
         if ((p_tau[_run] > 0) && (stop != 1) && (p_owner[_run] != eFACTION.TAU)) {
             // They don't own the planet, go ham
-            // if (eldar_score>0) then tau_attack="eldar";
             if (guard_score > 0) {
                 tau_attack = "imp";
             }
@@ -282,7 +260,6 @@ function scr_enemy_ai_a() {
         }
         if ((p_tau[_run] > 0) && (stop != 1) && (p_owner[_run] == eFACTION.TAU)) {
             // They own the planet
-            // if (eldar_score>0) then tau_attack="eldar";
             if (traitors_score > 0) {
                 tau_attack = "traitors";
             }
@@ -392,21 +369,12 @@ function scr_enemy_ai_a() {
 
             if (tau_attack == "imp") {
                 tau_attack = default_imperium_attack;
-            } // if (tau_attack="imp") and (guard_score<=0) then tau_attack="pdf";
+            }
 
             if ((sisters_attack == "imp") && (pdf_score > 0)) {
                 sisters_attack = "pdf";
             }
 
-            // if (eldar_attack="imp") and (guard_score>0) then eldar_attack="guard";if (eldar_attack="imp") and (guard_score<=0) then eldar_attack="pdf";
-
-            // if (eldar_attack="guard") and ((guard_score<=0.5) and (pdf_score>1)) then eldar_attack="pdf";
-
-            // if ((traitors_attack="guard") or (traitors_attack="pdf")) and (traitors_score>=3){obj_controller.x=self.x;obj_controller.y=self.y;}
-
-            var after_combat_guard = guard_score;
-            var after_combat_guard_count = p_guardsmen[_run];
-            var after_combat_pdf = pdf_score;
             var after_combat_ork_force = planet_forces[eFACTION.ORK];
             var after_combat_tau = planet_forces[eFACTION.TAU];
             var after_combat_traitor = traitors_score;
@@ -417,12 +385,12 @@ function scr_enemy_ai_a() {
             var after_combat_necrons = necrons_score;
             var after_combat_tyranids = tyranids_score;
             var after_combat_sisters = sisters_score;
-            var tempor = 0, rand1 = 0, rand2 = 0;
-
+            var tempor = 0;
+            var rand1 = 0;
+            var rand2 = 0;
             var _active_garrison = pdf_with_player && _garrison.viable_garrison > 0;
             // Guard attack
             if ((guard_score > 0) && (guard_attack != "") && (guard_score > 0.5)) {
-                LOGGER.debug($"{name}:{guard_attack}");
                 if (guard_attack == "ork") {
                     tempor = choose(1, 2, 3, 4, 5, 6) * planet_forces[eFACTION.ORK];
                 }
@@ -464,7 +432,6 @@ function scr_enemy_ai_a() {
                     }
                     rand1 = (choose(3, 4, 5, 6) * guard_score) * choose(1, 1.25, 1.25);
                     rand2 = (pdf_mod * pdf_score) * choose(1, 1.25);
-                    LOGGER.debug($"{name} guard attack guard_Win:{rand1 > rand2}");
                     if (rand1 > rand2) {
                         var _pdf_before = p_pdf[_run];
                         if (guard_score <= 3) {
@@ -591,7 +558,6 @@ function scr_enemy_ai_a() {
 
                 if (pdf_attack == "guard") {
                     rand2 = (choose(1, 2, 3, 4, 5, 6) * guard_score) * choose(1, 1.25, 2);
-                    LOGGER.debug($"{name} : pdf attack ,pdf win {rand1 > rand2}");
                     if (rand1 > rand2) {
                         if (pdf_score <= 3) {
                             p_guardsmen[_run] = floor(p_guardsmen[_run] * 0.7);
@@ -776,7 +742,6 @@ function scr_enemy_ai_a() {
                                 tixt += $". {_garrison.garrison_sustain_damages("loose")} Marines Lost";
                             }
                             scr_alert("red", "owner", tixt, x, y);
-                            //_garrison.determine_battle(false,rand2-rand1, eFACTION.ORK);
                         }
                     } else {
                         if (_active_garrison) {
@@ -801,10 +766,10 @@ function scr_enemy_ai_a() {
                                     //visited variable check whether the star has been visisted or not 1 for true 0 for false
                                     if (p_type[_run] == "Forge") {
                                         dispo[_run] -= 5; // 10 Disposition decrease for the planet govrnor if it's overrun by orks
-                                        obj_controller.disposition[3] -= 5; // obj_controller.disposition[3] refer to the disposition of the toaster jocks.
+                                        obj_controller.disposition[eFACTION.MECHANICUS] -= 5;
                                     } else if (planet_feature_bool(p_feature[_run], eP_FEATURES.SORORITAS_CATHEDRAL) || (p_type[_run] == "Shrine")) {
                                         dispo[_run] -= 10; // diso[_run] is the disposition of the planet. where _run refer to the planet that is currently running the code.
-                                        obj_controller.disposition[5] -= 3; // obj_controller.disposition[2] refer to the disposition of the sororitas while 3 refer to mechanicus
+                                        obj_controller.disposition[eFACTION.ECCLESIARCHY] -= 3;
                                     } else {
                                         dispo[_run] -= 5;
                                     }
@@ -813,7 +778,6 @@ function scr_enemy_ai_a() {
                             if ((badd == 2) && (p_tyranids[_run] == 0) && (p_necrons[_run] == 0) && (p_sisters[_run] == 0)) {
                                 scr_popup("System Lost", "The " + string(name) + " system has been ovewhelmed by Orks!", "orks", "");
                                 scr_event_log("red", "System " + string(name) + " has been overwhelmed by Orkz.", name);
-                                // owner=7;p_owner[1]=7;p_owner[2]=7;p_owner[3]=7;p_owner[4]=7;
                             }
                         }
                     }
@@ -846,10 +810,6 @@ function scr_enemy_ai_a() {
                         after_combat_ork_force -= 1;
                     }
                 } else if (traitors_attack == "guard") {
-                    /*if (traitors_attack="eldar"){
-	            rand2=(choose(1,2,3,4,5)*eldar_score)*choose(1,1.25);
-	            if (rand1>rand2) then after_combat_csm-=1;
-	        }*/
                     rand2 = (choose(1, 2, 3, 4, 5) * guard_score) * choose(1, 1.25);
                     if (rand1 > rand2) {
                         if (traitors_score <= 3) {
@@ -984,7 +944,6 @@ function scr_enemy_ai_a() {
 
             // Tyranids attack
             if (((tyranids_score > 4) || (guard_attack == "tyranids")) && (tyranids_attack != "") && (tyranids_attack != "player")) {
-                // if (tyranids_score>4) and (tyranids_attack!="") and (tyranids_attack!="player"){
                 rand1 = choose(3, 4, 5, 6, 7) * tyranids_score;
                 if (tyranids_score >= 6) {
                     rand1 = choose(30, 36);
@@ -1021,8 +980,6 @@ function scr_enemy_ai_a() {
                     rand1 = (choose(1, 2, 3, 4, 5, 6, 7) * tyranids_score) * choose(1, 1.25);
                     rand2 = (choose(1, 2, 3, 4, 5) * guard_score) * choose(1, 1.25);
                     if (rand1 > rand2) {
-                        /*if (tyranids_score<=3) then p_guardsmen[_run]=floor(p_guardsmen[_run]*0.6);
-	                if (tyranids_score>=4) then p_guardsmen[_run]=floor(p_guardsmen[_run]*0.5);*/
                         var onh = 0;
                         if ((tyranids_score == 1) && (onh == 0)) {
                             p_guardsmen[_run] -= 2000;
@@ -1048,8 +1005,6 @@ function scr_enemy_ai_a() {
                             p_guardsmen[_run] -= max(floor(p_guardsmen[_run] * 0.2), 2000000);
                             onh = 1;
                         }
-                        // if (tyranids_score>=6) and (onh=0){p_guardsmen[_run]=floor(p_guardsmen[_run]*0.2);onh=1;}
-
                         if (p_guardsmen[_run] < 0) {
                             p_guardsmen[_run] = 0;
                         }
@@ -1157,10 +1112,10 @@ function scr_enemy_ai_a() {
                                 if (p_type[_run] == "Forge") {
                                     //visited variable check whether the star has been visisted or not 1 for true 0 for false
                                     dispo[_run] -= 10; // 10 Disposition decrease for the planet govrnor if it's overrun by necrons
-                                    obj_controller.disposition[3] -= 10; // 10 dis decrease for the faction mechanicus
+                                    obj_controller.disposition[eFACTION.MECHANICUS] -= 10;
                                 } else if (planet_feature_bool(p_feature[_run], eP_FEATURES.SORORITAS_CATHEDRAL) || (p_type[_run] == "Shrine")) {
                                     dispo[_run] -= 10; // 10 Disposition decrease for the planet govrnor if it's overrun by necrons
-                                    obj_controller.disposition[5] -= 5; // 5 dis decrease for the Nurses
+                                    obj_controller.disposition[eFACTION.ECCLESIARCHY] -= 5;
                                 } else {
                                     dispo[_run] -= 10;
                                 }
@@ -1201,8 +1156,6 @@ function scr_enemy_ai_a() {
 
             // End stop
         }
-
-        // 135;
 
         var planet_saved = (p_player[_run] + p_raided[_run] > 0) && (p_orks[_run] + p_tyranids[_run] + p_chaos[_run] + p_traitors[_run] + p_necrons[_run] + p_tau[_run] <= 0);
 
@@ -1269,10 +1222,7 @@ function scr_enemy_ai_a() {
     scr_star_ownership(true);
 
     // Restock PDF and military
-    var i;
-    i = 0;
-    repeat (planets) {
-        i += 1;
+    for (var i = 1; i <= planets; i++) {
         if (p_type[i] == "Daemon") {
             p_heresy[i] = 200;
             p_owner[i] = eFACTION.CHAOS;
@@ -1287,11 +1237,10 @@ function scr_enemy_ai_a() {
         }
 
         if ((p_owner[i] == eFACTION.IMPERIUM) && (p_type[i] != "Dead") && (planets >= i) && (p_tyranids[i] == 0) && (p_chaos[i] == 0) && (p_traitors[i] == 0) && (p_eldar[i] == 0) && (p_tau[i] == 0)) {
-            var military, pdf, rando, contin;
-            military = 0;
-            pdf = 0;
-            contin = 0;
-            rando = floor(random(100)) + 1;
+            var military = 0;
+            var pdf = 0;
+            var contin = 0;
+            var rando = floor(random(100)) + 1;
 
             if (p_population[i] >= 10000000) {
                 military = p_population[i] / 470;
@@ -1310,13 +1259,11 @@ function scr_enemy_ai_a() {
             }
             if (p_large[i] == 1) {
                 military = military * 1000000000;
-                pdf = pdf * 1000000000;
+                pdf *= 1000000000;
             }
 
             if ((p_large[i] == 0) && (rando < 50) && (military != 0) && (pdf != 0)) {
-                // if (p_guardsmen[i]<military) and (rando<50){rando=10;contin=max(floor(p_guardsmen[i]*1.05),500);p_population[i]-=contin;p_guardsmen[i]+=contin;}/
                 if ((p_pdf[i] < pdf) && (rando < 50)) {
-                    rando = 1;
                     rando = 10;
                     contin = max(floor(p_pdf[i] * 1.02), 1000);
                     p_population[i] -= contin;
@@ -1324,9 +1271,7 @@ function scr_enemy_ai_a() {
                 }
             }
             if ((p_large[i] == 1) && (rando < 50) && (military != 0) && (pdf != 0)) {
-                // if (p_guardsmen[i]<military) and (rando<50){rando=10;contin=0.01*p_population[i];p_guardsmen[i]+=contin*1250000;}
                 if ((p_pdf[i] < pdf) && (rando < 50)) {
-                    rando = 1;
                     rando = 10;
                     contin = 0.01 * p_population[i];
                     p_pdf[i] += contin * 1250000;
@@ -1339,28 +1284,20 @@ function scr_enemy_ai_a() {
             }
             if ((p_population[i] < 100000) && (p_population[i] > 5) && (p_large[i] == 0)) {
                 pdf = floor(p_population[i] / 25);
-                military = 0;
             }
             if ((p_population[i] < 2000) && (p_population[i] > 5) && (p_large[i] == 0)) {
                 pdf = floor(p_population[i] / 10);
-                military = 0;
             }
 
             if ((p_large[i] == 0) && (rando < 3)) {
-                // if (p_guardsmen[i]<military) and (rando<3){rando=1;contin=max(floor(p_guardsmen[i]*1.05),500);p_population[i]-=contin;p_guardsmen[i]+=contin;}
                 if ((p_pdf[i] < pdf) && (rando < 3)) {
-                    rando = 1;
-                    rando = 1;
                     contin = max(floor(p_pdf[i] * 1.02), 1000);
                     p_population[i] -= contin;
                     p_pdf[i] += contin;
                 }
             }
             if ((p_large[i] == 1) && (rando < 3)) {
-                // if (p_guardsmen[i]<military) and (rando<3){rando=1;contin=0.01*p_population[i];p_guardsmen[i]+=floor(contin*1250000);}
                 if ((p_pdf[i] < pdf) && (rando < 3)) {
-                    rando = 1;
-                    rando = 1;
                     contin = 0.01 * p_population[i];
                     p_pdf[i] += floor(contin * 1250000);
                 }

--- a/scripts/scr_enemy_ai_b/scr_enemy_ai_b.gml
+++ b/scripts/scr_enemy_ai_b/scr_enemy_ai_b.gml
@@ -9,13 +9,10 @@ function scr_enemy_ai_b() {
     }
     // Tau rebellions
     if ((present_fleet[8] >= 1) && (owner != eFACTION.TAU)) {
-        var tau_chance;
         var flit = scr_orbiting_fleet(eFACTION.TAU);
-        var ran1 = 0;
-        var ran2 = floor(random(planets)) + 1;
-
         if (flit != noone) {
-            ran1 = floor(random(100)) + 1;
+            var ran1 = floor(random(100)) + 1;
+            var ran2 = floor(random(planets)) + 1;
             var tau_influence = p_influence[ran2][eFACTION.TAU];
             if (tau_influence < 90 && (p_type[ran2] != "Dead")) {
                 if ((flit.image_index == 1) && (ran1 <= 90)) {
@@ -42,7 +39,7 @@ function scr_enemy_ai_b() {
 
         for (var i = 1; i <= planets; i++) {
             var tau_influence = p_influence[i][eFACTION.TAU];
-            tau_chance = floor(random(100)) + 1;
+            var tau_chance = floor(random(100)) + 1;
 
             if ((i <= planets) && (tau_influence >= 70) && (p_owner[i] != 8) && (p_owner[i] != 10) && (p_owner[i] != 7) && (p_owner[i] != 9) && (p_type[i] != "Space Hulk")) {
                 for (var s = 1; s <= planets; s++) {
@@ -63,8 +60,6 @@ function scr_enemy_ai_b() {
                     }
 
                     var have = 0;
-                    var badd = 1;
-
                     var targ = planets;
                     for (var s = 1; s <= planets; s++) {
                         if (p_type[s] == "Dead") {
@@ -76,10 +71,10 @@ function scr_enemy_ai_b() {
                     }
 
                     if (have == targ) {
-                        badd = 2;
-                    }
-
-                    if (badd == 1) {
+                        scr_popup("System Lost", $"The {name} system has been taken by the Tau Empire!", "tau", "");
+                        owner = eFACTION.TAU;
+                        scr_event_log("red", $"System {name} has been taken by the Tau Empire.", name);
+                    } else {
                         scr_alert("red", "owner", $"Planet {planet_numeral_name(i)} has succeeded to the Tau Empire!", x, y);
                         if (visited == 1) {
                             //visited variable checks whether the star has been visited by the chapter or not 1 for true 0 for false
@@ -95,11 +90,6 @@ function scr_enemy_ai_b() {
                         }
                     }
 
-                    if (badd == 2) {
-                        scr_popup("System Lost", $"The {name} system has been taken by the Tau Empire!", "tau", "");
-                        owner = eFACTION.TAU;
-                        scr_event_log("red", $"System {name} has been taken by the Tau Empire.", name);
-                    }
 
                     if (p_pdf[i] != 0) {
                         p_pdf[i] = round(p_pdf[i] * 0.75);

--- a/scripts/scr_enemy_ai_c/scr_enemy_ai_c.gml
+++ b/scripts/scr_enemy_ai_c/scr_enemy_ai_c.gml
@@ -1,8 +1,5 @@
 /// @self Asset.GMObject.obj_star
 function scr_enemy_ai_c() {
-    var rando = 0;
-    var contin = 0;
-
     with (obj_star) {
         if ((craftworld == 1) || (space_hulk == 1)) {
             x -= 20000;
@@ -17,19 +14,14 @@ function scr_enemy_ai_c() {
     if (array_sum(p_traitors)) {
         var traitor_system = true;
         for (var i = 1; i <= planets; i++) {
-            if (p_owner[i] != 10) {
+            if ((p_owner[i] != 10) || (p_pdf[i] > 0) || (p_guardsmen[i] > 0) || (p_orks[i] > 0) || (p_tau[i] > 0)) {
                 traitor_system = false;
-            } else if ((p_pdf[i] > 0) || (p_guardsmen[i] > 0) || (p_orks[i] > 0) || (p_tau[i] > 0)) {
-                traitor_system = false;
-            }
-            if (!traitor_system) {
                 break;
             }
         }
         for (var i = 1; i <= planets; i++) {
-            contin = 0;
-            rando = irandom(100) + 1; // This part handles the spreading
-            contin = floor(random(planets)) + 1;
+            var rando = irandom(100) + 1; // This part handles the spreading
+            var contin = floor(random(planets)) + 1;
             repeat (30) {
                 if ((p_type[contin] == "Dead") || (contin == i)) {
                     contin = floor(random(planets)) + 1;
@@ -43,13 +35,10 @@ function scr_enemy_ai_c() {
             if (contin < 100) {
                 if ((p_traitors[i] >= 3) && (p_traitors[contin] < ceil(p_traitors[i] / 2)) && (p_type[contin] != "Dead")) {
                     p_traitors[contin] += 1;
-                    contin = 500;
                 }
             }
 
-            contin = 0;
-            rando = floor(random(100)) + 1; // This part handles the ship building
-
+            // This part handles the ship building
             if (traitor_system) {
                 rando = floor(random(100)) + 1;
                 // Check for industrial facilities
@@ -156,10 +145,6 @@ function scr_enemy_ai_c() {
 
     // This is the traitors corruption code
     var kay = 0;
-    var temp5 = 0;
-    var temp6 = 0;
-    var temp7 = 0;
-
     var boat = scr_orbiting_fleet(eFACTION.CHAOS);
 
     if ((present_fleet[10] > 0) && (present_fleet[1] + present_fleet[2] == 0) && (boat != noone) && (owner != eFACTION.CHAOS) && (planets > 0)) {
@@ -238,34 +223,26 @@ function scr_enemy_ai_c() {
     } // End corruption code
 
     // This is the CSM landing code
-    boat = scr_orbiting_fleet(eFACTION.CHAOS);
-
-    var aler = 0;
     if ((present_fleet[10] > 0) && (present_fleet[1] + present_fleet[2] == 0) && (boat != noone) && (planets > 0)) {
-        var ii = 0, gud = 0;
-        repeat (planets) {
-            ii += 1;
-            if (gud == 0) {
-                if ((planets >= ii) && (p_type[ii] != "Dead") && (p_owner[ii] != 10)) {
-                    gud = ii;
-                }
-            }
-        }
-
-        if ((gud != 0) && instance_exists(boat)) {
-            if (fleet_has_cargo("chaos", boat)) {
-                if (p_chaos[gud] < 4) {
-                    p_chaos[gud] += max(1, floor(boat.image_index * 0.5));
-                    if (p_chaos[gud] > 4) {
-                        p_chaos[gud] = 4;
+        for (var i = 1; i <= planets; i++) {
+            if ((planets >= i) && (p_type[i] != "Dead") && (p_owner[i] != 10)) {
+                if (instance_exists(boat)) {
+                    if (fleet_has_cargo("chaos", boat)) {
+                        if (p_chaos[i] < 4) {
+                            p_chaos[i] += max(1, floor(boat.image_index * 0.5));
+                            if (p_chaos[i] > 4) {
+                                p_chaos[i] = 4;
+                            }
+                        }
+                        if (p_traitors[i] < 5) {
+                            p_traitors[i] += max(2, floor(boat.image_index * 0.5));
+                            if (p_traitors[i] > 5) {
+                                p_traitors[i] = 5;
+                            }
+                        }
                     }
                 }
-                if (p_traitors[gud] < 5) {
-                    p_traitors[gud] += max(2, floor(boat.image_index * 0.5));
-                    if (p_traitors[gud] > 5) {
-                        p_traitors[gud] = 5;
-                    }
-                }
+                break;
             }
         }
     } // End landing portion of code
@@ -273,10 +250,8 @@ function scr_enemy_ai_c() {
     // Tau Here
     if (array_sum(p_tau) > 0) {
         for (var i = 1; i <= 4; i++) {
-            contin = 0;
-            rando = floor(random(100)) + 1; // This part handles the spreading
-            // if (rando<30){
-            contin = floor(random(planets)) + 1;
+            var rando = floor(random(100)) + 1; // This part handles the spreading
+            var contin = floor(random(planets)) + 1;
             repeat (30) {
                 if ((p_type[contin] == "Dead") || (contin == i)) {
                     contin = floor(random(planets)) + 1;
@@ -349,8 +324,7 @@ function scr_enemy_ai_c() {
                 if ((p_type[i] != "Dead") && (p_type[i] != "Lava")) {
                     if ((p_tau[i] >= 2) && (p_influence[i][eFACTION.TAU] >= 70)) {
                         // Have the proppa facilities and size
-                        var fleet;
-                        fleet = 0;
+                        var fleet = noone;
                         contin = 2;
                         if (!instance_exists(obj_en_fleet)) {
                             contin = 3;
@@ -389,10 +363,10 @@ function scr_enemy_ai_c() {
 
                                 if (fleet.image_index >= 5) {
                                     var kawaii = 0;
-                                    var think = 0;
+                                    var think = noone;
 
                                     repeat (50) {
-                                        if ((think == 0) && (kawaii == 0)) {
+                                        if ((think == noone) && (kawaii == 0)) {
                                             var xx = x + floor(choose(random(300), random(300) * -1));
                                             var yy = y + floor(choose(random(300), random(300) * -1));
                                             think = instance_nearest(xx, yy, obj_star);
@@ -410,7 +384,7 @@ function scr_enemy_ai_c() {
                                             }
 
                                             if (kawaii == 0) {
-                                                think = 0;
+                                                think = noone;
                                             }
                                         }
                                     }

--- a/scripts/scr_enemy_ai_d/scr_enemy_ai_d.gml
+++ b/scripts/scr_enemy_ai_d/scr_enemy_ai_d.gml
@@ -14,7 +14,6 @@ function scr_enemy_ai_d() {
     }
 
     // Planetary problems here
-
     for (var i = 1; i <= planets; i++) {
         //this will skip for given planet if no problems associated wiht planet
         if ((p_necrons[i] > 0) && (p_necrons[i] < 6)) {
@@ -133,17 +132,10 @@ function scr_enemy_ai_d() {
                     p_problem[i][firstest] = "Hive Fleet";
                     p_timer[i][firstest] = irandom_range(60, 120) + 1;
                     p_timer[i][firstest] += irandom_range(80, 120) + 1;
-                    // p_timer[i][firstest]=floor(random_range(3,6))+1;
-                    // show_message("Hive Fleet Destination: "+string(name)+"#ETA: "+string(p_timer[i][firstest]));
 
-                    var fleet, xx, yy;
-                    xx = random_range(room_width * 1.25, room_width * 2);
-                    xx = choose(xx * -1, xx);
-                    xx = x + xx;
-                    yy = random_range(room_height * 1.25, room_height * 2);
-                    yy = choose(yy * -1, yy);
-                    yy = y + yy;
-                    fleet = instance_create(xx, yy, obj_en_fleet);
+                    var xx = (random_range(room_width * 1.25, room_width * 2) * choose(-1, 1)) + x;
+                    var yy = (random_range(room_height * 1.25, room_height * 2) * choose(-1, 1)) + y;
+                    var fleet = instance_create(xx, yy, obj_en_fleet);
                     fleet.owner = eFACTION.TYRANIDS;
                     fleet.sprite_index = spr_fleet_tyranid;
                     fleet.image_speed = 0;
@@ -151,10 +143,6 @@ function scr_enemy_ai_d() {
                     fleet.capital_number = choose(7, 8, 9);
                     fleet.frigate_number = round(random_range(6, 12));
                     fleet.escort_number = round(random_range(12, 27));
-
-                    /*fleet.capital_number=choose(5,6);
-	                fleet.frigate_number=round(random_range(4,8));
-	                fleet.escort_number=round(random_range(8,18));*/
 
                     fleet.image_index = floor(fleet.capital_number + (fleet.frigate_number / 2) + (fleet.escort_number / 4));
                     fleet.image_alpha = 0;
@@ -170,39 +158,24 @@ function scr_enemy_ai_d() {
 
         if (has_problem_planet_and_time(i, "Hive Fleet", 3) > -1) {
             var woop = scr_role_count("Chief " + string(obj_ini.role[100][17]), "");
+            var yep = !scr_has_disadv("Psyker Intolerant");
 
-            var o, yep, yep2;
-            o = 0;
-            yep = true;
-            yep2 = false;
-            if (scr_has_disadv("Psyker Intolerant")) {
-                yep = false;
-            }
-
-            if ((obj_controller.known[eFACTION.TYRANIDS] == 0) && (woop != 0) && (yep != false)) {
+            if ((obj_controller.known[eFACTION.TYRANIDS] == 0) && (woop != 0) && yep) {
                 scr_popup("Shadow in the Warp", $"Chief {obj_ini.role[100][17]} " + string(obj_ini.name[0][5]) + " reports a disturbance in the warp.  He claims it is like a shadow.", "shadow", "");
                 scr_event_log("red", $"Chief {obj_ini.role[100][17]} reports a disturbance in the warp.  He claims it is like a shadow.");
             }
-            if ((obj_controller.known[eFACTION.TYRANIDS] == 0) && (woop == 0) && (yep != false)) {
-                var q = 0, q2 = 0;
-                repeat (90) {
-                    if (q2 == 0) {
-                        q += 1;
-                        if (obj_ini.role[0][q] == obj_ini.role[100][eROLE.CHAPTERMASTER]) {
-                            q2 = q;
-                            if (string_count("0", obj_ini.spe[0][q2]) > 0) {
-                                yep2 = true;
-                            }
+            if ((obj_controller.known[eFACTION.TYRANIDS] == 0) && (woop == 0) && yep) {
+                for (var q = 1; q <= 90; q++) {
+                    if (obj_ini.role[0][q] == obj_ini.role[100][eROLE.CHAPTERMASTER]) {
+                        if (string_count("0", obj_ini.spe[0][q]) > 0) {
+                            scr_popup("Shadow in the Warp", "You are distracted and bothered by a nagging sensation in the warp.  It feels as though a shadow descends upon your sector.", "shadow", "");
+                            scr_event_log("red", "You sense a disturbance in the warp.  It feels something like a massive shadow.");
                         }
+                        break;
                     }
-                }
-                if (yep2 == true) {
-                    scr_popup("Shadow in the Warp", "You are distracted and bothered by a nagging sensation in the warp.  It feels as though a shadow descends upon your sector.", "shadow", "");
-                    scr_event_log("red", "You sense a disturbance in the warp.  It feels something like a massive shadow.");
                 }
             }
 
-            g = 50;
             i = 50;
             obj_controller.known[eFACTION.TYRANIDS] = 1;
         }
@@ -271,8 +244,7 @@ function scr_enemy_ai_d() {
         var priority_requests = [];
         var non_priority_requests = [];
 
-        var r = 0, yep = 0;
-        for (r = 1; r <= planets; r++) {
+        for (var r = 1; r <= planets; r++) {
             // temp5: new hive, temp4: new planet
             if (!scr_planet_owned_by_group(r, fetch_faction_group())) {
                 continue;
@@ -308,13 +280,12 @@ function scr_enemy_ai_d() {
         }
 
         if (array_length(pop_doner_options) > 0 && (array_length(non_priority_requests) || array_length(priority_requests))) {
-            var onceh = 0;
             var random_chance = floor(random(100)) + 1;
             var doner_index = 0;
             // TODO check possible fixes for this logic
             // currently this only calculates for priority requests for pops
             for (var i = 1; i < array_length(pop_doner_options); i++) {
-                if (star_distace_calc(pop_doner_options[i], priority_requests[i]) < star_distace_calc(pop_doner_options[doner_index], priority_requests[doner_index])) {
+                if (star_distace_calc(pop_doner_options[i], priority_requests[0]) < star_distace_calc(pop_doner_options[doner_index], priority_requests[0])) {
                     doner_index = i;
                 }
             }
@@ -346,7 +317,6 @@ function scr_enemy_ai_d() {
     }
 
     // Local problems will go here
-    var planet;
     for (var i = 1; i <= planets; i++) {
         if (i < array_length(system_garrison)) {
             var garrison = get_garrison(i);

--- a/scripts/scr_enemy_ai_e/scr_enemy_ai_e.gml
+++ b/scripts/scr_enemy_ai_e/scr_enemy_ai_e.gml
@@ -8,10 +8,9 @@ function scr_enemy_ai_e() {
 
     var imperium_fleets = present_fleet[2] + present_fleet[3];
 
-    var have_fleets, battle, battle2;
-    have_fleets = 0;
-    battle = 0;
-    battle2 = 0;
+    var have_fleets = 0;
+    var battle = 0;
+    var battle2 = 0;
 
     var attack = array_create(20, 0);
     var strength = array_create(20, 0);
@@ -157,12 +156,8 @@ function scr_enemy_ai_e() {
         } // This grabs the "strength" from all present fleets and adds it to the temporary variable for this AI battle
 
         // Determine who will attack who
-        var still_battling = true;
-        var rond = 0;
-
         repeat (5) {
-            rond += 1;
-            still_battling = false;
+            var still_battling = false;
             if ((strength[2] + strength[3] > 0) && (strength[6] + strength[7] + strength[8] + strength[9] + strength[10] + strength[13] > 0)) {
                 still_battling = true;
             }
@@ -455,18 +450,13 @@ function scr_enemy_ai_e() {
 
     if (battle > 0) {
         if ((present_fleet[1] > 0) && ((present_fleet[6] + present_fleet[7] + present_fleet[8] + present_fleet[9] + present_fleet[10] + present_fleet[13] > 0) || ((present_fleet[2] > 0) && (obj_controller.faction_status[2] == "War")))) {
-            var i, onceh;
-            i = 1;
-            onceh = 0;
-
-            repeat (9) {
-                i += 1;
+            for (var i = 2; i <= 10; i++) {
                 var special_stop = false;
-                if ((i == 10) || (i == 11)) {
+                if ((i == 10)) {
                     special_stop = has_problem_star("meeting") || has_problem_star("meeting_trap");
                 }
 
-                if ((obj_controller.faction_status[i] == "War") && (onceh == 0) && (!special_stop)) {
+                if ((obj_controller.faction_status[i] == "War") && (!special_stop)) {
                     // Quene battle
                     obj_turn_end.battles += 1;
                     obj_turn_end.battle[obj_turn_end.battles] = 1;
@@ -506,7 +496,7 @@ function scr_enemy_ai_e() {
                             }
                         }
                     }
-                    onceh = 1;
+                    break;
                 }
             }
         }
@@ -515,14 +505,9 @@ function scr_enemy_ai_e() {
     instance_activate_object(obj_p_fleet);
     instance_activate_object(obj_en_fleet);
 
-    var run = 0;
-    var force = 1;
-    var beetle = 0;
     var chaos_meeting = 0;
 
-    repeat (planets) {
-        run += 1;
-        force = 1;
+    for (var run = 1; run <= planets; run++) {
         var forces_list = [];
         var force_count = 0;
         if (p_player[run] > 0 && struct_exists(obj_controller.location_viewer.garrison_log, name)) {
@@ -531,10 +516,6 @@ function scr_enemy_ai_e() {
         }
 
         if (p_player[run] > 0 && force_count > 0) {
-            var spyrer, fallen;
-            spyrer = 0;
-            fallen = 0;
-
             if (p_player[run] > 0) {
                 if (has_problem_planet(run, "meeting")) {
                     chaos_meeting = run;
@@ -544,8 +525,7 @@ function scr_enemy_ai_e() {
             }
             if (has_problem_planet(run, "spyrer")) {
                 if (p_player[run] > 20) {
-                    var tixt = "The Spyrer on " + planet_numeral_name(run);
-                    tixt += " seems to have vanished, presumably gone into hiding.";
+                    var tixt = "The Spyrer on " + planet_numeral_name(run) + " seems to have vanished, presumably gone into hiding.";
                     scr_popup("Spyrer Rampage", tixt, "spyrer", "");
                 } else if (p_player[run] <= 20) {
                     obj_turn_end.battles += 1;
@@ -559,25 +539,21 @@ function scr_enemy_ai_e() {
             }
 
             if ((p_player[run] > 0) && has_problem_planet(run, "fallen")) {
-                var chan;
-                chan = choose(1, 2, 3, 4);
-                if (chan <= 2) {
+                if (choose(true, false)) {
                     obj_turn_end.battles += 1;
                     obj_turn_end.battle[obj_turn_end.battles] = 1;
                     obj_turn_end.battle_world[obj_turn_end.battles] = run;
                     obj_turn_end.battle_opponent[obj_turn_end.battles] = 10;
                     obj_turn_end.battle_location[obj_turn_end.battles] = name;
                     obj_turn_end.battle_object[obj_turn_end.battles] = id;
-                    if (chan == 1) {
+                    if (choose(true, false)) {
                         obj_turn_end.battle_special[obj_turn_end.battles] = "fallen1";
-                    }
-                    if (chan == 2) {
+                    } else {
                         obj_turn_end.battle_special[obj_turn_end.battles] = "fallen2";
                     }
-                } else if (chan >= 3) {
+                } else {
                     if (remove_planet_problem(run, "fallen")) {
-                        var tixt = "Your marines have scoured " + planet_numeral_name(run);
-                        tixt += " in search of the Fallen.  Despite their best efforts, and meticulous searching, none have been found.  It appears as though the information was faulty or out of date.";
+                        var tixt = "Your marines have scoured " + planet_numeral_name(run) + " in search of the Fallen.  Despite their best efforts, and meticulous searching, none have been found.  It appears as though the information was faulty or out of date.";
                         scr_popup("Hunt the Fallen", tixt, "fallen", "");
                         scr_event_log("", $"Mission Successful: No Fallen located upon {planet_numeral_name(run)}");
                     }
@@ -588,7 +564,7 @@ function scr_enemy_ai_e() {
             setup_necron_tomb_raid(run);
         }
         if ((p_player[run] > 0) && (force_count > 0)) {
-            for (force = 2; force < 14; force++) {
+            for (var force = 2; force < 14; force++) {
                 battle_opponent = 0;
                 var pause = false;
 
@@ -662,16 +638,7 @@ function scr_enemy_ai_e() {
         }
 
         // Other planetary stuff
-
-        var thirdpop;
-        var halfpop;
-
-        thirdpop = p_max_population[run] / 3;
-        halfpop = p_max_population[run] / 2;
-
         if (array_length(p_feature[run])) {
-            var planet_data = get_planet_data(run);
-
             // Transforming billions pop number to a real number so the code can handle it
             // Otherwise, 3 and a half billions get translated as 3,50 instead of 3500000000
 
@@ -680,12 +647,11 @@ function scr_enemy_ai_e() {
                 var monestary = search_planet_features(p_feature[run], eP_FEATURES.MONASTERY);
                 if (array_length(monestary) > 0) {
                     monestary = p_feature[run][monestary[0]];
-                    var md, ms, ml, build_rate, build_rate2;
-                    md = 225;
-                    ms = 300;
-                    ml = 32;
-                    build_rate = 4;
-                    build_rate2 = 6;
+                    var md = 225;
+                    var ms = 300;
+                    var ml = 32;
+                    var build_rate = 4;
+                    var build_rate2 = 6;
                     if (scr_has_adv("Siege Masters")) {
                         md = 300;
                         ms = 400;
@@ -728,12 +694,12 @@ function scr_enemy_ai_e() {
 
         // Work on upgrades
         if (array_length(p_upgrades[run]) > 0) {
-            var upgrade_type, tx, display_type, upgrade;
             for (var up = 0; up < array_length(p_upgrades[run]); up++) {
-                upgrade = p_upgrades[run][up];
+                var upgrade = p_upgrades[run][up];
                 if (struct_exists(upgrade, "built")) {
-                    upgrade_type = upgrade.f_type;
+                    var upgrade_type = upgrade.f_type;
                     if (upgrade.built == obj_controller.turn) {
+                        var display_type = "No Available Feature";
                         if (upgrade_type == eP_FEATURES.ARSENAL) {
                             display_type = "Arsenal";
                             obj_controller.und_armouries++;
@@ -744,7 +710,7 @@ function scr_enemy_ai_e() {
                             display_type = "Gene Vault";
                             obj_controller.und_gene_vaults++;
                         }
-                        tx = $"Hidden {display_type} on {name} {scr_roman(run)} has been completed.";
+                        var tx = $"Hidden {display_type} on {name} {scr_roman(run)} has been completed.";
                         scr_alert("green", "owner", string(tx), x, y);
                         scr_event_log("", string(tx));
                     }
@@ -767,40 +733,27 @@ function scr_enemy_ai_e() {
 
     if (chaos_meeting > 0) {
         // Run through forces and determine what all is there
+        var _meeting = instance_create(0, 0, obj_temp_meeting);
 
-        instance_create(0, 0, obj_temp_meeting);
-
-        var i, co, ii, otm, good, master_present;
-        ii = 0;
-        i = 0;
-        co = -1;
-        good = 0;
-        master_present = 0;
-        repeat (11) {
-            co += 1;
-            i = 0;
-            repeat (200) {
-                i += 1;
-                good = 0;
+        var otm = 0;
+        var master_present = false;
+        for (var co = 0; co <= 10; co++) {
+            for (var i = 1; i <= 200; i++) {
                 var _unit = fetch_unit([co, i]);
-                if ((_unit.role() != "" && _unit.location_string == name) && (_unit.planet_location == floor(chaos_meeting))) {
-                    good += 1;
-                }
-                if ((_unit.role() != obj_ini.role[100][6]) && (_unit.role() != "Venerable " + string(obj_ini.role[100][6]))) {
-                    good += 1;
-                }
-                if ((string_count("Dread", obj_ini.armour[co][i]) == 0) || (_unit.role() == obj_ini.role[100][eROLE.CHAPTERMASTER])) {
-                    good += 1;
-                }
-
-                if (good == 3) {
-                    obj_temp_meeting.dudes += 1;
-                    otm = obj_temp_meeting.dudes;
-                    obj_temp_meeting.present[otm] = 1;
-                    obj_temp_meeting.co[otm] = co;
-                    obj_temp_meeting.ide[otm] = i;
+                var _is_unit_real_and_here = _unit.role() != "" && _unit.location_string == name;
+                var _is_this_a_chaos_meeting = _unit.planet_location == floor(chaos_meeting);
+                var _unit_does_not_have_dreadnought_role = _unit.role() != obj_ini.role[100][6];
+                var _unit_is_not_venerable = _unit.role() != "Venerable " + string(obj_ini.role[100][6]);
+                var _unit_does_not_have_dreadnought_armour = string_count("Dread", obj_ini.armour[co][i]) == 0;
+                var _is_chapter_master = _unit.role() == obj_ini.role[100][eROLE.CHAPTERMASTER];
+                if (_is_unit_real_and_here && _is_this_a_chaos_meeting && _unit_does_not_have_dreadnought_role && _unit_is_not_venerable && (_unit_does_not_have_dreadnought_armour || _is_chapter_master)) {
+                    _meeting.dudes += 1;
+                    otm = _meeting.dudes;
+                    _meeting.present[otm] = 1;
+                    _meeting.co[otm] = co;
+                    _meeting.ide[otm] = i;
                     if (_unit.role() == obj_ini.role[100][eROLE.CHAPTERMASTER]) {
-                        master_present = 1;
+                        master_present = true;
                     }
                 }
             }
@@ -808,25 +761,20 @@ function scr_enemy_ai_e() {
 
         // title / text / image / speshul
         var popup_text = "A cloaked, ragged figure approaches your forces and hails you. ";
-        if ((master_present == 1) && (otm <= 21)) {
-            var effect;
-            effect = "meeting_1t";
+        if (master_present && (otm <= 21)) {
+            var effect = "meeting_1t";
             if (chaos_meeting == floor(chaos_meeting)) {
                 effect = "meeting_1";
             }
             scr_popup("Chaos Meeting", $"{popup_text}He is to bring you to meet with their master and you have few enough forces to be permitted.  What is thy will?", "chaos_messenger", effect);
         }
-        if ((master_present == 1) && (otm > 21)) {
+        if (master_present && (otm > 21)) {
             scr_popup("Chaos Meeting", $"{popup_text}He is to bring you to their master, but before the meeting proceeds, you must bring fewer forces.  Only yourself and up to two squads will be allowed in the presence of {obj_controller.faction_title[10]} {obj_controller.faction_leader[10]}.", "chaos_messenger", "meeting_2");
-            with (obj_temp_meeting) {
-                instance_destroy();
-            }
+        instance_destroy(_meeting);
         }
-        if ((master_present == 0) && (otm > 21)) {
+        if (!master_present && (otm > 21)) {
             scr_popup("Chaos Meeting", $"{popup_text}The meeting was supposed to be with the Chaos Lord, and yourself, but you are not planet-side.  Land on the planet with up to two squads and the meeting will proceed.", "chaos_messenger", "meeting_3");
-            with (obj_temp_meeting) {
-                instance_destroy();
-            }
+        instance_destroy(_meeting);
         }
     }
 


### PR DESCRIPTION
Going through each file one at a time and just doing basic cleaning things. Inlining variable definitions, Type reinforcements, and loop/nesting simplifications.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up end-turn AI (A–E), star scripts, and battle sorting for clearer loops, enum use, and safer `id` calls. Fixes cover Tau rebellions, Chaos landing/meetings, battle queuing, star tag caching, save/load, influence updates, and population transfers.

- **Refactors**
  - Replaced repeats with for-loops, localized temps, and removed dead code across `scr_enemy_ai_a–e`, `scr_battle_sort`, and `obj_star` alarms/draw/mouse/create; standardized `id`/`noone` and faction enums.
  - Cached star data now uses `undefined` sentinels with `is_undefined`; Save/Load uses `variable_instance_*` and `variable_instance_get_names`; only persist `p_governor` when defined.
  - Star selection and labels: controller/selector now use `id`; selection data is sanitized; tag sprites are rebuilt only when owner changes or cache is missing.

- **Bug Fixes**
  - Tau rebellions can flip the whole system to Tau with correct owner/popup/log; Chaos landing selects a single valid non-dead, non-chaos planet; meetings enforce attendee limits and require the Chapter Master.
  - Battle queuing schedules a single engagement per faction and skips stars with meeting/trap events; battle sorting uses a descending index swap loop.
  - Star/system and economy: fixed `p_station[i]` for Craftworlds; warp-join and influence/disposition updates use `id` and enums; Save/Load restores `p_feature`/`p_governor`; population transfers choose the nearest donor.

<sup>Written for commit 512a9e752b30bdf352ea169daf922ad496b0fbaf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

