### PR TITLE
feat: RAM, starting formations; column sizes; fix: column targeting

### DIFF
--- a/objects/obj_controller/Create_0.gml
+++ b/objects/obj_controller/Create_0.gml
@@ -806,23 +806,23 @@ LOGGER.info("Set Battle Formations");
 var _count = 16;
 bat_formation = array_create(_count, "");
 bat_formation_type = array_create(_count, 0);
-bat_deva_for = array_create(_count, 1);
-bat_assa_for = array_create(_count, 4);
-bat_tact_for = array_create(_count, 2);
-bat_vete_for = array_create(_count, 2);
+bat_deva_for = array_create(_count, 3);
+bat_assa_for = array_create(_count, 5);
+bat_tact_for = array_create(_count, 4);
+bat_vete_for = array_create(_count, 3);
 bat_hire_for = array_create(_count, 3);
-bat_libr_for = array_create(_count, 3);
-bat_comm_for = array_create(_count, 3);
-bat_tech_for = array_create(_count, 3);
-bat_term_for = array_create(_count, 3);
-bat_hono_for = array_create(_count, 3);
-bat_drea_for = array_create(_count, 5);
+bat_libr_for = array_create(_count, 2);
+bat_comm_for = array_create(_count, 2);
+bat_tech_for = array_create(_count, 2);
+bat_term_for = array_create(_count, 5);
+bat_hono_for = array_create(_count, 2);
+bat_drea_for = array_create(_count, 6);
 bat_rhin_for = array_create(_count, 6);
-bat_pred_for = array_create(_count, 7);
-bat_landraid_for = array_create(_count, 7);
-bat_landspee_for = array_create(_count, 4);
+bat_pred_for = array_create(_count, 6);
+bat_landraid_for = array_create(_count, 6);
+bat_landspee_for = array_create(_count, 5);
 bat_whirl_for = array_create(_count, 1);
-bat_scou_for = array_create(_count, 1);
+bat_scou_for = array_create(_count, 3);
 // ground=1    raid=2
 // 1: Attack        type=1
 // 2: Defend        type=1
@@ -831,23 +831,23 @@ bat_scou_for = array_create(_count, 1);
 default_bat_formation();
 // Defaults formations end here
 
-bat_devastator_column = 1;
-bat_assault_column = 4;
-bat_tactical_column = 2;
-bat_veteran_column = 2;
+bat_devastator_column = 3;
+bat_assault_column = 5;
+bat_tactical_column = 4;
+bat_veteran_column = 3;
 bat_hire_column = 3;
-bat_librarian_column = 3;
-bat_command_column = 3;
-bat_techmarine_column = 3;
-bat_terminator_column = 3;
-bat_honor_column = 3;
-bat_dreadnought_column = 5;
+bat_librarian_column = 2;
+bat_command_column = 2;
+bat_techmarine_column = 2;
+bat_terminator_column = 5;
+bat_honor_column = 2;
+bat_dreadnought_column = 6;
 bat_rhino_column = 6;
-bat_predator_column = 7;
-bat_landraider_column = 7;
+bat_predator_column = 6;
+bat_landraider_column = 6;
 bat_whirlwind_column = 1;
-bat_landspeeder_column = 4;
-bat_scout_column = 1;
+bat_landspeeder_column = 5;
+bat_scout_column = 3;
 // ** Sets up disposition per faction **
 
 LOGGER.info("Set Ai Faction data");

--- a/objects/obj_enunit/Alarm_0.gml
+++ b/objects/obj_enunit/Alarm_0.gml
@@ -205,62 +205,69 @@ if (!engaged) {
     obj_ncombat.combat_debugger.add(eCOMBAT_CATEGORY.TARGETING, $"Engaged, attacking in melee");
     //TODO: The melee code was not refactored;
     // Melee
-    engaged = 1;
     for (var i = 0; i < array_length(wep); i++) {
-        if (wep[i] == "" || wep_num[i] == 0) {
+        if (wep[i] == "" || wep_num[i] == 0 || (range[i] > 2 && floor(range[i]) == range[i])) {
             continue;
         }
-        var _armour_piercing = false;
+
         if (!flank) {
             enemy = get_rightmost();
             if (enemy == noone) {
+                engaged = false;
                 exit;
             }
         } else if (flank) {
             enemy = get_leftmost();
             if (enemy == noone) {
+                engaged = false;
                 exit;
             }
         }
 
-        if ((range[i] <= 2) || (floor(range[i]) != range[i])) {
-            obj_ncombat.combat_debugger.add(eCOMBAT_CATEGORY.TARGETING, $"{wep[i]}(i{i}) is striking");
-            // Weapon meets preliminary checks
-            if (apa[i] > 2) {
-                _armour_piercing = true;
-                obj_ncombat.combat_debugger.add(eCOMBAT_CATEGORY.TARGETING, $"melee AP=true");
-            }
-            if (_armour_piercing && instance_exists(obj_nfort) && (!flank)) {
-                // Huff and puff and blow the wall down
-                enemy = instance_nearest(x, y, obj_nfort);
-                obj_ncombat.combat_debugger.add(eCOMBAT_CATEGORY.TARGETING, $"melee AP -> wall");
-                scr_shoot(i, enemy, 1, "arp", "wall");
-                continue;
-            }
-            if (_armour_piercing) {
-                // Check for vehicles
-                var good = false;
+        var dist = get_block_distance(enemy);
+        if (dist > 1) {
+            engaged = false;
+            exit;
+        }
+    
+        var _armour_piercing = false;
 
-                if (block_has_armour(enemy)) {
-                    obj_ncombat.combat_debugger.add(eCOMBAT_CATEGORY.TARGETING, $"melee AP -> vehicles in {obj_ncombat.combat_debugger.resolve_label(enemy)}");
-                    scr_shoot(i, enemy, 1, "arp", "melee");
-                    good = true;
-                }
-                if (!good) {
-                    _armour_piercing = false;
-                    obj_ncombat.combat_debugger.add(eCOMBAT_CATEGORY.TARGETING, $"melee AP -> no vehicles, falling back to infantry");
-                }
-            }
+        obj_ncombat.combat_debugger.add(eCOMBAT_CATEGORY.TARGETING, $"{wep[i]}(i{i}) is striking");
+        // Weapon meets preliminary checks
+        if (apa[i] > 2) {
+            _armour_piercing = true;
+            obj_ncombat.combat_debugger.add(eCOMBAT_CATEGORY.TARGETING, $"melee AP=true");
+        }
+        if (_armour_piercing && instance_exists(obj_nfort) && (!flank)) {
+            // Huff and puff and blow the wall down
+            enemy = instance_nearest(x, y, obj_nfort);
+            obj_ncombat.combat_debugger.add(eCOMBAT_CATEGORY.TARGETING, $"melee AP -> wall");
+            scr_shoot(i, enemy, 1, "arp", "wall");
+            continue;
+        }
+        if (_armour_piercing) {
+            // Check for vehicles
+            var good = false;
 
-            if ((!_armour_piercing) && target_block_is_valid(enemy, obj_pnunit)) {
-                // Check for men
-                if (enemy.men) {
-                    obj_ncombat.combat_debugger.add(eCOMBAT_CATEGORY.TARGETING, $"melee -> infantry in {obj_ncombat.combat_debugger.resolve_label(enemy)}");
-                    scr_shoot(i, enemy, 1, "att", "melee");
-                } else if (block_has_armour(enemy)) {
-                    obj_ncombat.combat_debugger.add(eCOMBAT_CATEGORY.TARGETING, $"melee -> armour fallback in {obj_ncombat.combat_debugger.resolve_label(enemy)}");
-                    scr_shoot(i, enemy, 1, "arp", "melee");
-                }
+            if (block_has_armour(enemy)) {
+                obj_ncombat.combat_debugger.add(eCOMBAT_CATEGORY.TARGETING, $"melee AP -> vehicles in {obj_ncombat.combat_debugger.resolve_label(enemy)}");
+                scr_shoot(i, enemy, 1, "arp", "melee");
+                good = true;
+            }
+            if (!good) {
+                _armour_piercing = false;
+                obj_ncombat.combat_debugger.add(eCOMBAT_CATEGORY.TARGETING, $"melee AP -> no vehicles, falling back to infantry");
+            }
+        }
+
+        if ((!_armour_piercing) && target_block_is_valid(enemy, obj_pnunit)) {
+            // Check for men
+            if (enemy.men) {
+                obj_ncombat.combat_debugger.add(eCOMBAT_CATEGORY.TARGETING, $"melee -> infantry in {obj_ncombat.combat_debugger.resolve_label(enemy)}");
+                scr_shoot(i, enemy, 1, "att", "melee");
+            } else if (block_has_armour(enemy)) {
+                obj_ncombat.combat_debugger.add(eCOMBAT_CATEGORY.TARGETING, $"melee -> armour fallback in {obj_ncombat.combat_debugger.resolve_label(enemy)}");
+                scr_shoot(i, enemy, 1, "arp", "melee");
             }
         }
     }

--- a/objects/obj_enunit/Alarm_0.gml
+++ b/objects/obj_enunit/Alarm_0.gml
@@ -139,7 +139,7 @@ if (!engaged) {
                     var x2 = enemy.x;
 
                     repeat (instance_number(obj_pnunit) - 1) {
-                        x2 += !flank ? 10 : -10;
+                        x2 += !flank ? -10 : 10;
                         enemy2 = instance_nearest(x2, y, obj_pnunit);
                         if (!target_block_is_valid(enemy2, obj_pnunit)) {
                             continue;

--- a/objects/obj_enunit/Alarm_0.gml
+++ b/objects/obj_enunit/Alarm_0.gml
@@ -150,21 +150,15 @@ if (!engaged) {
                         }
 
                         var _back_column_size_value = enemy2.column_size;
-                        if (_back_column_size_value < _column_size_value) {
-                            continue;
+
+                        if (!check_column_obstruction(_column_size_value, _back_column_size_value)) {
+                            obj_ncombat.combat_debugger.add(eCOMBAT_CATEGORY.TARGETING, $"non-AP -> infantry found in back column {obj_ncombat.combat_debugger.resolve_label(enemy2)}, firing");
+                            scr_shoot(i, enemy2, target_unit_index, "att", "ranged");
+                            _shot = true;
+                            break;
                         } else {
-                            // Calculate chance of shots passing through to back row
-                            // Higher ratio of back column size to front column size increases pass-through chance
-                            // Maximum chance capped at 40% to ensure some protection remains
-                            var _pass_chance = ((_back_column_size_value / _column_size_value) - 1) * 100;
-                            if (irandom_range(1, 100) < min(_pass_chance, 80)) {
-                                continue;
-                            }
+                            continue;
                         }
-                        obj_ncombat.combat_debugger.add(eCOMBAT_CATEGORY.TARGETING, $"non-AP -> infantry found in back column {obj_ncombat.combat_debugger.resolve_label(enemy2)}, firing");
-                        scr_shoot(i, enemy2, target_unit_index, "att", "ranged");
-                        _shot = true;
-                        break;
                     }
                 }
 

--- a/objects/obj_enunit/Alarm_0.gml
+++ b/objects/obj_enunit/Alarm_0.gml
@@ -8,7 +8,7 @@ if (!instance_exists(obj_pnunit)) {
 }
 
 enemy = flank ? get_leftmost() : get_rightmost();
-if (enemy == noone) {
+if (enemy == noone || !target_block_is_valid(enemy, obj_pnunit)) {
     obj_ncombat.combat_debugger.add(eCOMBAT_CATEGORY.TARGETING, $"Couldn't find valid player blocks, exiting");
     exit;
 }
@@ -201,7 +201,7 @@ if (!engaged) {
         }
         LOGGER.error($"{wep[i]} didn't find a valid target! This shouldn't happen!");
     }
-} else if ((engaged || enemy.engaged) && target_block_is_valid(enemy, obj_pnunit)) {
+} else if (engaged) {
     obj_ncombat.combat_debugger.add(eCOMBAT_CATEGORY.TARGETING, $"Engaged, attacking in melee");
     //TODO: The melee code was not refactored;
     // Melee
@@ -238,36 +238,37 @@ if (!engaged) {
             _armour_piercing = true;
             obj_ncombat.combat_debugger.add(eCOMBAT_CATEGORY.TARGETING, $"melee AP=true");
         }
-        if (_armour_piercing && instance_exists(obj_nfort) && (!flank)) {
-            // Huff and puff and blow the wall down
-            enemy = instance_nearest(x, y, obj_nfort);
-            obj_ncombat.combat_debugger.add(eCOMBAT_CATEGORY.TARGETING, $"melee AP -> wall");
-            scr_shoot(i, enemy, 1, "arp", "wall");
-            continue;
-        }
-        if (_armour_piercing) {
-            // Check for vehicles
-            var good = false;
 
+        if (_armour_piercing) {
+            // Huff and puff and blow the wall down
+            if (instance_exists(obj_nfort) && (!flank)) {
+                enemy = instance_nearest(x, y, obj_nfort);
+                obj_ncombat.combat_debugger.add(eCOMBAT_CATEGORY.TARGETING, $"melee AP -> wall");
+                scr_shoot(i, enemy, 1, "arp", "wall");
+                continue;
+            }
+
+            // Check for vehicles
             if (block_has_armour(enemy)) {
                 obj_ncombat.combat_debugger.add(eCOMBAT_CATEGORY.TARGETING, $"melee AP -> vehicles in {obj_ncombat.combat_debugger.resolve_label(enemy)}");
                 scr_shoot(i, enemy, 1, "arp", "melee");
-                good = true;
-            }
-            if (!good) {
+                continue;
+            } else {
                 _armour_piercing = false;
                 obj_ncombat.combat_debugger.add(eCOMBAT_CATEGORY.TARGETING, $"melee AP -> no vehicles, falling back to infantry");
             }
         }
 
-        if ((!_armour_piercing) && target_block_is_valid(enemy, obj_pnunit)) {
+        if (!_armour_piercing) {
             // Check for men
-            if (enemy.men) {
+            if (enemy.men > 0) {
                 obj_ncombat.combat_debugger.add(eCOMBAT_CATEGORY.TARGETING, $"melee -> infantry in {obj_ncombat.combat_debugger.resolve_label(enemy)}");
                 scr_shoot(i, enemy, 1, "att", "melee");
+                continue;
             } else if (block_has_armour(enemy)) {
                 obj_ncombat.combat_debugger.add(eCOMBAT_CATEGORY.TARGETING, $"melee -> armour fallback in {obj_ncombat.combat_debugger.resolve_label(enemy)}");
                 scr_shoot(i, enemy, 1, "arp", "melee");
+                continue;
             }
         }
     }

--- a/objects/obj_enunit/Alarm_1.gml
+++ b/objects/obj_enunit/Alarm_1.gml
@@ -1676,6 +1676,12 @@ if (obj_ncombat.enemy == eFACTION.NECRONS) {
     }
 }
 
+for (var j = 1; j <= 20; j++) {
+    if (dudes_vehicle[j] == 1 && dudes_hp[j] > 0 && dudes_num[j] > 0) {
+        scr_en_weapon("RAM", false, dudes_num[j], dudes[j], j);
+    }
+}
+
 if (men + veh + medi <= 0) {
     instance_destroy(id);
     exit;

--- a/scripts/scr_en_weapon/scr_en_weapon.gml
+++ b/scripts/scr_en_weapon/scr_en_weapon.gml
@@ -121,6 +121,13 @@ function scr_en_weapon(name, is_man, man_number, man_type, group) {
             arp = 1;
             rang = 1;
             break;
+        case "RAM":
+            atta = 100;
+            arp = 3;
+            rang = 1;
+            amm = -1;
+            spli = 6;
+            break;
         default:
             break;
     }

--- a/scripts/scr_flavor/scr_flavor.gml
+++ b/scripts/scr_flavor/scr_flavor.gml
@@ -325,6 +325,44 @@ function scr_flavor(id_of_attacking_weapons, target, target_type, number_of_shot
                 }
             }
         }
+    } else if (string_contains("RAM", weapon_name)) {
+        flavoured = true;
+        if (!character_shot) {
+            if (number_of_shots < 10) {
+                attack_message += $"{number_of_shots} vehicle{((number_of_shots > 1) ? "s" : "")} thunder forward, armoured hulls crashing into the enemy lines- ";
+            } else {
+                attack_message += $"An armoured column of {number_of_shots} vehicles smashes into the enemy, grinding everything in its path- ";
+            }
+            if (target.dudes_num[targeh] == 1) {
+                if (casulties == 0) {
+                    attack_message += $"but the {target_name} withstands the impact.";
+                } else {
+                    attack_message += $"the {target_name} is crushed beneath their treads.";
+                }
+            } else {
+                if (casulties == 0) {
+                    attack_message += $"{target_name} ranks scatter before the charge, but no casualties are confirmed.";
+                } else {
+                    attack_message += $"{target_name} ranks are crushed, killing {casulties} in the onslaught.";
+                }
+            }
+        } else {
+            if (target.dudes_num[targeh] == 1) {
+                attack_message += $"{unit_name} rams into the {target_name}- ";
+                if (casulties == 0) {
+                    attack_message += $"but it endures the impact.";
+                } else {
+                    attack_message += $"and it is shattered.";
+                }
+            } else {
+                attack_message += $"{unit_name} rams into {target_name} ranks- ";
+                if (casulties == 0) {
+                    attack_message += $"but they all survive the impact.";
+                } else {
+                    attack_message += $"crushing {casulties} beneath its hull.";
+                }
+            }
+        }
     } else if (weapon_name == "Assault Cannon") {
         flavoured = true;
         if (!character_shot) {

--- a/scripts/scr_flavor2/scr_flavor2.gml
+++ b/scripts/scr_flavor2/scr_flavor2.gml
@@ -227,15 +227,6 @@ function scr_flavor2(lost_units_count, target_type, hostile_range, hostile_weapo
         }
     }
 
-    if (string_contains("RAM", _hostile_weapon)) {
-        flavor = 1;
-        if (_hostile_shots == 1) {
-            m1 = $"A vehicle thunders forward, armoured hulls crashing into {target_type}.  ";
-        } else {
-            m1 = $"An armoured column of {_hostile_shots} vehicles smashes into {target_type}, grinding everything in its path.  ";
-        }
-    }
-
     if (_hostile_shots > 0) {
         if (_hostile_weapon == "Choppa") {
             m1 = $"{_hostile_shots} {_hostile_weapon}z cleave into {target_type}.  ";
@@ -365,6 +356,15 @@ function scr_flavor2(lost_units_count, target_type, hostile_range, hostile_weapo
                     m1 = $"{_hostile_shots} large necron claws strike at and shred {target_type}.  ";
                 }
             }
+        }
+    }
+
+    if (flavor == 0 && string_contains("RAM", _hostile_weapon)) {
+        flavor = 1;
+        if (_hostile_shots == 1) {
+            m1 = $"A vehicle thunders forward, armoured hulls crashing into {target_type}.  ";
+        } else {
+            m1 = $"An armoured column of {_hostile_shots} vehicles smashes into {target_type}, grinding everything in its path.  ";
         }
     }
 

--- a/scripts/scr_flavor2/scr_flavor2.gml
+++ b/scripts/scr_flavor2/scr_flavor2.gml
@@ -227,6 +227,15 @@ function scr_flavor2(lost_units_count, target_type, hostile_range, hostile_weapo
         }
     }
 
+    if (string_contains("RAM", _hostile_weapon)) {
+        flavor = 1;
+        if (_hostile_shots == 1) {
+            m1 = $"A vehicle thunders forward, armoured hulls crashing into {target_type}.  ";
+        } else {
+            m1 = $"An armoured column of {_hostile_shots} vehicles smashes into {target_type}, grinding everything in its path.  ";
+        }
+    }
+
     if (_hostile_shots > 0) {
         if (_hostile_weapon == "Choppa") {
             m1 = $"{_hostile_shots} {_hostile_weapon}z cleave into {target_type}.  ";

--- a/scripts/scr_player_combat_weapon_stacks/scr_player_combat_weapon_stacks.gml
+++ b/scripts/scr_player_combat_weapon_stacks/scr_player_combat_weapon_stacks.gml
@@ -307,6 +307,16 @@ function scr_player_combat_weapon_stacks() {
                         }
                     }
                 }
+
+                var ram_weapon = create_vehicle_ram_weapon(veh_type[g]);
+                if (is_struct(ram_weapon)) {
+                    for (var j = 0; j <= 40; j++) {
+                        if (wep[j] == "" || wep[j] == ram_weapon.name) {
+                            add_data_to_stack(j, ram_weapon,,, "vehicle");
+                            break;
+                        }
+                    }
+                }
             }
         }
     }
@@ -397,6 +407,50 @@ function scr_add_unit_to_roster(unit, is_local = false, is_ally = false) {
         dreads++;
     } else {
         men++;
+    }
+}
+
+function create_vehicle_ram_weapon(veh_type) {
+    switch (veh_type) {
+        case "Rhino":
+        case "Whirlwind":
+        case "Predator":
+            return new EquipmentStruct(
+                {
+                    attack: 100,
+                    name: "RAM",
+                    range: 1,
+                    ammo: -1,
+                    spli: 6,
+                    arp: 3,
+                },
+                "weapon",
+            );
+        case "Land Raider":
+            return new EquipmentStruct(
+                {
+                    attack: 200,
+                    name: "Heavy RAM",
+                    range: 1,
+                    ammo: -1,
+                    spli: 10,
+                    arp: 4,
+                },
+                "weapon",
+            );
+        default:
+        case "Land Speeder":
+            return new EquipmentStruct(
+                {
+                    attack: 60,
+                    name: "Light RAM",
+                    range: 1,
+                    ammo: -1,
+                    spli: 4,
+                    arp: 2,
+                },
+                "weapon",
+            );
     }
 }
 

--- a/scripts/scr_punit_combat_heplers/scr_punit_combat_heplers.gml
+++ b/scripts/scr_punit_combat_heplers/scr_punit_combat_heplers.gml
@@ -263,7 +263,7 @@ function draw_block_fadein() {
 
 /// @self Asset.GMObject.obj_enunit|Asset.GMObject.obj_pnunit
 function update_block_size() {
-    column_size = (men * 0.5) + medi + (dreads * 2) + (veh * 2.5);
+    column_size = men + (medi * 3) + (dreads * 6) + (veh * 8);
 }
 
 /// @self Asset.GMObject.obj_enunit|Asset.GMObject.obj_pnunit

--- a/scripts/scr_punit_combat_heplers/scr_punit_combat_heplers.gml
+++ b/scripts/scr_punit_combat_heplers/scr_punit_combat_heplers.gml
@@ -311,7 +311,7 @@ function pick_target_column(target_type, mode) {
                 _x2 += 10;
                 var _enemy2 = instance_nearest(_x2, y, obj_enunit);
 
-                if (has_target_type(_enemy2, target_type, mode)) {
+                if (has_target_type(_enemy2, target_type, mode) && !check_column_obstruction(enemy.column_size, _enemy2.column_size)) {
                     return _enemy2;
                 }
             }
@@ -322,4 +322,17 @@ function pick_target_column(target_type, mode) {
         ERROR_HANDLER.handle_exception(_exception);
         return undefined;
     }
+}
+
+function check_column_obstruction(front_size, back_size) {
+    if (back_size < front_size) {
+        return true;
+    } else {
+        var _pass_chance = ((back_size / front_size) - 1) * 100;
+        if (irandom_range(1, 100) < min(_pass_chance, 80)) {
+            return true;
+        }
+    }
+
+    return false;
 }

--- a/scripts/scr_ui_formation_bars/scr_ui_formation_bars.gml
+++ b/scripts/scr_ui_formation_bars/scr_ui_formation_bars.gml
@@ -72,23 +72,23 @@ function scr_ui_formation_bars() {
             }
 
             if (temp[4800 + bar] > 10) {
-                bat_deva_for[bar] = 1;
-                bat_assa_for[bar] = 4;
-                bat_tact_for[bar] = 2;
-                bat_vete_for[bar] = 2;
+                bat_deva_for[bar] = 3;
+                bat_assa_for[bar] = 5;
+                bat_tact_for[bar] = 4;
+                bat_vete_for[bar] = 3;
                 bat_hire_for[bar] = 3;
-                bat_libr_for[bar] = 3;
-                bat_comm_for[bar] = 3;
-                bat_tech_for[bar] = 3;
-                bat_term_for[bar] = 3;
-                bat_hono_for[bar] = 3;
-                bat_drea_for[bar] = 5;
+                bat_libr_for[bar] = 2;
+                bat_comm_for[bar] = 2;
+                bat_tech_for[bar] = 2;
+                bat_term_for[bar] = 5;
+                bat_hono_for[bar] = 2;
+                bat_drea_for[bar] = 6;
                 bat_rhin_for[bar] = 6;
-                bat_pred_for[bar] = 7;
-                bat_landraid_for[bar] = 7;
-                bat_landspee_for[bar] = 4;
+                bat_pred_for[bar] = 6;
+                bat_landraid_for[bar] = 6;
+                bat_landspee_for[bar] = 5;
                 bat_whirl_for[bar] = 1;
-                bat_scou_for[bar] = 1;
+                bat_scou_for[bar] = 3;
                 bar_fix = true;
             }
         }

--- a/scripts/scr_ui_settings/scr_ui_settings.gml
+++ b/scripts/scr_ui_settings/scr_ui_settings.gml
@@ -527,23 +527,23 @@ function scr_ui_settings() {
                         if (bat_formation[formating] == "") {
                             bat_formation[formating] = "Custom" + string(formating - 3);
                             bat_formation_type[formating] = 1;
-                            bat_deva_for[formating] = 1;
-                            bat_assa_for[formating] = 4;
-                            bat_tact_for[formating] = 2;
-                            bat_vete_for[formating] = 2;
+                            bat_deva_for[formating] = 3;
+                            bat_assa_for[formating] = 5;
+                            bat_tact_for[formating] = 4;
+                            bat_vete_for[formating] = 3;
                             bat_hire_for[formating] = 3;
-                            bat_libr_for[formating] = 3;
-                            bat_comm_for[formating] = 3;
-                            bat_tech_for[formating] = 3;
-                            bat_term_for[formating] = 3;
-                            bat_hono_for[formating] = 3;
-                            bat_drea_for[formating] = 5;
+                            bat_libr_for[formating] = 2;
+                            bat_comm_for[formating] = 2;
+                            bat_tech_for[formating] = 2;
+                            bat_term_for[formating] = 5;
+                            bat_hono_for[formating] = 2;
+                            bat_drea_for[formating] = 6;
                             bat_rhin_for[formating] = 6;
-                            bat_pred_for[formating] = 7;
-                            bat_landraid_for[formating] = 7;
-                            bat_landspee_for[formating] = 4;
+                            bat_pred_for[formating] = 6;
+                            bat_landraid_for[formating] = 6;
+                            bat_landspee_for[formating] = 5;
                             bat_whirl_for[formating] = 1;
-                            bat_scou_for[formating] = 1;
+                            bat_scou_for[formating] = 3;
                         }
                     }
                 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds vehicle `RAM` melee attacks with class-based stats and new combat flavor. Unifies obstruction-based targeting with new column weights, updates formations/UI defaults, and fixes melee distance and pass-through issues.

- **New Features**
  - Auto-add `RAM` attacks for all vehicles (player and enemy), with Light/Standard/Heavy variants by vehicle class.
  - Shared obstruction checks for ranged targeting (player and enemy); back-row shots only when unobstructed.
  - Retuned formation columns (e.g., Devastator 3, Assault 5, Tactical 4, Terminator 5, Rhino/Pred/Land Raider 6); UI defaults updated to match.

- **Bug Fixes**
  - Corrected flank scan direction, fixed enemy back-row pass-through, and tightened enemy target validation.
  - Melee now requires adjacent blocks and respects weapon reach; fractional ranges are treated as melee; removed forced engaged to stop teleporting.
  - General enemy targeting cleanup with safer early exits when no valid player blocks are found.

<sup>Written for commit 3cc2a2e40944fe02ebe7ba1df94bad93b691e05b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

