### PR TITLE
refactor: More random Cleanups

### DIFF
--- a/objects/obj_saveload/Alarm_1.gml
+++ b/objects/obj_saveload/Alarm_1.gml
@@ -1,4 +1,4 @@
-obj_controller.menu = 0;
+obj_controller.menu = eMENU.DEFAULT;
 obj_controller.zui = 0;
 obj_controller.invis = false;
 obj_cursor.image_alpha = 1;

--- a/objects/obj_saveload/Alarm_3.gml
+++ b/objects/obj_saveload/Alarm_3.gml
@@ -1,3 +1,3 @@
-hide = 0;
+hide = false;
 obj_controller.invis = false;
 obj_controller.zui = 1;

--- a/objects/obj_saveload/Create_0.gml
+++ b/objects/obj_saveload/Create_0.gml
@@ -16,7 +16,7 @@ autosaving = false;
 /// number of frames between load sections to draw the progress bar
 trickle = 0;
 txt = "";
-hide = 0;
+hide = false;
 bar = 0;
 slow = 0;
 saves = 0;

--- a/objects/obj_saveload/Draw_64.gml
+++ b/objects/obj_saveload/Draw_64.gml
@@ -22,7 +22,7 @@ if (!hide) {
 
     if ((menu == 1) || (menu == 2)) {
         // This is the other one
-        draw_set_color(0);
+        draw_set_color(c_black);
         draw_set_alpha(0.75);
         if (room_get_name(room) != "rm_main_menu") {
             draw_rectangle(0, 0, room_width, room_height, 0);
@@ -33,7 +33,6 @@ if (!hide) {
         draw_set_alpha(1);
 
         draw_set_halign(fa_center);
-        draw_set_color(0);
 
         draw_sprite(spr_save_header, 0, 0, 27);
         if (menu == 1) {
@@ -51,7 +50,7 @@ if (!hide) {
             if (((save[slot_index] >= 0) || ((first_open == slot_index) && (menu == 1)) || (global.load == slot_index) || (save_number == slot_index)) && (save_number == 0)) {
                 draw_set_font(fnt_40k_30b);
                 draw_set_halign(fa_left);
-                draw_set_color(0);
+                draw_set_color(c_black);
 
                 draw_rectangle(slot_left + 56, slot_top + 5, slot_left + 238, slot_top + 123, 0);
                 draw_rectangle(slot_left + 258, slot_top + 25, slot_left + 1480, slot_top + 80, 0);
@@ -62,14 +61,14 @@ if (!hide) {
                 draw_sprite(spr_save_data, 0, slot_left, slot_top);
                 if (slot_index == 0) {
                     //autosave
-                    draw_text_transformed(slot_left + 21, slot_top + 62, string_hash_to_newline("A"), 1.1, 1.1, 0);
+                    draw_text_transformed(slot_left + 21, slot_top + 62, "A", 1.1, 1.1, 0);
                 } else {
-                    draw_text_transformed(slot_left + 23, slot_top + 62, string_hash_to_newline(slot_index), 1.1, 1.1, 0);
+                    draw_text_transformed(slot_left + 23, slot_top + 62, string(slot_index), 1.1, 1.1, 0);
                 }
-                draw_text_transformed(slot_left + 270, slot_top + 10, string_hash_to_newline("Chapter"), 0.9, 0.9, 0);
-                draw_text_transformed(slot_left + 774, slot_top + 10, string_hash_to_newline("Marines"), 0.9, 0.9, 0);
-                draw_text_transformed(slot_left + 1024, slot_top + 10, string_hash_to_newline("Turn"), 0.9, 0.9, 0);
-                draw_text_transformed(slot_left + 1274, slot_top + 10, string_hash_to_newline("Game Time"), 0.9, 0.9, 0);
+                draw_text_transformed(slot_left + 270, slot_top + 10, "Chapter", 0.9, 0.9, 0);
+                draw_text_transformed(slot_left + 774, slot_top + 10, "Marines", 0.9, 0.9, 0);
+                draw_text_transformed(slot_left + 1024, slot_top + 10, "Turn", 0.9, 0.9, 0);
+                draw_text_transformed(slot_left + 1274, slot_top + 10, "Game Time", 0.9, 0.9, 0);
 
                 draw_set_color(c_gray);
                 if (first_open != slot_index) {
@@ -134,7 +133,7 @@ if (!hide) {
                     draw_text_transformed(slot_left + 1274, slot_top + 48, string_hash_to_newline(string(result)), 0.7, 0.7, 0);
                 }
                 if ((first_open == slot_index) && (menu == 1)) {
-                    draw_text_transformed(slot_left + 270, slot_top + 48, string_hash_to_newline("(EMPTY SAVE SLOT)"), 0.7, 0.7, 0);
+                    draw_text_transformed(slot_left + 270, slot_top + 48, "(EMPTY SAVE SLOT)", 0.7, 0.7, 0);
                 }
             }
 
@@ -149,7 +148,7 @@ if (!hide) {
                 draw_rectangle(slot_left + 807, slot_top + 113, slot_left + 951, slot_top + 146, 0);
                 draw_set_color(c_black);
                 draw_rectangle(slot_left + 807, slot_top + 113, slot_left + 951, slot_top + 146, 1);
-                draw_text_transformed(slot_left + 879, slot_top + 117, string_hash_to_newline("Delete Game"), 0.7, 0.7, 0);
+                draw_text_transformed(slot_left + 879, slot_top + 117, "Delete Game", 0.7, 0.7, 0);
                 if (scr_hit(slot_left + 807, slot_top + 113, slot_left + 951, slot_top + 146)) {
                     draw_set_alpha(0.1);
                     draw_set_color(c_white);

--- a/scripts/is_specialist/is_specialist.gml
+++ b/scripts/is_specialist/is_specialist.gml
@@ -22,7 +22,7 @@ function active_roles() {
 }
 
 /// @description Returns a list of roles based on the specified group, with optional inclusion of trainees and heads.
-/// @param {Real} group The group of roles to retrieve (e.g., SPECIALISTS_STANDARD, SPECIALISTS_LIBRARIANS).
+/// @param {String} group The group of roles to retrieve (e.g., SPECIALISTS_STANDARD, SPECIALISTS_LIBRARIANS).
 /// @param {Bool} include_trainee Whether to include trainee roles (default is false).
 /// @param {Bool} include_heads Whether to include head roles (default is true).
 /// @returns {Array<String>}
@@ -155,7 +155,7 @@ function role_groups(group, include_trainee = false, include_heads = true) {
                 "Master of Sanctity",
                 $"Chief {_roles[eROLE.LIBRARIAN]}",
                 "Forge Master",
-                obj_ini.role[100][eROLE.CHAPTERMASTER],
+                string(obj_ini.role[100][eROLE.CHAPTERMASTER]),
                 "Master of the Apothecarion"
             ];
             break;

--- a/scripts/scr_PlanetData/scr_PlanetData.gml
+++ b/scripts/scr_PlanetData/scr_PlanetData.gml
@@ -1,3 +1,4 @@
+/// @self Asset.GMObject.obj_star
 /// @param {Real} _planet
 /// @param {Id.Instance.obj_star} _system
 function PlanetData(_planet, _system) constructor {
@@ -291,19 +292,19 @@ function PlanetData(_planet, _system) constructor {
     planet_forces = array_create(14, 0);
 
     try {
-        planet_forces[1] = player_forces;
+        planet_forces[eFACTION.PLAYER] = player_forces;
 
-        planet_forces[2] = guardsmen;
+        planet_forces[eFACTION.IMPERIUM] = guardsmen;
 
-        planet_forces[5] = system.p_sisters[planet];
-        planet_forces[6] = system.p_eldar[planet];
-        planet_forces[7] = system.p_orks[planet];
-        planet_forces[8] = system.p_tau[planet];
-        planet_forces[9] = system.p_tyranids[planet];
-        planet_forces[10] = system.p_chaos[planet] + system.p_demons[planet];
-        planet_forces[11] = system.p_traitors[planet];
+        planet_forces[eFACTION.ECCLESIARCHY] = system.p_sisters[planet];
+        planet_forces[eFACTION.ELDAR] = system.p_eldar[planet];
+        planet_forces[eFACTION.ORK] = system.p_orks[planet];
+        planet_forces[eFACTION.TAU] = system.p_tau[planet];
+        planet_forces[eFACTION.TYRANIDS] = system.p_tyranids[planet];
+        planet_forces[eFACTION.CHAOS] = system.p_chaos[planet] + system.p_demons[planet];
+        planet_forces[eFACTION.HERETICS] = system.p_traitors[planet];
 
-        planet_forces[13] = system.p_necrons[planet];
+        planet_forces[eFACTION.NECRONS] = system.p_necrons[planet];
     } catch (_exception) {
         ERROR_HANDLER.handle_exception(_exception);
     }
@@ -347,8 +348,7 @@ function PlanetData(_planet, _system) constructor {
     };
 
     static assasinate_governor = function(assaination_type, discovery_modifier) {
-        var randa = roll_dice_chapter(1, 100, "high");
-        var randa2 = roll_dice(1, 100);
+        var _discovery_threshold = roll_dice(1, 100);
         var _text = $"All of the successors for {name()} are removed or otherwise made indisposed.  Paperwork is slightly altered.  Rather than any sort of offical one of your Chapter Serfs is installed as the Planetary Governor.  The planet is effectively under your control.";
         var _discovery_rate = 25;
 
@@ -366,7 +366,7 @@ function PlanetData(_planet, _system) constructor {
             scr_event_log("", $"Planetary Governor of {name()} assassinated.  One of your Chapter Serfs take their position.");
         }
 
-        if (randa2 <= (_discovery_rate * discovery_modifier)) {
+        if (_discovery_threshold <= (_discovery_rate * discovery_modifier)) {
             var _duration = (choose(1, 2) * 6) + choose(-3, -2, -1, 0, 1, 2, 3);
             if (assaination_type == 1) {
                 _duration = ((choose(1, 2, 3, 4, 5, 6) + choose(1, 2, 3, 4, 5, 6)) * 6) + choose(-3, -2, -1, 0, 1, 2, 3);
@@ -381,7 +381,6 @@ function PlanetData(_planet, _system) constructor {
     static assasinate_governor_setup = function(action_score) {
         var aroll = roll_dice_chapter(1, 100, "high");
         var chance = 100;
-        var o = 0;
         var yep = 0;
 
         // Disposition
@@ -396,15 +395,10 @@ function PlanetData(_planet, _system) constructor {
         }
 
         // Size - unused
-        // if ((action_score > 5) && (action_score <= 10)) { siz_penalty = 5; }
-        // if ((action_score > 10) && (action_score <= 20)) { siz_penalty = 20; }
-        // if ((action_score > 20) && (action_score <= 50)) { siz_penalty = 30; }
-        // if ((action_score > 50) && (action_score <= 100)) { siz_penalty = 50; }
-        // if ((action_score > 100) && (action_score <= 200)) { siz_penalty = 75; }
-        // if (action_score > 200) { siz_penalty = 125; }
-
-        var spec1 = 0, spec2 = 0, txt = ""; // TODO consider making it a battle with Planetary governor's guards
-        txt = $"Your Astartes descend upon the surface of {name()} and plot the movements and schedule of the governor.  ";
+        // TODO consider making it a battle with Planetary governor's guards
+        var spec1 = 0;
+        var spec2 = 0;
+        var txt = $"Your Astartes descend upon the surface of {name()} and plot the movements and schedule of the governor.  ";
         txt += "Once the time is right their target is ambushed ";
         txt += choose("in their home", "in the streets", "while driving", "taking a piss") + " and tranquilized.  ";
 
@@ -502,7 +496,6 @@ function PlanetData(_planet, _system) constructor {
     };
 
     static grow_ork_forces = function() {
-        var contin = 0;
         var _rando = roll_dice(1, 100); // This part handles the spreading
         var _non_deads = planets_without_type("dead", system);
 
@@ -569,7 +562,6 @@ function PlanetData(_planet, _system) constructor {
                 }
             }
         }
-        contin = 0;
         _rando = roll_dice(1, 100); // This part handles the ship building
         if ((population > 0 && pdf == 0 && guardsmen == 0 && planet_forces[10] == 0) && (planet_forces[eFACTION.TAU] == 0)) {
             if (!large_population) {
@@ -697,10 +689,7 @@ function PlanetData(_planet, _system) constructor {
                             break;
                     }
                 }
-                var ii = round(standard_fleet_strength_calc());
-                if (ii <= 1) {
-                    ii = 1;
-                }
+                var ii = max(round(standard_fleet_strength_calc()), 1);
                 image_index = ii;
                 //if big enough flee bugger off to new star
                 if (image_index >= 5) {
@@ -773,7 +762,7 @@ function PlanetData(_planet, _system) constructor {
     problem_timers = system.p_timer[planet];
 
     static has_problem = function(problem) {
-        has_problem_planet(planet, problem, system);
+        return has_problem_planet(planet, problem, system);
     };
 
     static remove_problem = function(problem) {
@@ -789,11 +778,7 @@ function PlanetData(_planet, _system) constructor {
     };
 
     static name = function() {
-        var _name = "";
-
-        _name = planet_numeral_name(planet, system);
-
-        return _name;
+        return planet_numeral_name(planet, system);
     };
 
     static xenos_and_heretics = function() {
@@ -889,7 +874,6 @@ function PlanetData(_planet, _system) constructor {
                 //TODO allow total tech point usage here
                 var _starship = get_features(eP_FEATURES.STARSHIP)[0];
 
-                var _engineer_score_start = _starship.engineer_score;
                 if (_starship.engineer_score < 2000) {
                     for (var v = 0; v < engineer_count; v++) {
                         _starship.engineer_score += techs[v].technology / 2;
@@ -928,7 +912,7 @@ function PlanetData(_planet, _system) constructor {
     };
 
     static guard_score_calc = function() {
-        guard_score = 0;
+        guard_score = 0.5;
         if (guardsmen < 500 && guardsmen > 0) {
             guard_score = 0.1;
         } else if (guardsmen >= 100000000) {
@@ -945,8 +929,6 @@ function PlanetData(_planet, _system) constructor {
             guard_score = 2;
         } else if (guardsmen >= 2000) {
             guard_score = 1;
-        } else {
-            guard_score = 0.5;
         }
 
         return guard_score;
@@ -967,7 +949,7 @@ function PlanetData(_planet, _system) constructor {
 
         if (stop) {
             if ((planet_forces[eFACTION.ORK] > 0) && (planet_forces[eFACTION.ECCLESIARCHY] > 0)) {
-                stop = 0;
+                stop = false;
             }
         }
 
@@ -975,7 +957,7 @@ function PlanetData(_planet, _system) constructor {
 
         if (stop) {
             if (planet_forces[eFACTION.NECRONS] >= 5 || planet_forces[eFACTION.TYRANIDS] >= 5 && imperium_forces) {
-                stop = 0;
+                stop = false;
             }
         }
 
@@ -983,20 +965,20 @@ function PlanetData(_planet, _system) constructor {
         if (stop) {
             if (current_owner == eFACTION.TAU) {
                 if (((guardsmen > 0) || (planet_forces[eFACTION.ECCLESIARCHY] > 0)) && ((pdf > 0) || (planet_forces[eFACTION.TAU] > 0))) {
-                    stop = 0;
+                    stop = false;
                 }
             }
         }
 
         // Attack heretics whenever possible, even player controlled ones
         if (stop) {
-            if ((player_forces + pdf > 0) && (guardsmen > 0) && (obj_controller.faction_status[2] == "War")) {
-                stop = 0;
+            if ((player_forces + pdf > 0) && (guardsmen > 0) && (obj_controller.faction_status[eFACTION.IMPERIUM] == "War")) {
+                stop = false;
             }
         }
         if (stop) {
-            if ((player_forces + pdf > 0) && (planet_forces[eFACTION.ECCLESIARCHY] > 0) && (obj_controller.faction_status[5] == "War")) {
-                stop = 0;
+            if ((player_forces + pdf > 0) && (planet_forces[eFACTION.ECCLESIARCHY] > 0) && (obj_controller.faction_status[eFACTION.ECCLESIARCHY] == "War")) {
+                stop = false;
             }
         }
 
@@ -1011,7 +993,7 @@ function PlanetData(_planet, _system) constructor {
             return false;
         }
 
-        if ((current_owner == 1 || obj_controller.faction_status[2] != "War") && pdf) {
+        if ((current_owner == eFACTION.PLAYER || obj_controller.faction_status[eFACTION.IMPERIUM] != "War") && pdf) {
             return true;
         }
         return false;
@@ -1019,8 +1001,6 @@ function PlanetData(_planet, _system) constructor {
 
     static guard_attack_matrix = function() {
         var guard_attack = "";
-        // if (p_eldar[planet]>0) and (p_owner[planet]!=6) then guard_attack="eldar";
-        //if (planet_forces[eFACTION.TAU] + planet_forces[eFACTION.ORK] + planet_forces[eFACTION.HERETICS]+ planet_forces[eFACTION.CHAOS])
         if (planet_forces[eFACTION.TAU] > 0) {
             guard_attack = "tau";
         }
@@ -1049,7 +1029,6 @@ function PlanetData(_planet, _system) constructor {
         if ((planet_forces[eFACTION.TYRANIDS] <= 1) && (planet_forces[eFACTION.ORK] >= 4)) {
             guard_attack = "ork";
         }
-        // if (p_tyranids[planet]>0) and (guard_attack="") then guard_attack="tyranids";
         if (planet_forces[eFACTION.TYRANIDS] >= 4) {
             guard_attack = "tyranids";
         } else if (planet_forces[eFACTION.TYRANIDS] > 0) {
@@ -1144,31 +1123,28 @@ function PlanetData(_planet, _system) constructor {
         if (!instance_exists(obj_star_select)) {
             exit;
         }
+
         var improve = 0;
         var xx = 15;
         var yy = 25;
         var current_planet = planet;
-        var nm = scr_roman(current_planet), temp1 = 0;
+        var nm = scr_roman(current_planet);
+        var _succession = has_problem("succession");
+        var _xenos_and_heretics = xenos_and_heretics();
+
         draw_set_halign(fa_center);
         draw_set_valign(fa_top);
         draw_set_font(fnt_40k_14);
 
-        var _xenos_and_heretics = xenos_and_heretics();
         if ((current_owner <= 5) && (!_xenos_and_heretics)) {
-            if (planet_forces[eFACTION.PLAYER] > 0 || system.present_fleet[1] > 0) {
+            if (planet_forces[eFACTION.PLAYER] > 0 || system.present_fleet[eFACTION.PLAYER] > 0) {
                 if (fortification_level < 5) {
                     improve = 1;
                 }
             }
         }
 
-        // Draw disposition here
-        var yyy = 0;
-
-        var _succession = has_problem("succession");
-
-        if ((player_disposition >= 0 && current_owner <= 5 && population > 0) && (_succession == 0)) {
-            var wack = 0;
+        if ((player_disposition >= 0 && current_owner <= eFACTION.ECCLESIARCHY && population > 0) && !_succession) {
             draw_set_color(c_blue);
             draw_rectangle(xx + 349, yy + 175, xx + 349 + (min(100, player_disposition) * 3.68), yy + 192, 0);
         }
@@ -1177,13 +1153,13 @@ function PlanetData(_planet, _system) constructor {
         draw_set_color(c_white);
 
         if (!_succession) {
-            if ((player_disposition >= 0) && (origional_owner <= 5) && (current_owner <= 5) && (population > 0)) {
+            if ((player_disposition >= 0) && (origional_owner <= eFACTION.ECCLESIARCHY) && (current_owner <= eFACTION.ECCLESIARCHY) && (population > 0)) {
                 draw_text(xx + 534, yy + 176, "Disposition: " + string(min(100, player_disposition)) + "/100");
             }
-            if ((player_disposition > -30) && (player_disposition < 0) && (current_owner <= 5) && (population > 0)) {
+            if ((player_disposition > -30) && (player_disposition < 0) && (current_owner <= eFACTION.ECCLESIARCHY) && (population > 0)) {
                 draw_text(xx + 534, yy + 176, "Disposition: ???/100");
             }
-            if (((player_disposition >= 0) && (origional_owner <= 5) && (current_owner > 5)) || (population <= 0)) {
+            if (((player_disposition >= 0) && (origional_owner <= eFACTION.ECCLESIARCHY) && (current_owner > eFACTION.ECCLESIARCHY)) || (population <= 0)) {
                 draw_text(xx + 534, yy + 176, "-------------");
             }
 
@@ -1193,11 +1169,10 @@ function PlanetData(_planet, _system) constructor {
         } else if (_succession) {
             draw_text(xx + 534, yy + 176, "War of _Succession");
         }
-        draw_set_color(c_gray);
         // End draw disposition
         draw_set_color(c_gray);
         draw_rectangle(xx + 349, yy + 193, xx + 717, yy + 210, 0);
-        var bar_width = 717 - 349;
+        var bar_width = 368;
         var bar_start_point = xx + 349;
         var bar_percent_length = bar_width / 100;
         var current_bar_percent = 0;
@@ -1216,7 +1191,6 @@ function PlanetData(_planet, _system) constructor {
                 draw_rectangle(current_start, yy + 193, current_start + (bar_percent_length * population_influences[i]), yy + 210, 0);
                 current_bar_percent += population_influences[i];
             }
-            draw_set_color(c_gray);
         }
 
         draw_set_color(c_white);
@@ -1230,13 +1204,10 @@ function PlanetData(_planet, _system) constructor {
         if (is_craftworld) {
             draw_text(xx + 480, yy + 196, $"{system.name} (Craftworld)");
         }
-        // if (is_craftworld=0) and (is_hulk=0) then draw_text(xx+534,yy+214,string(planet_type)+" World");
-        // if (is_craftworld=1) then draw_text(xx+594,yy+214,"Craftworld");
         if (is_hulk) {
             draw_text(xx + 480, yy + 196, "Space Hulk");
         }
 
-        // draw_sprite(spr_planet_splash,temp1,xx+349,yy+194);
         scr_image("ui/planet", scr_planet_image_numbers(planet_type), xx + 349, yy + 194, 128, 128);
         draw_rectangle(xx + 349, yy + 194, xx + 477, yy + 322, 1);
         draw_set_font(fnt_40k_14);
@@ -1253,8 +1224,9 @@ function PlanetData(_planet, _system) constructor {
             }
         }
 
-        if ((is_craftworld == 0) && (is_hulk == 0)) {
-            var y7 = 240, temp3 = string(scr_display_number(guardsmen));
+        if (!is_craftworld && !is_hulk) {
+            var y7 = 240;
+            var temp3 = string(scr_display_number(guardsmen));
             if (guardsmen > 0) {
                 draw_text(xx + 480, yy + y7, $"Imperial Guard: {temp3}");
                 y7 += 20;
@@ -1276,16 +1248,16 @@ function PlanetData(_planet, _system) constructor {
                 draw_rectangle(xx + 481, yy + 280, xx + 716, yy + 298, 0);
                 draw_sprite(spr_requisition, 0, xx + 657, yy + 283);
 
-                var improve_cost = 1500, yep = 0, o = 0;
+                var improve_cost = 1500;
 
                 if (scr_has_adv("Siege Masters")) {
                     improve_cost = 1100;
                 }
 
-                draw_text_glow(xx + 671, yy + 281, improve_cost, 16291875, 0);
+                draw_text_glow(xx + 671, yy + 281, improve_cost, #F89823, 0);
 
                 if (scr_hit(xx + 481, yy + 282, xx + 716, yy + 300)) {
-                    draw_set_color(0);
+                    draw_set_color(c_black);
                     draw_set_alpha(0.2);
                     draw_rectangle(xx + 481, yy + 280, xx + 716, yy + 298, 0);
                     if (mouse_button_clicked() && (obj_controller.requisition >= improve_cost)) {
@@ -1298,7 +1270,7 @@ function PlanetData(_planet, _system) constructor {
                     }
                 }
                 draw_set_alpha(1);
-                draw_set_color(0);
+                draw_set_color(c_black);
             }
             var forti_string = [
                 "None",
@@ -1316,7 +1288,7 @@ function PlanetData(_planet, _system) constructor {
 
         draw_set_color(c_gray);
 
-        if (is_hulk == 1) {
+        if (is_hulk) {
             temp5 = "Integrity: " + string(floor(fortification_level * 20)) + "%";
             draw_text(xx + 480, yy + 280, temp5);
         }
@@ -1405,9 +1377,6 @@ function PlanetData(_planet, _system) constructor {
 
         draw_text(xx + 349, yy + 346, string_hash_to_newline(string(presence_text)));
 
-        var to_show = 0, temp9 = "";
-
-        var fit = array_create(11, "");
         var planet_displays = [];
         var feat_count = array_length(features);
         var upgrade_count = array_length(upgrades);
@@ -1475,7 +1444,9 @@ function PlanetData(_planet, _system) constructor {
             }
         }
 
-        var button_size, y_move = 0, button_colour;
+        var button_size;
+        var y_move = 0;
+        var button_colour;
         for (var i = 0; i < array_length(planet_displays); i++) {
             button_colour = c_green;
             if (planet_displays[i][0] == "????") {
@@ -1554,9 +1525,9 @@ function PlanetData(_planet, _system) constructor {
             }
         }
 
-        if ((population + pdf <= 0) && (current_owner == 1) && (obj_controller.faction_status[eFACTION.IMPERIUM] == "War")) {
+        if ((population + pdf <= 0) && (current_owner == eFACTION.PLAYER) && (obj_controller.faction_status[eFACTION.IMPERIUM] == "War")) {
             if (!has_feature(eP_FEATURES.MONASTERY)) {
-                current_owner = 2;
+                current_owner = eFACTION.IMPERIUM;
                 add_disposition(-50);
             }
         }
@@ -1788,13 +1759,9 @@ function PlanetData(_planet, _system) constructor {
                     var enemy_fleets = 0;
                     with (necron_fleet) {
                         if (owner == eFACTION.NECRONS) {
-                            var ii = 0;
-                            ii += capital_number;
+                            var ii = capital_number;
                             ii += round((frigate_number / 2));
                             ii += round((escort_number / 4));
-                            if (ii <= 1) {
-                                ii = 1;
-                            }
 
                             if ((ii >= 7) && (capital_number > 1)) {
                                 for (var fleet_n = 1; fleet_n <= 10; fleet_n++) {
@@ -1855,8 +1822,6 @@ function PlanetData(_planet, _system) constructor {
                         }
 
                         if (_found_near_planet) {
-                            var tgt1, tgt2;
-
                             necron_fleet2.action_x = _nearest_planet.x;
                             necron_fleet2.action_y = _nearest_planet.y;
                             with (necron_fleet2) {
@@ -1874,8 +1839,8 @@ function PlanetData(_planet, _system) constructor {
 
         // Spread influence on controlled sector
         if ((planet_type != "Space Hulk") && (planet_type != "Dead")) {
-            if (corruption < 70 && current_owner == 10) {
-                if (current_owner == 10) {
+            if (corruption < 70 && current_owner == eFACTION.CHAOS) {
+                if (current_owner == eFACTION.CHAOS) {
                     alter_corruption(2);
                 }
             }
@@ -1905,7 +1870,6 @@ function PlanetData(_planet, _system) constructor {
             alter_influence(eFACTION.TYRANIDS, cult.cult_age / 100);
             var planet_garrison = garrisons;
             if (cult.hiding) {
-                var find_nid_chance = 50 - planet_garrison.total_garrison;
                 if (population_influences[eFACTION.TYRANIDS] > 50) {
                     var find_cult_chance = irandom(50);
                     var alert_text = $"A hidden Genestealer Cult on {name()} Has suddenly burst forth from hiding!";
@@ -2113,10 +2077,7 @@ function PlanetData(_planet, _system) constructor {
     static init_fallen_marines = function() {
         var _eta = scr_mission_eta(system.x, system.y, 1);
 
-        LOGGER.info($"Fallen: found star {name()} as candidate");
-
         var assigned_problem = add_problem("fallen", _eta);
-        LOGGER.info($"assigned_problem {assigned_problem}");
 
         if (!assigned_problem) {
             LOGGER.error("RE: Hunt the Fallen, coulnd't assign a problem to the planet");

--- a/scripts/scr_battle_sort/scr_battle_sort.gml
+++ b/scripts/scr_battle_sort/scr_battle_sort.gml
@@ -2,8 +2,8 @@ function scr_battle_sort() {
     // This is ran in order to sort the battles that have been quened up
     // Space battles are placed in front whenever possible
 
-    for (var i = 49; i >= 0; i--) {
-        if ((battles <= i) && (i >= 2) && (battles > 0)) {
+    for (var i = 49; i >= 2; i--) {
+        if ((battles <= i) && (battles > 0)) {
             if ((battle[i] != 0) && (battle[i - 1] != 0) && (battle_world[i] == 0) && (battle_world[i - 1] > 0)) {
                 var tem1 = battle[i - 1];
                 var tem2 = battle_location[i - 1];

--- a/scripts/scr_company_view/scr_company_view.gml
+++ b/scripts/scr_company_view/scr_company_view.gml
@@ -42,7 +42,7 @@ function reset_manage_arrays() {
 }
 
 function find_company_open_slot(target_company) {
-    good = -1;
+    var good = -1;
     for (var i = 0; i < array_length(obj_ini.name[target_company]); i++) {
         if ((obj_ini.name[target_company][i] == "") || (obj_ini.role[target_company][i] == "")) {
             good = i;
@@ -138,12 +138,9 @@ function scr_company_view(company) {
         show_error(error_message, true);
     }
 
-    var mans, squads, squad_type, squad_loc, squad_members, unit, unit_loc;
-    mans = 0;
-    squads = 0;
-    squad_type = "";
-    squad_loc = 0;
-    squad_members = 0;
+    var unit;
+    var unit_loc;
+    var mans = 0;
     reset_manage_arrays();
     sel_uni = array_create(20, "");
     sel_veh = array_create(20, "");
@@ -166,7 +163,8 @@ function scr_company_view(company) {
 
             mans += 1;
             add_man_to_manage_arrays(unit);
-            var go = 0, op = 0;
+            var go = 0;
+            var op = 0;
             if (!unit.IsSpecialist()) {
                 for (var j = 0; j < 20; j++) {
                     if (sel_uni[j] == "" && op == 0) {
@@ -201,7 +199,8 @@ function scr_company_view(company) {
         add_vehicle_to_manage_arrays([company, i]);
 
         // Select All Vehicle Setup
-        var go = 0, op = 0;
+        var go = 0;
+        var op = 0;
         for (var p = 0; p < 20; p++) {
             if (sel_veh[p] == "" && op == 0) {
                 op = p;
@@ -222,13 +221,12 @@ function scr_company_view(company) {
 
 /// @description Manages unit data, including squad assignments, promotions, and location-based grouping.
 function other_manage_data() {
-    var _mans, _bad, _squads, _squad_type, _squad_loc, _squad_members, _unit, _unit_loc;
-    _mans = 0;
-    _bad = 0;
-    _squads = 0;
-    _squad_type = "";
-    _squad_loc = 0;
-    _squad_members = 0;
+    var _unit;
+    var _unit_loc;
+    var _squads = 0;
+    var _squad_type = "";
+    var _squad_loc = 0;
+    var _squad_members = 0;
     for (var v = 0; v < array_length(display_unit); v++) {
         if (!is_struct(display_unit[v])) {
             continue;
@@ -363,7 +361,6 @@ function other_manage_data() {
 }
 
 function filter_and_sort_company(type, specific) {
-    var i, j, limit;
     function switchy(a, b) {
         var tempman = man[a];
         var tempide = ide[a];
@@ -426,28 +423,22 @@ function filter_and_sort_company(type, specific) {
         squad[b] = temp_squad;
     }
     if (type == "stat") {
-        var swapped;
         with (obj_controller) {
-            for (i = 0; i < array_length(display_unit); i++) {
-                //if (man[i] != "man") continue;
-                swapped = false;
-                limit = array_length(display_unit) - i;
-                for (j = 0; j < limit - 1; j++) {
+            for (var i = 0; i < array_length(display_unit); i++) {
+                var limit = array_length(display_unit) - i;
+                for (var j = 0; j < limit - 1; j++) {
                     if (man[j] != "man") {
                         if (man[j + 1] == "man") {
                             switchy(j, j + 1);
-                            swapped = true;
                         }
                     } else {
                         if (man[j + 1] == "man") {
                             if (display_unit[j][$ specific] < display_unit[j + 1][$ specific]) {
                                 switchy(j, j + 1);
-                                swapped = true;
                             }
                         }
                     }
                 }
-                //if (swapped == false) then break;
             }
         }
     }
@@ -487,7 +478,6 @@ function switch_view_company(new_view) {
 }
 
 function company_manage_actions() {
-    var onceh = 0;
     var xx = camera_get_view_x(view_camera[0]);
     var yy = camera_get_view_y(view_camera[0]);
 

--- a/scripts/scr_draw_rainbow/scr_draw_rainbow.gml
+++ b/scripts/scr_draw_rainbow/scr_draw_rainbow.gml
@@ -2,9 +2,8 @@ function scr_draw_rainbow(x1, y1, x2, y2, colour_ratio) {
     // Draws a variable length and color rectangle based on a ratio of two variables
 
     with (obj_controller) {
-        var wid, rat;
-        wid = x2 - x1;
-        rat = colour_ratio;
+        var wid = x2 - x1;
+        var rat = colour_ratio;
 
         if ((menu != eMENU.DIPLOMACY) || (diplomacy != 0)) {
             if (colour_ratio <= 0.15) {

--- a/scripts/scr_income/scr_income.gml
+++ b/scripts/scr_income/scr_income.gml
@@ -1,3 +1,4 @@
+/// @self Asset.GMObject.obj_controller
 function scr_income() {
     // Determines income
 
@@ -20,14 +21,14 @@ function scr_income() {
         obj_controller.income_fleet -= escort_number / 10;
     }
     if (obj_ini.fleet_type == ePLAYER_BASE.HOME_WORLD) {
-        obj_controller.income_fleet = round(obj_controller.income_fleet / 2);
+        income_fleet = round(income_fleet / 2);
     }
 
     income_forge = 0;
     income_agri = 0;
     income_training = 0;
 
-    if (obj_controller.faction_status[eFACTION.MECHANICUS] != "War") {
+    if (faction_status[eFACTION.MECHANICUS] != "War") {
         var _chapter_tech_count = scr_role_count(obj_ini.role[100][eROLE.TECHMARINE], "");
         if (_chapter_tech_count >= ((disposition[3] / 2) + 5)) {
             training_techmarine = 0;
@@ -117,11 +118,11 @@ function scr_income() {
 
     if (obj_ini.fleet_type == ePLAYER_BASE.HOME_WORLD) {
         with (obj_star) {
-            if (planet_feature_bool(p_feature[1], eP_FEATURES.MONASTERY) == 1) {
+            if (planet_feature_bool(p_feature[1], eP_FEATURES.MONASTERY)) {
                 obj_controller.income += 10;
                 instance_create(x, y, obj_temp1);
             }
-            if (planet_feature_bool(p_feature[2], eP_FEATURES.MONASTERY) == 1) {
+            if (planet_feature_bool(p_feature[2], eP_FEATURES.MONASTERY)) {
                 obj_controller.income += 10;
                 instance_create(x, y, obj_temp1);
             }
@@ -135,12 +136,8 @@ function scr_income() {
     if (obj_ini.fleet_type != ePLAYER_BASE.HOME_WORLD) {
         with (obj_p_fleet) {
             if ((action == "") && (capital_number > 0)) {
-                var mine;
-                mine = instance_nearest(x, y, obj_star);
-                var i;
-                i = 0;
-                repeat (4) {
-                    i += 1;
+                var mine = instance_nearest(x, y, obj_star);
+                for (var i = 1; i <= 4; i++) {
                     if ((mine.p_owner[i] == eFACTION.IMPERIUM) || (mine.p_owner[i] == eFACTION.MECHANICUS)) {
                         if ((mine.p_type[i] == "Desert") || (mine.p_type[i] == "Temperate")) {
                             obj_controller.income_home += 2 * capital_number;
@@ -155,10 +152,7 @@ function scr_income() {
     }
 
     with (obj_star) {
-        var o;
-        o = 0;
-        repeat (4) {
-            o += 1;
+        for (var o = 1; o <= 4; o++) {
             if (dispo[o] >= 100) {
                 if (planet_feature_bool(p_feature[1], eP_FEATURES.MONASTERY) == 0) {
                     obj_controller.income_controlled_planets += 1;
@@ -177,6 +171,6 @@ function scr_income() {
         }
     }
 
-    obj_controller.alarm[4] = 10;
+    alarm[4] = 10;
     // This tells the controller to give moolah if it is the end of the turn
 }

--- a/scripts/scr_load_all/scr_load_all.gml
+++ b/scripts/scr_load_all/scr_load_all.gml
@@ -1,12 +1,11 @@
+/// @self Asset.GMObject.obj_controller
 function scr_load_all(select_units) {
-    var sell = "", unit;
-
     // Load / Select All
     if (select_units) {
         man_size = 0;
         // This sets the maximum size of marines in a company to 200 size
         for (var i = 0; i < array_length(display_unit); i++) {
-            unit = display_unit[i];
+            var unit = display_unit[i];
             if (is_struct(unit)) {
                 if ((man[i] == "man") && (ma_loc[i] == selecting_location) && (ma_wid[i] == selecting_planet) && (ma_god[i] < 10)) {
                     if (unit.assignment() == "none") {
@@ -15,7 +14,6 @@ function scr_load_all(select_units) {
                     }
                 }
             } else if (is_array(unit)) {
-                //if (i<=200){
                 if ((man[i] == "vehicle") && (ma_loc[i] == selecting_location) && (ma_wid[i] == selecting_planet)) {
                     man_sel[i] = 1;
                     if (selecting_location == "") {
@@ -26,7 +24,6 @@ function scr_load_all(select_units) {
                     man_size += scr_unit_size("", ma_role[i], true);
                 }
             }
-            //}
         }
     }
     // Unload / Unselect All

--- a/scripts/scr_mission_functions/scr_mission_functions.gml
+++ b/scripts/scr_mission_functions/scr_mission_functions.gml
@@ -981,7 +981,7 @@ function add_new_problem(planet, problem, timer, star = noone, other_data = {}) 
                 p_problem[planet][i] = problem;
                 p_problem_other_data[planet][i] = other_data;
                 p_timer[planet][i] = timer;
-                problem_added = i;
+                problem_added = bool(i);
                 break;
             }
         }

--- a/scripts/scr_mission_functions/scr_mission_functions.gml
+++ b/scripts/scr_mission_functions/scr_mission_functions.gml
@@ -1,6 +1,3 @@
-// Script assets have changed for v2.3.0 see
-// https://help.yoyogames.com/hc/en-us/articles/360005277377 for more information
-
 function MissionHandler(planet, system) : PlanetData(planet, system) constructor {}
 
 function location_out_of_player_control(unit_loc) {
@@ -206,7 +203,6 @@ function problem_end_turn_checks(){
                 awaken_tomb_world(features);
             }
             remove_problem("necron");
-            // scr_alert("red","mission_failed",_alert_text,0,0);
         },
 
         "spyrer" : function(problem_index){
@@ -331,7 +327,6 @@ function scr_new_governor_mission(planet, problem = "") {
 }
 
 function init_marine_acting_strange() {
-    LOGGER.info("RE: Strange Behavior");
     var marine_and_company = scr_random_marine("", 0);
     if (marine_and_company == "none") {
         LOGGER.error("RE: Strange Behavior, couldn't pick a space marine");
@@ -359,12 +354,10 @@ function init_garrison_mission(planet, star, mission_slot) {
         mission_data.stage = "active";
         var garrison_length = 10 + irandom(6);
         star.p_timer[planet][mission_slot] = garrison_length;
-        //pop.image="ancient_ruins";
         var gar_pop = instance_create(0, 0, obj_popup);
         //TODO some new universal methods for popups
         gar_pop.title = $"Requested Garrison Provided to {numeral_name}";
         gar_pop.text = $"The governor of {numeral_name} Thanks you for considering his request for a garrison, you agree that the garrison will remain for at least {garrison_length} months.";
-        //pip.image="event_march"
         gar_pop.add_option("Commence Garrison");
         gar_pop.image = "";
         gar_pop.cooldown = 8;
@@ -381,12 +374,10 @@ function init_beast_hunt_mission(planet, star, mission_slot) {
         mission_data.stage = "active";
         var _mission_length = irandom_range(2, 5);
         star.p_timer[planet][mission_slot] = _mission_length;
-        //pop.image="ancient_ruins";
         var gar_pop = instance_create(0, 0, obj_popup);
         //TODO some new universal methods for popups
         gar_pop.title = $"Marines assigned to hunt beasts around {numeral_name}";
         gar_pop.text = $"The govornor of {numeral_name} Thanks you for the participation of your elite warriors in your execution of such a menial task.";
-        //pip.image="event_march"
         gar_pop.add_option("Happy Hunting");
         gar_pop.image = "";
         gar_pop.cooldown = 8;
@@ -416,14 +407,12 @@ function init_protect_raider_mission(squad) {
     var _wis_test = _tester.standard_test(_leader, "wisdom", _mod, ["ambush"]);
 
     if (!_wis_test[0]) {
-        var _mission_data = variable_clone(selection_data);
         if (_wis_test[1] < -25) {
             scr_toggle_manage();
             var gar_pop = instance_create(0, 0, obj_popup);
             gar_pop.title = $"Strange Disappearance";
             gar_pop.pdata = _pdata;
             gar_pop.text = $"Your Marines make planet fall and are directed to report to the governor for the duration of the operation after a period of reconnaissance dig in for their ambush. After a two weeks have passed A message from the governor reaches your astropaths that your marines have not been heard of for some time, The raiders also were not noted to have arrived onor left the planet";
-            //pip.image="event_march"
             var _dead_marine = array_random_index(_squad_units);
             for (var i = 0; i < array_length(_dead_marine); i++) {
                 if (i == _dead_marine) {
@@ -448,8 +437,6 @@ function init_protect_raider_mission(squad) {
             var gar_pop = instance_create(0, 0, obj_popup);
             gar_pop.title = $"Ineffective Ambush";
             gar_pop.text = $"Your Marines Are ineffective at setting up an ambush the assailants clearly got wind of the operation or the plan was otherwise so ill thought out that by the time your forces arrived there was little that could be done to intercept them";
-            //pip.image="event_march"
-            //var _dead_marine = array_random_index(_squad_units);
             gar_pop.text += $"";
             gar_pop.pathway = "protect_raiders_ineffective";
             gar_pop.pdata = _pdata;
@@ -810,12 +797,6 @@ function planet_problemless(planet, star = noone) {
     return _problemless;
 }
 
-/*
-//may not be needed but will be a loop of planet_problemless
-function star_problemless(){
-
-}*/
-
 // returns a bool for if any planet on a given star has the given problem
 /// @self Asset.GMObject.obj_star
 function has_problem_star(problem, star = noone) {
@@ -824,7 +805,7 @@ function has_problem_star(problem, star = noone) {
         for (var i = 1; i <= planets; i++) {
             has_problem = has_problem_planet(i, problem);
             if (has_problem) {
-                has_problem = i;
+                has_problem = true;
                 break;
             }
         }
@@ -908,7 +889,7 @@ function find_problem_planet(planet, problem, star = noone) {
 ///removie all of a given problem from a planet
 /// @self Asset.GMObject.obj_star
 function remove_planet_problem(planet, problem, star = noone) {
-    var _had_problem = -1;
+    var _had_problem = false;
     if (star == noone) {
         for (var i = 0; i < array_length(p_problem[planet]); i++) {
             if (p_problem[planet][i] == problem) {
@@ -923,7 +904,7 @@ function remove_planet_problem(planet, problem, star = noone) {
             _had_problem = remove_planet_problem(planet, problem);
         }
     }
-    return -1;
+    return _had_problem;
 }
 
 //find an open problem slot on a given planet
@@ -981,7 +962,7 @@ function add_new_problem(planet, problem, timer, star = noone, other_data = {}) 
                 p_problem[planet][i] = problem;
                 p_problem_other_data[planet][i] = other_data;
                 p_timer[planet][i] = timer;
-                problem_added = bool(i);
+                problem_added = true;
                 break;
             }
         }

--- a/scripts/scr_random_find/scr_random_find.gml
+++ b/scripts/scr_random_find/scr_random_find.gml
@@ -1,6 +1,5 @@
 function scr_random_find(owner, is_planet, ship_action, feature) {
     // This returns a star or fleet instanceID
-
     if (is_planet && instance_exists(obj_star)) {
         var stars = [];
         with (obj_star) {
@@ -16,8 +15,6 @@ function scr_random_find(owner, is_planet, ship_action, feature) {
             var star_index = irandom(array_length(stars) - 1);
             var star = stars[star_index];
             return star; // use that to get the obj
-        } else {
-            return noone;
         }
     } else if (!is_planet && instance_exists(obj_all_fleet)) {
         var ships = [];
@@ -34,10 +31,7 @@ function scr_random_find(owner, is_planet, ship_action, feature) {
             var ship_index = irandom(array_length(ships) - 1);
             var ship = ships[ship_index];
             return ship;
-        } else {
-            return noone;
         }
-    } else {
-        return noone; //?? I think it would return that regardless
     }
+    return noone;
 }

--- a/scripts/scr_random_marine/scr_random_marine.gml
+++ b/scripts/scr_random_marine/scr_random_marine.gml
@@ -18,7 +18,7 @@ function scr_random_marine(role, exp_req, search_params = {}) {
     if (!is_array(role) && role == SPECIALISTS_LIBRARIANS) {
         role = role_groups(SPECIALISTS_LIBRARIANS);
     }
-    for (var comp_shuffle = 0; comp_shuffle < 11; comp_shuffle++) {
+    for (var comp_shuffle = 0; comp_shuffle <= 10; comp_shuffle++) {
         // this ensures that companies are searched randomly
         var new_comp = irandom(array_length(company_list) - 1);
         var company = company_list[new_comp];
@@ -94,7 +94,7 @@ function scr_random_marine(role, exp_req, search_params = {}) {
                     //if searching for marines with particular traits
                     if (struct_exists(search_params, "trait")) {
                         //list of traits (all required) need an option for if only one is required
-                        if (is_array(search_params[$ "trait"])) {
+                        if (is_array(search_params.trait)) {
                             if (!struct_exists(search_params, "trait_any")) {
                                 for (var trait = 0; trait < array_length(search_params[$ "trait"]); trait++) {
                                     if (!array_contains(unit.traits, search_params[$ "trait"][trait])) {
@@ -137,22 +137,22 @@ function scr_random_marine(role, exp_req, search_params = {}) {
                         match = false;
                         switch (search_params.role_tag) {
                             case "Techmarine":
-                                if (unit.role_tag[eROLE_TAG.Techmarine] == true) {
+                                if (unit.role_tag[eROLE_TAG.Techmarine]) {
                                     match = true;
                                 }
                                 break;
                             case "Librarian":
-                                if (unit.role_tag[eROLE_TAG.Librarian] == true) {
+                                if (unit.role_tag[eROLE_TAG.Librarian]) {
                                     match = true;
                                 }
                                 break;
                             case "Chaplain":
-                                if (unit.role_tag[eROLE_TAG.Chaplain] == true) {
+                                if (unit.role_tag[eROLE_TAG.Chaplain]) {
                                     match = true;
                                 }
                                 break;
                             case "Apothecary":
-                                if (unit.role_tag[eROLE_TAG.Apothecary] == true) {
+                                if (unit.role_tag[eROLE_TAG.Apothecary]) {
                                     match = true;
                                 }
                                 break;
@@ -185,6 +185,5 @@ function scr_random_marine(role, exp_req, search_params = {}) {
             }
         }
     }
-
     return "none";
 }


### PR DESCRIPTION
Just whatever I find I guess, as long as it's nothing bigger than a few lines each. Bot summarize it or whatever.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors PlanetData, mission/problem helpers, save/load UI, and company management view to use enums, booleans, and named colors, and simplifies battle sorting, random selection, and income logic. Fixes type checks and normalizes return values to reduce edge-case errors.

- **Refactors**
  - Planet logic: consistent `eFACTION` indexing for forces/ownership/status; default `guard_score` 0.5; clamp fleet strength with `max()`; correct player→Imperium transfer on depopulation; presence checks use `present_fleet[eFACTION.*]`; `name()` inlines; `assasinate_governor` discovery uses a single threshold.
  - Save/Load UI: use `eMENU.DEFAULT`; `hide` is boolean; use `c_black` and plain strings for labels/slot IDs; tidy disposition bar width/visibility; minor draw helpers cleanup.
  - Company view: localized variables, removed unused state, and simplified selection/sorting loops for unit and vehicle management.
  - Missions/Problems: `PlanetData.has_problem` returns underlying result; small cleanups and removed noise logs; simplified necron logic.
  - Systems: `scr_battle_sort` loop simplified to prioritize space battles; `scr_random_find` single return path with `noone` fallback; `scr_income` HOME_WORLD halving on `income_fleet`, boolean feature checks, simpler loops, and direct `alarm[4]` set; `scr_draw_rainbow` var cleanup; `scr_load_all` clarifies unit scoping.
  - Annotations: added `@self` on `obj_star` and `obj_controller`.

- **Bug Fixes**
  - Problem API returns booleans: `add_new_problem`, `remove_planet_problem`, and `has_problem_star` now return true/false.
  - Type enforcement: `is_specialist` doc param is String and Chapter Master role is stringified; `scr_random_marine` fixes loop bounds, uses `search_params.trait`, and truthy `role_tag` checks.
  - Faction lookups: guard/war checks use `eFACTION` keys (e.g., `faction_status[eFACTION.IMPERIUM]`); fixes incorrect indices.
  - Robust flows: `init_marine_acting_strange` handles missing marine and exits cleanly.

<sup>Written for commit 16fe5a5b5be99817054a7a649c0de3b4dc6a727d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

