### PR TITLE
fix: Iron Halo centered for Terminators

### DIFF
--- a/scripts/scr_draw_unit_image/scr_draw_unit_image.gml
+++ b/scripts/scr_draw_unit_image/scr_draw_unit_image.gml
@@ -404,6 +404,7 @@ function scr_draw_unit_image(_background = false) {
 
                 // Draw the Iron Halo
                 if (halo == 1 && !halo_bypass) {
+					var halo_offset_x = 0;
                     var halo_offset_y = 0;
                     var halo_color = 0;
                     var halo_type = 2;
@@ -412,12 +413,14 @@ function scr_draw_unit_image(_background = false) {
                     }
                     if (unit_armour == "Terminator Armour") {
                         halo_type = 2;
+						halo_offset_x += 7
                         halo_offset_y -= 20;
                     } else if (unit_armour == "Tartaros") {
                         halo_type = 2;
+						halo_offset_x += 7
                         halo_offset_y -= 20;
                     }
-                    draw_sprite(spr_gear_halo, halo_type + halo_color, x_surface_offset, y_surface_offset + halo_offset_y);
+                    draw_sprite(spr_gear_halo, halo_type + halo_color, x_surface_offset + halo_offset_x, y_surface_offset + halo_offset_y);
                 }
                 if (armour_type == eARMOUR_TYPE.NORMAL && (!robes_bypass || !robes_hood_bypass)) {
                     var robe_offset_x = 0;


### PR DESCRIPTION
properly aligned to the center

tested by boot and look

<!--- YOU CAN DELETE ALL OF THIS AFTER READING. -->

<!--- Make use of markdown lists. They make stuff much easier to read through. -->
<!--- Explain why and what your changes do in simple terms. --->
<!--- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. --->

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->

<!--- "Inspired" by the CDDA PR template -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centers the Iron Halo for units in Terminator and Tartaros armour by adding a horizontal offset and drawing at the adjusted position. Fixes the halo appearing off-center above these units.

- **Bug Fixes**
  - Introduced halo_offset_x and set +7 for Terminator and Tartaros armour; kept existing -20 y offset.
  - Updated draw_sprite to use x_surface_offset + halo_offset_x for correct centering.

<sup>Written for commit 9d7fd46b90f58c0aa36287e630aa04e9182ca172. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

