### PR TITLE
fix: Restore obj_cursor/Draw_0 to fix phantom cursor

### DIFF
--- a/objects/obj_cursor/Draw_0.gml
+++ b/objects/obj_cursor/Draw_0.gml
@@ -1,0 +1,6 @@
+// INTENTIONALLY EMPTY DO NOT DELETE.
+// If an object has no Draw event, GameMaker auto-draws its sprite at
+// (x, y) in room coordinates. This object sets x/y to GUI mouse coords
+// and draws itself in Draw GUI (Draw_64.gml) instead, so the default
+// draw would render a second phantom cursor on the sector map.
+// This empty event exists solely to suppress the engine's default draw.

--- a/objects/obj_cursor/obj_cursor.yy
+++ b/objects/obj_cursor/obj_cursor.yy
@@ -5,6 +5,7 @@
     {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":0,"eventType":0,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
     {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":1,"eventType":3,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
     {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":64,"eventType":8,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
+    {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":0,"eventType":8,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
   ],
   "managed":true,
   "name":"obj_cursor",


### PR DESCRIPTION
Fixes the tiny second mouse pointer on the sector map introduced by commit 191d189, which removed obj_cursor's empty Draw event as dead code. It was not dead code: in GameMaker, an object with no Draw event gets its `sprite_index` auto-drawn by the engine at `(x, y)` in room coordinates. obj_cursor stores GUI mouse coords in `x`/`y` and draws itself in Draw GUI (`Draw_64.gml`), so the default draw rendered a phantom cursor through the sector map camera – tiny, offset top-left, mirroring the real pointer. `rm_main_menu`, `rm_creation`, and `rm_defeat` also had the phantom cursor rendering but their view is 1:1 with the GUI so the phantom hid under the real cursor.

* Bug Fixes
   * Restore `objects/obj_cursor/Draw_0.gml` and its event entry in `obj_cursor.yy`. The empty Draw event's existence is what suppresses GameMaker's default world-space draw.
   * Rewrite the `Draw_0.gml` comment to say the event is intentionally empty and explain the mechanism, so any future dead-code pass (hopefully) doesn't delete it again.
* Audit of other Draw events deleted by 191d189 for similar issues
   * `obj_img`, `obj_mass_equip`, and `obj_temp8` have spriteId: null and no runtime sprite_index assignment, so the default draw correctly renders nothing for them.
   * `obj_duel`: object removed entirely by that commit and has zero remaining references.

* Testing
   * `git diff 191d189^ -- objects/obj_cursor/` shows only the new comment text in `Draw_0.gml`; `obj_cursor.yy` is identical to its pre-191d189 state.
   * Ran the game: panned and zoomed the sector map and there is only one cursor again.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores `obj_cursor`’s empty Draw event to suppress GameMaker’s default world-space draw and remove the tiny phantom cursor on the sector map. The cursor now renders only in Draw GUI as intended.

- **Bug Fixes**
  - Brought back the empty `Draw_0.gml` for `obj_cursor` and its event entry in `obj_cursor.yy` to disable engine auto-draw.
  - Added a clear comment explaining why this event must stay empty.
  - Audited other removed Draw events: `obj_img`, `obj_mass_equip`, and `obj_temp8` are safe (no sprite); `obj_duel` was fully removed.

<sup>Written for commit 073876560af0bf4a70f9d78ccdc37de8a0dbb097. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

