### PR TITLE
fix: Planet ownership flip; Fleet orbiting; Purge world error

### DIFF
--- a/objects/obj_bomb_select/Alarm_1.gml
+++ b/objects/obj_bomb_select/Alarm_1.gml
@@ -133,7 +133,7 @@ if ((traitors > ork) && (traitors >= chaos) && (traitors > eldar) && (traitors >
 if ((necrons > ork) && (necrons >= chaos) && (necrons > eldar) && (necrons > tau) && (necrons > tyranids) && (necrons > traitors)) {
     target = 13;
 }
-if (p_target.p_owner[obj_controller.selecting_planet] == 8) {
+if (p_target.p_owner[obj_controller.selecting_planet] == eFACTION.TAU) {
     if ((pdf > chaos) && (pdf > traitors) && (pdf > eldar) && (pdf > ork) && (pdf > tyranids) && (pdf > tau) && (pdf > necrons)) {
         target = 2.5;
     }

--- a/objects/obj_bomb_select/Draw_0.gml
+++ b/objects/obj_bomb_select/Draw_0.gml
@@ -55,7 +55,7 @@ if ((max_ships > 0) && instance_exists(obj_star_select)) {
                 t_name = "Imperial Forces";
                 break;
             case 2.5:
-                if (p_target.p_owner[obj_controller.selecting_planet] == 8) {
+                if (p_target.p_owner[obj_controller.selecting_planet] == eFACTION.TAU) {
                     t_name = "Gue'la Forces";
                 } else {
                     t_name = "PDF";

--- a/objects/obj_controller/Alarm_1.gml
+++ b/objects/obj_controller/Alarm_1.gml
@@ -335,7 +335,7 @@ if (did) {
         with (_current_system) {
             if ((planets > 0) && (owner == eFACTION.IMPERIUM)) {
                 planet[1] = 1;
-                p_owner[1] = 10;
+                p_owner[1] = eFACTION.CHAOS;
                 owner = eFACTION.CHAOS;
             }
         }
@@ -425,7 +425,7 @@ if (did) {
             _current_system = _imperial_planets[i];
 
             _current_system.planet[1] = 1;
-            _current_system.p_owner[1] = 9;
+            _current_system.p_owner[1] = eFACTION.TYRANIDS;
             _current_system.owner = eFACTION.TYRANIDS;
 
             array_delete(_imperial_planets, i, 1);
@@ -436,7 +436,7 @@ if (did) {
         if (is_dead_star() || planets == 0) {
             continue;
         }
-        if (owner <= 5) {
+        if (owner <= eFACTION.ECCLESIARCHY) {
             array_push(_non_xenos_chaos, id);
         }
     }

--- a/objects/obj_controller/Alarm_8.gml
+++ b/objects/obj_controller/Alarm_8.gml
@@ -8,26 +8,26 @@ if ((faction_gender[10] == 1) && (known[eFACTION.CHAOS] == 0) && (faction_defeat
 }
 
 with (obj_star) {
-    if ((p_owner[1] == 1) || (p_owner[2] == 1) || (p_owner[3] == 1) || (p_owner[4] == 1)) {
+    if ((p_owner[1] == eFACTION.PLAYER) || (p_owner[2] == eFACTION.PLAYER) || (p_owner[3] == eFACTION.PLAYER) || (p_owner[4] == eFACTION.PLAYER)) {
         var heh = instance_create(x, y, obj_crusade);
         heh.radius = 64;
         heh.duration = 9999;
         heh.show = false;
         heh.placing = false;
         heh.alarm[1] = -1;
-        if (p_owner[1] == 1) {
+        if (p_owner[1] == eFACTION.PLAYER) {
             p_pdf[1] += p_guardsmen[1];
             p_guardsmen[1] = 0;
         }
-        if (p_owner[2] == 1) {
+        if (p_owner[2] == eFACTION.PLAYER) {
             p_pdf[2] += p_guardsmen[2];
             p_guardsmen[2] = 0;
         }
-        if (p_owner[3] == 1) {
+        if (p_owner[3] == eFACTION.PLAYER) {
             p_pdf[3] += p_guardsmen[3];
             p_guardsmen[3] = 0;
         }
-        if (p_owner[4] == 1) {
+        if (p_owner[4] == eFACTION.PLAYER) {
             p_pdf[4] += p_guardsmen[4];
             p_guardsmen[4] = 0;
         }

--- a/objects/obj_en_fleet/Alarm_1.gml
+++ b/objects/obj_en_fleet/Alarm_1.gml
@@ -52,10 +52,10 @@ try {
 
         if ((orbiting.owner == eFACTION.PLAYER) && (obj_controller.faction_status[eFACTION.IMPERIUM] == "War") && (owner == eFACTION.IMPERIUM)) {
             for (var i = 1; i <= orbiting.planets; i++) {
-                if (orbiting.p_owner[i] == 1) {
+                if (orbiting.p_owner[i] == eFACTION.PLAYER) {
                     orbiting.p_pdf[i] -= capital_number * 50000;
                 }
-                if (orbiting.p_owner[i] == 1) {
+                if (orbiting.p_owner[i] == eFACTION.PLAYER) {
                     orbiting.p_pdf[i] -= frigate_number * 10000;
                 }
                 if (orbiting.p_pdf[i] < 0) {
@@ -139,7 +139,7 @@ try {
                     scr_loyalty("Xeno Associate", "+");
                 }
 
-                if ((orbiting.p_owner[2] == 1) && (orbiting.p_heresy[2] >= 60)) {
+                if ((orbiting.p_owner[2] == eFACTION.PLAYER) && (orbiting.p_heresy[2] >= 60)) {
                     scr_loyalty("Heretic Homeworld", "+");
                 }
 

--- a/objects/obj_en_fleet/Create_0.gml
+++ b/objects/obj_en_fleet/Create_0.gml
@@ -89,12 +89,14 @@ serialize = function() {
         x,
         y,
         cargo_data: cargo_data,
+        orbiting: instance_exists(orbiting) ? true : false,
     };
 
     var excluded_from_save = [
         "temp",
         "serialize",
-        "deserialize"
+        "deserialize",
+        "orbiting",
     ];
 
     copy_serializable_fields(object_fleet, save_data, excluded_from_save);
@@ -104,7 +106,8 @@ serialize = function() {
 deserialize = function(save_data) {
     var exclusions = [
         "id",
-        "cargo_data"
+        "cargo_data",
+        "orbiting",
     ]; // skip automatic setting of certain vars, handle explicitly later
 
     // Automatic var setting
@@ -131,7 +134,7 @@ deserialize = function(save_data) {
         }
     }
 
-    if (save_data.orbiting != noone && action == "") {
+    if (save_data.orbiting && (save_data.orbiting != noone)) {
         orbiting = instance_nearest(x, y, obj_star);
     }
 };

--- a/objects/obj_ground_mission/Alarm_5.gml
+++ b/objects/obj_ground_mission/Alarm_5.gml
@@ -10,7 +10,7 @@ mission_roll = floor(random(100)) + 1;
 if (scr_has_adv("Ambushers")) {
     mission_roll -= 15;
 }
-if (plan.p_owner[num] == 3) {
+if (plan.p_owner[num] == eFACTION.MECHANICUS) {
     mission_roll += 20;
 }
 if (mission_roll <= 60) {
@@ -26,26 +26,26 @@ pop = instance_create(0, 0, obj_popup);
 pop.image = "artifact_recovered";
 pop.title = "STC Recovered!";
 
-if ((plan.p_first[num] != 3) || (plan.p_type[num] != "Forge")) {
+if ((plan.p_first[num] != eFACTION.MECHANICUS) || (plan.p_type[num] != "Forge")) {
     pop.text = "Your forces descend beneath the surface of the planet, delving deep into an ancient tomb.  Automated defenses and locks are breached.##";
     pop.text += "The STC Fragment has been safely stowed away, and is ready to be decrypted or gifted at your convenience.";
     scr_return_ship(loc, self, num);
 }
 
-if ((mission == "good") && (plan.p_first[num] == 3) && (plan.p_type[num] == "Forge")) {
+if ((mission == "good") && (plan.p_first[num] == eFACTION.MECHANICUS) && (plan.p_type[num] == "Forge")) {
     pop.text = "Your forces descend into the vaults of the Mechanicus Forge, bypassing sentries, automated defenses, and blast doors on the way.##";
     pop.text += "The STC Fragment has been safely recovered and stowed away.  It is ready to be decrypted or gifted at your convenience.";
 
     /*if (plan.p_type[num]!="Dead"){
-        if (plan.p_owner[num]=2) then obj_controller.disposition[2]-=1;
-        if (plan.p_owner[num]=3) then obj_controller.disposition[3]-=10;// max(obj_controller.disposition/4,10)
-        if (plan.p_owner[num]=4) then obj_controller.disposition[4]-=max(obj_controller.disposition[4]/4,10);
-        if (plan.p_owner[num]=5) then obj_controller.disposition[5]-=3;
-        if (plan.p_owner[num]=8) then obj_controller.disposition[8]-=3;
+        if (plan.p_owner[num]=eFACTION.IMPERIUM) then obj_controller.disposition[2]-=1;
+        if (plan.p_owner[num]=eFACTION.MECHANICUS) then obj_controller.disposition[3]-=10;
+        if (plan.p_owner[num]=eFACTION.INQUISITION) then obj_controller.disposition[4]-=max(obj_controller.disposition[4]/4,10);
+        if (plan.p_owner[num]=eFACTION.ECCLESIARCHY) then obj_controller.disposition[5]-=3;
+        if (plan.p_owner[num]=eFACTION.TAU) then obj_controller.disposition[8]-=3;
     }*/
     scr_return_ship(loc, self, num);
 }
-if ((mission == "bad") && (plan.p_first[num] == 3) && (plan.p_type[num] == "Forge")) {
+if ((mission == "bad") && (plan.p_first[num] == eFACTION.MECHANICUS) && (plan.p_type[num] == "Forge")) {
     /*pop.text="Your marines converge upon the STC Fragment; resistance is light and easily dealt with.  After a brief firefight it is retrieved.##";
     pop.text+="The fragment been safely stowed away, and is ready to be decrypted or gifted at your convenience.";
 
@@ -55,19 +55,19 @@ if ((mission == "bad") && (plan.p_first[num] == 3) && (plan.p_type[num] == "Forg
     pop.text = "Your forces descend into the vaults of the Mechanicus Forge.  Sentries, automated defenses, and blast doors stand in their way.##";
     pop.text += "Half-way through the mission a small army of Praetorian Servitors and Skitarii bear down upon your men.  The Mechanicus guards seem to be upset.";
 
-    /*if (plan.p_owner[num]=2) then obj_controller.disposition[2]-=2;*/
-    if (plan.p_owner[num] == 3) {
+    /*if (plan.p_owner[num]=eFACTION.IMPERIUM) then obj_controller.disposition[2]-=2;*/
+    if (plan.p_owner[num] == eFACTION.MECHANICUS) {
         obj_controller.disposition[3] -= 40;
     }
-    /*if (plan.p_owner[num]=4) then obj_controller.disposition[4]-=max(obj_controller.disposition[4]/3,20);
-    if (plan.p_owner[num]=5) then obj_controller.disposition[5]-=max(obj_controller.disposition[3]/4,15);
-    if (plan.p_owner[num]=6) then obj_controller.disposition[6]-=15;
-    if (plan.p_owner[num]=8) then obj_controller.disposition[8]-=8;*/
+    /*if (plan.p_owner[num]=eFACTION.INQUISITION) then obj_controller.disposition[4]-=max(obj_controller.disposition[4]/3,20);
+    if (plan.p_owner[num]=eFACTION.ECCLESIARCHY) then obj_controller.disposition[5]-=max(obj_controller.disposition[3]/4,15);
+    if (plan.p_owner[num]=eFACTION.ELDAR) then obj_controller.disposition[6]-=15;
+    if (plan.p_owner[num]=eFACTION.TAU) then obj_controller.disposition[8]-=8;*/
 
-    if ((plan.p_owner[num] > 3) && (plan.p_owner[num] <= 6)) {
+    if ((plan.p_owner[num] > eFACTION.MECHANICUS) && (plan.p_owner[num] <= eFACTION.ELDAR)) {
         scr_audience(plan.p_owner[num], "artifact_angry",);
     }
-    if ((plan.p_owner[num] == 3) && (obj_controller.faction_status[eFACTION.MECHANICUS] != "War")) {
+    if ((plan.p_owner[num] == eFACTION.MECHANICUS) && (obj_controller.faction_status[eFACTION.MECHANICUS] != "War")) {
         scr_audience(plan.p_owner[num], "declare_war", -20);
     }
 
@@ -95,7 +95,7 @@ if (scr_has_adv("Tech-Scavengers")) {
     var stah;
     stah = instance_nearest(x, y, obj_star);
 
-    if (stah.p_first[num] == 2) {
+    if (stah.p_first[num] == eFACTION.IMPERIUM) {
         ex1 = "Meltagun";
         ex1_num = choose(2, 3, 4);
         ex2 = "Flamer";
@@ -103,7 +103,7 @@ if (scr_has_adv("Tech-Scavengers")) {
         ex3 = choose("Power Fist", "Chainsword", "Bolt Pistol");
         ex3_num = choose(2, 3, 4, 5);
     }
-    if (stah.p_first[num] == 3) {
+    if (stah.p_first[num] == eFACTION.MECHANICUS) {
         ex1 = "Plasma Pistol";
         ex1_num = choose(1, 2);
         ex2 = "Power Armour";
@@ -111,7 +111,7 @@ if (scr_has_adv("Tech-Scavengers")) {
         ex3 = choose("Servo-arm", "Bionics");
         ex3_num = choose(2, 3, 4);
     }
-    if (stah.p_first[num] == 5) {
+    if (stah.p_first[num] == eFACTION.ECCLESIARCHY) {
         ex1 = "Flamer";
         ex1_num = choose(3, 4, 5, 6);
         ex2 = "Heavy Flamer";

--- a/objects/obj_ncombat/Alarm_5.gml
+++ b/objects/obj_ncombat/Alarm_5.gml
@@ -460,10 +460,10 @@ if (defeat == 0 && _reduce_power) {
                     adjust_influence(eFACTION.TYRANIDS, -25, battle_planet, id);
                 }
                 if (make_alert) {
-                    if (p_first[battle_planet] == 1) {
+                    if (p_first[battle_planet] == eFACTION.PLAYER) {
                         who_return = "your";
                         p_owner[battle_planet] = eFACTION.PLAYER;
-                    } else if (p_first[battle_planet] == 3 || p_type[battle_planet] == "Forge") {
+                    } else if (p_first[battle_planet] == eFACTION.MECHANICUS || p_type[battle_planet] == "Forge") {
                         who_return = "mechanicus";
                         obj_controller.disposition[3] += 10;
                         p_owner[battle_planet] = eFACTION.MECHANICUS;

--- a/objects/obj_ncombat/Alarm_5.gml
+++ b/objects/obj_ncombat/Alarm_5.gml
@@ -474,12 +474,9 @@ if (defeat == 0 && _reduce_power) {
                         }
                         p_owner[battle_planet] = eFACTION.IMPERIUM;
                     }
-                    dispo[battle_planet] += 10;
+                    scr_gov_disp(name, battle_planet, 10);
                     scr_event_log("", $"{who_cleansed} cleansed from {planet_string}", name);
                     scr_alert("green", "owner", $"{who_cleansed} cleansed from {planet_string}. Control returned to {who_return}", x, y);
-                    if (dispo[battle_planet] >= 101) {
-                        p_owner[battle_planet] = 1;
-                    }
                 }
             }
         }

--- a/objects/obj_ncombat/Alarm_7.gml
+++ b/objects/obj_ncombat/Alarm_7.gml
@@ -120,7 +120,7 @@ try {
             battle_object.p_traitors[battle_id] = 6;
             battle_object.p_chaos[battle_id] = 4;
             battle_object.p_pdf[battle_id] = 0;
-            battle_object.p_owner[battle_id] = 10;
+            battle_object.p_owner[battle_id] = eFACTION.CHAOS;
 
             var corro = 0;
 
@@ -128,10 +128,10 @@ try {
                 if (corro <= 5) {
                     var moar = instance_nearest(ox, oy, obj_star);
 
-                    if (moar.owner <= 3) {
+                    if (moar.owner <= eFACTION.MECHANICUS) {
                         corro += 1;
                         for (var i = 1; i <= 4; i++) {
-                            if (moar.p_owner[i] <= 3) {
+                            if (moar.p_owner[i] <= eFACTION.MECHANICUS) {
                                 moar.p_heresy[i] = min(100, moar.p_heresy[i] + floor(random_range(30, 50)));
                             }
                         }

--- a/objects/obj_p_fleet/Alarm_1.gml
+++ b/objects/obj_p_fleet/Alarm_1.gml
@@ -88,7 +88,7 @@ try {
 
             meet_system_governors(steh);
 
-            if ((steh.p_owner[1] == 5) || (steh.p_owner[2] == 5) || (steh.p_owner[3] == 5) || (steh.p_owner[4] == 5)) {
+            if ((steh.p_owner[1] == eFACTION.ECCLESIARCHY) || (steh.p_owner[2] == eFACTION.ECCLESIARCHY) || (steh.p_owner[3] == eFACTION.ECCLESIARCHY) || (steh.p_owner[4] == eFACTION.ECCLESIARCHY)) {
                 if ((obj_controller.faction_defeated[5] == 0) && (obj_controller.known[eFACTION.ECCLESIARCHY] == 0)) {
                     obj_controller.known[eFACTION.ECCLESIARCHY] = 1;
                 }

--- a/objects/obj_p_fleet/Create_0.gml
+++ b/objects/obj_p_fleet/Create_0.gml
@@ -3,6 +3,7 @@ capital_number = 0;
 frigate_number = 0;
 escort_number = 0;
 selected = 0;
+/// @type {Id.Instance.obj_star}
 orbiting = noone;
 warp_able = true;
 ii_check = choose(8, 9, 10, 11, 12);
@@ -11,7 +12,7 @@ var wop = instance_nearest(x, y, obj_star);
 if (instance_exists(wop) && (y > 0) && (x > 0)) {
     if (point_distance(x, y, wop.x, wop.y) <= 40) {
         orbiting = wop;
-        wop.present_fleet[1] += 1;
+        orbiting.present_fleet[1] += 1;
     }
 }
 
@@ -63,11 +64,13 @@ serialize = function() {
         x,
         y,
         point_breakdown: point_breakdown,
+        orbiting: instance_exists(orbiting) ? true : false,
     };
     var excluded_from_save = [
         "temp",
         "serialize",
-        "deserialize"
+        "deserialize",
+        "orbiting",
     ];
 
     copy_serializable_fields(object_fleet, save_data, excluded_from_save);
@@ -94,7 +97,7 @@ deserialize = function(save_data) {
         }
     }
 
-    if (save_data.orbiting != noone) {
+    if (save_data.orbiting && (save_data.orbiting != noone)) {
         var nearest_star = instance_nearest(x, y, obj_star);
         set_player_fleet_image();
         orbiting = nearest_star;

--- a/objects/obj_star/Alarm_0.gml
+++ b/objects/obj_star/Alarm_0.gml
@@ -30,8 +30,8 @@ if (obj_controller.craftworld && (space_hulk == 0)) {
     planets = 1;
     p_type[1] = "Craftworld";
     heresy = -999;
-    p_owner[1] = 6;
-    p_first[1] = 6;
+    p_owner[1] = eFACTION.ELDAR;
+    p_first[1] = eFACTION.ELDAR;
     owner = eFACTION.ELDAR;
     p_population[1] = floor(random_range(150000, 300000));
     p_fortified[1] = 6;
@@ -49,7 +49,7 @@ if (space_hulk == 1) {
     planets = 1;
     p_type[1] = "Space Hulk";
     heresy = -999;
-    p_owner[1] = 2;
+    p_owner[1] = eFACTION.IMPERIUM;
     p_population[1] = 0;
     p_fortified[1] = 5;
 
@@ -128,8 +128,8 @@ switch (star) {
                 planet[rui] = 1;
                 p_type[rui] = choose("Temperate", "Temperate", choose("Temperate", "Shrine"), "Feudal", "Agri", "Death", "Desert", "Ice", "Hive");
                 if (p_type[rui] == "Agri" || p_type[rui] == "Hive") {
-                    p_owner[rui] = 2;
-                    p_first[rui] = 2;
+                    p_owner[rui] = eFACTION.IMPERIUM;
+                    p_first[rui] = eFACTION.IMPERIUM;
                 }
             }
         }
@@ -364,20 +364,20 @@ for (var i = 0; i < 10; i++) {
 }
 
 if (p_type[1] != "") {
-    p_owner[1] = 2;
-    p_first[1] = 2;
+    p_owner[1] = eFACTION.IMPERIUM;
+    p_first[1] = eFACTION.IMPERIUM;
 }
 if (p_type[2] != "") {
-    p_owner[2] = 2;
-    p_first[2] = 2;
+    p_owner[2] = eFACTION.IMPERIUM;
+    p_first[2] = eFACTION.IMPERIUM;
 }
 if (p_type[3] != "") {
-    p_owner[3] = 2;
-    p_first[3] = 2;
+    p_owner[3] = eFACTION.IMPERIUM;
+    p_first[3] = eFACTION.IMPERIUM;
 }
 if (p_type[4] != "") {
-    p_owner[4] = 2;
-    p_first[4] = 2;
+    p_owner[4] = eFACTION.IMPERIUM;
+    p_first[4] = eFACTION.IMPERIUM;
 }
 
 if (p_type[1] != "Dead") {

--- a/objects/obj_star/Alarm_1.gml
+++ b/objects/obj_star/Alarm_1.gml
@@ -116,7 +116,7 @@ for (var i = 1; i <= 4; i++) {
         p_pdf[i] = 0;
         p_eldar[i] = 6;
         owner = eFACTION.ELDAR;
-        p_owner[1] = 6;
+        p_owner[1] = eFACTION.ELDAR;
         warp_lanes = [];
         x2 = 0;
     }
@@ -280,8 +280,8 @@ if (owner == eFACTION.TAU) {
     }
     for (var i = 1; i <= planets; i++) {
         if (p_tau[i] > 0) {
-            p_owner[i] = 8;
-            p_first[i] = 8;
+            p_owner[i] = eFACTION.TAU;
+            p_first[i] = eFACTION.TAU;
 
             switch (p_type[i]) {
                 case "Forge":
@@ -334,19 +334,19 @@ if (owner > 20) {
                 new_cult.hiding = false;
             }
         }
-        p_owner[i] = 2;
+        p_owner[i] = eFACTION.IMPERIUM;
     }
     owner = eFACTION.TYRANIDS;
 }
 
 for (var i = 1; i <= planets; i++) {
-    if ((p_owner[i] == 8) && (p_guardsmen[i] > 0)) {
+    if ((p_owner[i] == eFACTION.TAU) && (p_guardsmen[i] > 0)) {
         p_pdf[i] += p_guardsmen[i];
         p_guardsmen[i] = 0;
     }
-    if ((p_type[i] == "Shrine") && (p_owner[i] != 1) && (p_first[i] != 1)) {
-        p_owner[i] = 5;
-        p_first[i] = 5;
+    if ((p_type[i] == "Shrine") && (p_owner[i] != eFACTION.PLAYER) && (p_first[i] != eFACTION.PLAYER)) {
+        p_owner[i] = eFACTION.ECCLESIARCHY;
+        p_first[i] = eFACTION.ECCLESIARCHY;
         p_sisters[i] = 4;
         adjust_influence(eFACTION.ECCLESIARCHY, (p_sisters[i] * 10) - irandom(5), i, id);
     }
@@ -377,7 +377,7 @@ if ((choose(0, 1) == 1) && (planets > 0)) {
         nostart = true;
     }
 
-    if ((array_length(p_feature[_ran_num]) == 0) && (p_owner[_ran_num] != 1) && nostart) {
+    if ((array_length(p_feature[_ran_num]) == 0) && (p_owner[_ran_num] != eFACTION.PLAYER) && nostart) {
         var ranb = 0;
         var goo = 0;
         if (goo == 0) {
@@ -459,9 +459,9 @@ for (var i = 1; i <= 4; i++) {
         p_pdf[i] = 0;
         p_population[i] = 0;
         hyu = true;
-        p_owner[i] = 9;
+        p_owner[i] = eFACTION.TYRANIDS;
     }
-    if ((p_first[i] <= 5) && (dispo[i] > -5000)) {
+    if ((p_first[i] <= eFACTION.ECCLESIARCHY) && (dispo[i] > -5000)) {
         dispo[i] = -20;
     }
 }
@@ -471,7 +471,7 @@ if ((!hyu) && (owner == eFACTION.TYRANIDS)) {
 
 scr_star_ownership(false);
 
-if ((obj_controller.is_test_map != true) && (p_owner[2] != 1)) {
+if ((obj_controller.is_test_map != true) && (p_owner[2] != eFACTION.PLAYER)) {
     for (var i = 1; i <= 4; i++) {
         p_guardsmen[i] = 0;
     }

--- a/objects/obj_star/Alarm_2.gml
+++ b/objects/obj_star/Alarm_2.gml
@@ -6,10 +6,10 @@ if (instance_exists(obj_temp1)) {
     // Nearby star system
     if ((tempy_d > 10) && (tempy_d <= 180)) {
         for (var i = 1; i <= planets; i++) {
-            if ((p_type[i] == "Forge") && (p_owner[i] == 3)) {
+            if ((p_type[i] == "Forge") && (p_owner[i] == eFACTION.MECHANICUS)) {
                 obj_controller.income_forge += 6;
             }
-            if ((p_type[i] == "Agri") && (p_owner[i] == 2)) {
+            if ((p_type[i] == "Agri") && (p_owner[i] == eFACTION.IMPERIUM)) {
                 obj_controller.income_agri += 3;
             }
         }
@@ -18,10 +18,10 @@ if (instance_exists(obj_temp1)) {
     var connected = determine_warp_join(biggy, id);
     if ((biggy.owner == eFACTION.PLAYER) && (tempy_d > 180) && connected) {
         for (var i = 1; i <= planets; i++) {
-            if ((p_type[i] == "Forge") && (p_owner[i] == 3)) {
+            if ((p_type[i] == "Forge") && (p_owner[i] == eFACTION.MECHANICUS)) {
                 obj_controller.income_forge += 6;
             }
-            if ((p_type[i] == "Agri") && (p_owner[i] == 2)) {
+            if ((p_type[i] == "Agri") && (p_owner[i] == eFACTION.IMPERIUM)) {
                 obj_controller.income_agri += 3;
             }
         }

--- a/scripts/Armamentarium/Armamentarium.gml
+++ b/scripts/Armamentarium/Armamentarium.gml
@@ -729,7 +729,7 @@ function Armamentarium(_controller) constructor {
                 continue;
             }
 
-            if (array_contains(p_owner, 1)) {
+            if (array_contains(p_owner, eFACTION.PLAYER)) {
                 other.discount_rogue_trader = ROGUE_TRADER_DISCOUNT;
                 break;
             }

--- a/scripts/macros/macros.gml
+++ b/scripts/macros/macros.gml
@@ -34,6 +34,7 @@ global.alliance_grades = ["Hated", "Hostile","Suspicious","Uneasy","Neutral","Al
 #macro SHIP_WEAPON_SLOTS 8
 
 enum eFACTION {
+    NONE = 0,
     PLAYER = 1,
     IMPERIUM = 2,
     MECHANICUS = 3,

--- a/scripts/scr_PlanetData/scr_PlanetData.gml
+++ b/scripts/scr_PlanetData/scr_PlanetData.gml
@@ -361,8 +361,9 @@ function PlanetData(_planet, _system) constructor {
         } else {
             if (origional_owner != 3) {
                 set_new_owner(eFACTION.PLAYER);
+                system.p_first[planet] = eFACTION.PLAYER;
             }
-            set_player_disposition(101);
+            set_player_disposition(100);
             scr_event_log("", $"Planetary Governor of {name()} assassinated.  One of your Chapter Serfs take their position.");
         }
 

--- a/scripts/scr_PlanetData/scr_PlanetData.gml
+++ b/scripts/scr_PlanetData/scr_PlanetData.gml
@@ -546,7 +546,7 @@ function PlanetData(_planet, _system) constructor {
         if (array_length(_non_deads) > 0 && _rando > 40) {
             var _ork_spread_planet = array_random_element(_non_deads);
             var _ork_target = system.p_orks[_ork_spread_planet];
-            var _spread_orks = current_owner == eFACTION.ORK && ((pdf + guardsmen + planet_forces[8] + planet_forces[10] + planet_forces[1]) == 0);
+            var _spread_orks = current_owner == eFACTION.ORK && ((pdf + guardsmen + planet_forces[eFACTION.TAU] + planet_forces[eFACTION.CHAOS] + planet_forces[eFACTION.PLAYER]) == 0);
             if (_spread_orks) {
                 // determine maximum Ork presence on the source planet
                 var _ork_max = planet_forces[eFACTION.ORK];
@@ -564,7 +564,7 @@ function PlanetData(_planet, _system) constructor {
             }
         }
         _rando = roll_dice(1, 100); // This part handles the ship building
-        if ((population > 0 && pdf == 0 && guardsmen == 0 && planet_forces[10] == 0) && (planet_forces[eFACTION.TAU] == 0)) {
+        if ((population > 0 && pdf == 0 && guardsmen == 0 && planet_forces[eFACTION.CHAOS] == 0) && (planet_forces[eFACTION.TAU] == 0)) {
             if (!large_population) {
                 set_population(population * 0.97);
             } else {
@@ -1803,7 +1803,7 @@ function PlanetData(_planet, _system) constructor {
 
                             var _valid_owners = false;
                             for (var plan = 1; plan <= planets; plan++) {
-                                if (p_owner[plan] <= 5) {
+                                if (p_owner[plan] <= eFACTION.ECCLESIARCHY) {
                                     _valid_owners = true;
                                     break;
                                 }

--- a/scripts/scr_destroy_planet/scr_destroy_planet.gml
+++ b/scripts/scr_destroy_planet/scr_destroy_planet.gml
@@ -136,8 +136,8 @@ function scr_destroy_planet(destruction_method) {
     with (you) {
         p_type[baid] = "Dead";
         p_feature[baid] = [];
-        p_owner[baid] = 0;
-        p_first[baid] = 0;
+        p_owner[baid] = eFACTION.NONE;
+        p_first[baid] = eFACTION.NONE;
         p_population[baid] = 0;
         p_max_population[baid] = 0;
         p_large[baid] = 0;

--- a/scripts/scr_drop_select_function/scr_drop_select_function.gml
+++ b/scripts/scr_drop_select_function/scr_drop_select_function.gml
@@ -303,7 +303,7 @@ function drop_select_unit_selection() {
 
             if (obj_ncombat.enemy == eFACTION.TAU) {
                 var eth = scr_quest(4, "ethereal_capture", 8, 0);
-                if ((eth > 0) && (obj_ncombat.battle_object.p_owner[obj_ncombat.battle_id] == 8)) {
+                if ((eth > 0) && (obj_ncombat.battle_object.p_owner[obj_ncombat.battle_id] == eFACTION.TAU)) {
                     var rolli;
                     rolli = irandom_range(1, 100);
                     if ((obj_ncombat.threat == 6) && (rolli <= 80)) {
@@ -429,7 +429,7 @@ function drop_select_draw() {
 
                 var succession = has_problem_planet(pp, "succession", p_target);
 
-                if (((p_target.dispo[pp] >= 0) && (p_target.p_owner[pp] <= 5) && (p_target.p_population[pp] > 0)) && (!succession)) {
+                if (((p_target.dispo[pp] >= 0) && (p_target.p_owner[pp] <= eFACTION.ECCLESIARCHY) && (p_target.p_population[pp] > 0)) && (!succession)) {
                     var wack = 0;
                     draw_set_color(c_blue);
                     draw_rectangle(x2 + 12, y2 + 53, x2 + 12 + max(0, (min(100, p_target.dispo[pp]) * 4.37)), y2 + 71, 0);
@@ -441,13 +441,13 @@ function drop_select_draw() {
                 draw_set_font(fnt_40k_14b);
                 draw_set_halign(fa_center);
                 if (!succession) {
-                    if ((p_target.dispo[pp] >= 0) && (p_target.p_first[pp] <= 5) && (p_target.p_owner[pp] <= 5) && (p_target.p_population[pp] > 0)) {
+                    if ((p_target.dispo[pp] >= 0) && (p_target.p_first[pp] <= eFACTION.ECCLESIARCHY) && (p_target.p_owner[pp] <= eFACTION.ECCLESIARCHY) && (p_target.p_population[pp] > 0)) {
                         draw_text(x2 + 231, y2 + 54, string_hash_to_newline("Disposition: " + string(min(100, p_target.dispo[pp])) + "/100"));
                     }
-                    if ((p_target.dispo[pp] > -30) && (p_target.dispo[pp] < 0) && (p_target.p_owner[pp] <= 5) && (p_target.p_population[pp] > 0)) {
+                    if ((p_target.dispo[pp] > -30) && (p_target.dispo[pp] < 0) && (p_target.p_owner[pp] <= eFACTION.ECCLESIARCHY) && (p_target.p_population[pp] > 0)) {
                         draw_text(x2 + 231, y2 + 54, string_hash_to_newline("Disposition: ???/100"));
                     }
-                    if (((p_target.dispo[pp] >= 0) && (p_target.p_first[pp] <= 5) && (p_target.p_owner[pp] > 5)) || (p_target.p_population[pp] <= 0)) {
+                    if (((p_target.dispo[pp] >= 0) && (p_target.p_first[pp] <= eFACTION.ECCLESIARCHY) && (p_target.p_owner[pp] > eFACTION.ECCLESIARCHY)) || (p_target.p_population[pp] <= 0)) {
                         draw_text(x2 + 231, y2 + 54, string_hash_to_newline("-------------"));
                     }
                     if (p_target.dispo[pp] <= -3000) {

--- a/scripts/scr_enemy_ai_a/scr_enemy_ai_a.gml
+++ b/scripts/scr_enemy_ai_a/scr_enemy_ai_a.gml
@@ -1201,12 +1201,9 @@ function scr_enemy_ai_a() {
                     }
                     p_owner[_run] = eFACTION.IMPERIUM;
                 }
-                dispo[_run] += 10;
+                scr_gov_disp(name, _run, 10);
                 scr_event_log("", $"{who_cleansed} cleansed from {planet_string}", name);
                 scr_alert("green", "owner", $"{who_cleansed} cleansed from {planet_string}. Control returned to {who_return}", x, y);
-                if (dispo[_run] >= 101) {
-                    p_owner[_run] = eFACTION.PLAYER;
-                }
             }
         }
 

--- a/scripts/scr_enemy_ai_a/scr_enemy_ai_a.gml
+++ b/scripts/scr_enemy_ai_a/scr_enemy_ai_a.gml
@@ -1187,10 +1187,10 @@ function scr_enemy_ai_a() {
             }
 
             if (make_alert) {
-                if (p_first[_run] == 1) {
+                if (p_first[_run] == eFACTION.PLAYER) {
                     p_owner[_run] = eFACTION.PLAYER;
                     who_return = "your";
-                } else if (p_first[_run] == 3 || p_type[_run] == "Forge") {
+                } else if (p_first[_run] == eFACTION.MECHANICUS || p_type[_run] == "Forge") {
                     who_return = "mechanicus";
                     obj_controller.disposition[3] += 10;
                     p_owner[_run] = eFACTION.MECHANICUS;

--- a/scripts/scr_enemy_ai_b/scr_enemy_ai_b.gml
+++ b/scripts/scr_enemy_ai_b/scr_enemy_ai_b.gml
@@ -41,9 +41,9 @@ function scr_enemy_ai_b() {
             var tau_influence = p_influence[i][eFACTION.TAU];
             var tau_chance = floor(random(100)) + 1;
 
-            if ((i <= planets) && (tau_influence >= 70) && (p_owner[i] != 8) && (p_owner[i] != 10) && (p_owner[i] != 7) && (p_owner[i] != 9) && (p_type[i] != "Space Hulk")) {
+            if ((i <= planets) && (tau_influence >= 70) && (p_owner[i] != eFACTION.TAU) && (p_owner[i] != eFACTION.CHAOS) && (p_owner[i] != eFACTION.ORK) && (p_owner[i] != eFACTION.TYRANIDS) && (p_type[i] != "Space Hulk")) {
                 for (var s = 1; s <= planets; s++) {
-                    if (p_owner[s] == 8) {
+                    if (p_owner[s] == eFACTION.TAU) {
                         tau_chance += 5;
                     }
                 }
@@ -53,7 +53,7 @@ function scr_enemy_ai_b() {
                 }
 
                 if ((tau_chance >= 95) && (p_orks[i] == 0) && (p_traitors[i] == 0) && (p_necrons[i] == 0) && (p_demons[i] == 0) && (p_chaos[i] == 0)) {
-                    p_owner[i] = 8;
+                    p_owner[i] = eFACTION.TAU;
                     if (p_guardsmen[i] > 0) {
                         p_pdf[i] += p_guardsmen[i];
                         p_guardsmen[i] = 0;
@@ -65,7 +65,7 @@ function scr_enemy_ai_b() {
                         if (p_type[s] == "Dead") {
                             targ -= 1;
                         }
-                        if (p_owner[s] == 8) {
+                        if (p_owner[s] == eFACTION.TAU) {
                             have += 1;
                         }
                     }
@@ -99,7 +99,7 @@ function scr_enemy_ai_b() {
                     }
                 }
             }
-            if ((p_owner[i] == 8) && (tau_influence < 80)) {
+            if ((p_owner[i] == eFACTION.TAU) && (tau_influence < 80)) {
                 if ((p_type[i] != "Forge") && (p_type[i] != "Shrine")) {
                     tau_influence += 2;
                 } else if ((p_type[i] == "Forge") || (p_type[i] == "Shrine")) {

--- a/scripts/scr_enemy_ai_c/scr_enemy_ai_c.gml
+++ b/scripts/scr_enemy_ai_c/scr_enemy_ai_c.gml
@@ -14,7 +14,7 @@ function scr_enemy_ai_c() {
     if (array_sum(p_traitors)) {
         var traitor_system = true;
         for (var i = 1; i <= planets; i++) {
-            if ((p_owner[i] != 10) || (p_pdf[i] > 0) || (p_guardsmen[i] > 0) || (p_orks[i] > 0) || (p_tau[i] > 0)) {
+            if ((p_owner[i] != eFACTION.CHAOS) || (p_pdf[i] > 0) || (p_guardsmen[i] > 0) || (p_orks[i] > 0) || (p_tau[i] > 0)) {
                 traitor_system = false;
                 break;
             }
@@ -149,55 +149,55 @@ function scr_enemy_ai_c() {
 
     if ((present_fleet[10] > 0) && (present_fleet[1] + present_fleet[2] == 0) && (boat != noone) && (owner != eFACTION.CHAOS) && (planets > 0)) {
         for (var i = 0; i < 5; i++) {
-            if ((p_type[1] != "Dead") && (p_owner[1] != 10)) {
+            if ((p_type[1] != "Dead") && (p_owner[1] != eFACTION.CHAOS)) {
                 kay = 1;
             }
-            if ((p_type[2] != "Dead") && (p_owner[2] != 10)) {
+            if ((p_type[2] != "Dead") && (p_owner[2] != eFACTION.CHAOS)) {
                 kay = 2;
             }
-            if ((p_type[3] != "Dead") && (p_owner[3] != 10)) {
+            if ((p_type[3] != "Dead") && (p_owner[3] != eFACTION.CHAOS)) {
                 kay = 3;
             }
-            if ((p_type[4] != "Dead") && (p_owner[4] != 10)) {
+            if ((p_type[4] != "Dead") && (p_owner[4] != eFACTION.CHAOS)) {
                 kay = 4;
             }
 
-            if ((p_type[4] == "Desert") && (p_owner[4] != 10)) {
+            if ((p_type[4] == "Desert") && (p_owner[4] != eFACTION.CHAOS)) {
                 kay = 14;
             }
-            if ((p_type[3] == "Desert") && (p_owner[3] != 10)) {
+            if ((p_type[3] == "Desert") && (p_owner[3] != eFACTION.CHAOS)) {
                 kay = 3;
             }
-            if ((p_type[2] == "Desert") && (p_owner[2] != 10)) {
+            if ((p_type[2] == "Desert") && (p_owner[2] != eFACTION.CHAOS)) {
                 kay = 12;
             }
-            if ((p_type[1] == "Desert") && (p_owner[1] != 10)) {
+            if ((p_type[1] == "Desert") && (p_owner[1] != eFACTION.CHAOS)) {
                 kay = 1;
             }
 
-            if ((p_type[4] == "Temperate") && (p_owner[4] != 10)) {
+            if ((p_type[4] == "Temperate") && (p_owner[4] != eFACTION.CHAOS)) {
                 kay = 4;
             }
-            if ((p_type[3] == "Temperate") && (p_owner[3] != 10)) {
+            if ((p_type[3] == "Temperate") && (p_owner[3] != eFACTION.CHAOS)) {
                 kay = 3;
             }
-            if ((p_type[2] == "Temperate") && (p_owner[2] != 10)) {
+            if ((p_type[2] == "Temperate") && (p_owner[2] != eFACTION.CHAOS)) {
                 kay = 2;
             }
-            if ((p_type[1] == "Temperate") && (p_owner[1] != 10)) {
+            if ((p_type[1] == "Temperate") && (p_owner[1] != eFACTION.CHAOS)) {
                 kay = 1;
             }
 
-            if ((p_type[4] == "Hive") && (p_owner[4] != 10)) {
+            if ((p_type[4] == "Hive") && (p_owner[4] != eFACTION.CHAOS)) {
                 kay = 4;
             }
-            if ((p_type[3] == "Hive") && (p_owner[3] != 10)) {
+            if ((p_type[3] == "Hive") && (p_owner[3] != eFACTION.CHAOS)) {
                 kay = 3;
             }
-            if ((p_type[2] == "Hive") && (p_owner[2] != 10)) {
+            if ((p_type[2] == "Hive") && (p_owner[2] != eFACTION.CHAOS)) {
                 kay = 2;
             }
-            if ((p_type[1] == "Hive") && (p_owner[1] != 10)) {
+            if ((p_type[1] == "Hive") && (p_owner[1] != eFACTION.CHAOS)) {
                 kay = 1;
             }
 
@@ -225,7 +225,7 @@ function scr_enemy_ai_c() {
     // This is the CSM landing code
     if ((present_fleet[10] > 0) && (present_fleet[1] + present_fleet[2] == 0) && (boat != noone) && (planets > 0)) {
         for (var i = 1; i <= planets; i++) {
-            if ((planets >= i) && (p_type[i] != "Dead") && (p_owner[i] != 10)) {
+            if ((planets >= i) && (p_type[i] != "Dead") && (p_owner[i] != eFACTION.CHAOS)) {
                 if (instance_exists(boat)) {
                     if (fleet_has_cargo("chaos", boat)) {
                         if (p_chaos[i] < 4) {
@@ -290,16 +290,16 @@ function scr_enemy_ai_c() {
             contin = 0;
             rando = floor(random(100)) + 1; // This part handles the ship building
 
-            if ((planets == 1) && (p_owner[1] == 8)) {
+            if ((planets == 1) && (p_owner[1] == eFACTION.TAU)) {
                 contin = 1;
             }
-            if ((planets == 2) && (p_owner[1] == 8) && (p_owner[2] == 8)) {
+            if ((planets == 2) && (p_owner[1] == eFACTION.TAU) && (p_owner[2] == eFACTION.TAU)) {
                 contin = 1;
             }
-            if ((planets == 3) && (p_owner[1] == 8) && (p_owner[2] == 8) && (p_owner[3] == 8)) {
+            if ((planets == 3) && (p_owner[1] == eFACTION.TAU) && (p_owner[2] == eFACTION.TAU) && (p_owner[3] == eFACTION.TAU)) {
                 contin = 1;
             }
-            if ((planets == 4) && (p_owner[1] == 8) && (p_owner[2] == 8) && (p_owner[3] == 8) && (p_owner[4] == 8)) {
+            if ((planets == 4) && (p_owner[1] == eFACTION.TAU) && (p_owner[2] == eFACTION.TAU) && (p_owner[3] == eFACTION.TAU) && (p_owner[4] == eFACTION.TAU)) {
                 contin = 1;
             }
 

--- a/scripts/scr_enemy_ai_d/scr_enemy_ai_d.gml
+++ b/scripts/scr_enemy_ai_d/scr_enemy_ai_d.gml
@@ -27,12 +27,12 @@ function scr_enemy_ai_d() {
         }
 
         // Requesting help here
-        if (((p_halp[i] == 1) || (p_halp[i] == 1.1)) && (p_population[i] > 0) && (p_owner[i] < 6)) {
+        if (((p_halp[i] == 1) || (p_halp[i] == 1.1)) && (p_population[i] > 0) && (p_owner[i] <= eFACTION.ECCLESIARCHY)) {
             if ((p_orks[i] + p_tau[i] + p_traitors[i] + p_chaos[i] + p_necrons[i] == 0) && (p_tyranids[i] < 4)) {
                 p_halp[i] = 0;
             }
         }
-        if ((p_halp[i] == 0) && (p_population[i] > 0) && (p_owner[i] < 6) && (p_owner[i] != 1) && (present_fleet[1] <= 0) && (p_player[i] <= 0)) {
+        if ((p_halp[i] == 0) && (p_population[i] > 0) && (p_owner[i] <= eFACTION.ECCLESIARCHY) && (p_owner[i] != eFACTION.PLAYER) && (present_fleet[1] <= 0) && (p_player[i] <= 0)) {
             var enemy1 = "", enemies = 0, minimum = 5, tx = "";
 
             if (p_guardsmen[i] + p_pdf[i] <= 1000000) {

--- a/scripts/scr_enemy_ai_e/scr_enemy_ai_e.gml
+++ b/scripts/scr_enemy_ai_e/scr_enemy_ai_e.gml
@@ -465,6 +465,11 @@ function scr_enemy_ai_e() {
                     obj_turn_end.battle_location[obj_turn_end.battles] = name;
                     obj_turn_end.battle_pobject[obj_turn_end.battles] = instance_nearest(x, y, obj_p_fleet);
 
+                    if (!instance_exists(obj_turn_end.battle_pobject[obj_turn_end.battles])) {
+                        obj_turn_end.battles -= 1;
+                        break;
+                    }
+
                     if (i == 10) {
                         obj_controller.temp[1049] = string(name);
                         with (obj_temp2) {

--- a/scripts/scr_enemy_ai_e/scr_enemy_ai_e.gml
+++ b/scripts/scr_enemy_ai_e/scr_enemy_ai_e.gml
@@ -579,10 +579,10 @@ function scr_enemy_ai_e() {
                     case 12:
                         continue;
                     case 2:
-                        if (p_player[run] > 0 && p_owner[run] == 1 && p_guardsmen[run] > 0 && obj_controller.faction_status[2] == "War") {
+                        if (p_player[run] > 0 && p_owner[run] == eFACTION.PLAYER && p_guardsmen[run] > 0 && obj_controller.faction_status[2] == "War") {
                             battle_opponent = 2;
                         }
-                        if (p_player[run] >= 10 && p_owner[run] != 1 && p_guardsmen[run] > 0 && obj_controller.faction_status[2] == "War") {
+                        if (p_player[run] >= 10 && p_owner[run] != eFACTION.PLAYER && p_guardsmen[run] > 0 && obj_controller.faction_status[2] == "War") {
                             battle_opponent = 2;
                         }
                         break;
@@ -648,7 +648,7 @@ function scr_enemy_ai_e() {
             // Otherwise, 3 and a half billions get translated as 3,50 instead of 3500000000
 
             //fortress monestary
-            if (p_owner[run] == 1) {
+            if (p_owner[run] == eFACTION.PLAYER) {
                 var monestary = search_planet_features(p_feature[run], eP_FEATURES.MONASTERY);
                 if (array_length(monestary) > 0) {
                     monestary = p_feature[run][monestary[0]];

--- a/scripts/scr_event_code/scr_event_code.gml
+++ b/scripts/scr_event_code/scr_event_code.gml
@@ -56,7 +56,8 @@ function event_end_turn_action() {
                     _event_star.dispo[_planet] = -10; // Resets
                     var twix = $"Inquisition executes Chapter Serf in control of {planet_numeral_name(_planet, _event_star)} and installs a new Planetary Governor.";
                     if (_event_star.p_owner[_planet] == eFACTION.PLAYER) {
-                        _event_star.p_owner[_planet] = _event_star.p_first[_planet];
+                        _event_star.p_first[_planet] = eFACTION.IMPERIUM;
+                        _event_star.p_owner[_planet] = eFACTION.IMPERIUM;
                     }
                     scr_alert("", "", twix, 0, 0);
                     scr_event_log("", twix, _star_name);

--- a/scripts/scr_fleet_functions/scr_fleet_functions.gml
+++ b/scripts/scr_fleet_functions/scr_fleet_functions.gml
@@ -614,7 +614,7 @@ function sector_imperial_fleet_strength() {
     }
     with (obj_star) {
         for (var i = 0; i <= planets; i++) {
-            var _owner_imperial = p_owner[i] < 5 && p_owner[i] > 1;
+            var _owner_imperial = p_owner[i] < eFACTION.ECCLESIARCHY && p_owner[i] > eFACTION.PLAYER;
             _imperial_planet_count += _owner_imperial;
         }
         if (owner == eFACTION.MECHANICUS) {
@@ -834,7 +834,7 @@ function fleet_arrival_logic() {
         if (sta.x=home_x) and (sta.y=home_y){
             repeat(4){i+=1;
                 en_p[i]=0;
-                if (sta.p_owner[i]<=5){en_p[i]=1;en_planets+=1;}
+                if (sta.p_owner[i]<=eFACTION.ECCLESIARCHY){en_p[i]=1;en_planets+=1;}
             }
             
             if (guardsmen>0) and (en_planets>0){

--- a/scripts/scr_forge_world_functions/scr_forge_world_functions.gml
+++ b/scripts/scr_forge_world_functions/scr_forge_world_functions.gml
@@ -122,7 +122,7 @@ function build_planet_defence_fleets() {
         }
         var _system_value = 0;
         for (var i = 0; i <= planets; i++) {
-            var _owner_imperial = p_owner[i] < 5 && p_owner[i] > 1;
+            var _owner_imperial = p_owner[i] < eFACTION.ECCLESIARCHY && p_owner[i] > eFACTION.PLAYER;
             _imperial_planet_count += _owner_imperial;
             if (p_type[i] == "Forge") {
                 continue;

--- a/scripts/scr_gift_items/scr_gift_items.gml
+++ b/scripts/scr_gift_items/scr_gift_items.gml
@@ -110,7 +110,7 @@ function gift_artifact(give_to, known = true) {
                         add_event({e_id: "imperium_daemon", duration: 1});
                         with (obj_star) {
                             for (var i = 1; i <= planets; i++) {
-                                if (p_owner[i] == 2) {
+                                if (p_owner[i] == eFACTION.IMPERIUM) {
                                     p_heresy[i] += choose(30, 40, 50, 60);
                                 }
                             }
@@ -119,7 +119,7 @@ function gift_artifact(give_to, known = true) {
                     if (is_chaos) {
                         with (obj_star) {
                             for (var i = 1; i <= planets; i++) {
-                                if ((p_owner[i] == 2) && (p_heresy[i] > 0)) {
+                                if ((p_owner[i] == eFACTION.IMPERIUM) && (p_heresy[i] > 0)) {
                                     p_heresy[i] += 10;
                                 }
                             }
@@ -130,7 +130,7 @@ function gift_artifact(give_to, known = true) {
                     if (is_daemon) {
                         with (obj_star) {
                             for (var i = 1; i <= planets; i++) {
-                                if (p_owner[i] == 8) {
+                                if (p_owner[i] == eFACTION.TAU) {
                                     p_heresy[i] += 40;
                                 }
                             }

--- a/scripts/scr_gov_disp/scr_gov_disp.gml
+++ b/scripts/scr_gov_disp/scr_gov_disp.gml
@@ -1,45 +1,16 @@
-function scr_gov_disp(argument0, argument1, argument2) {
-    // argument0: star name
-    // argument1: planet number
-    // argument2: amount
-
-    if (instance_exists(obj_star) && instance_exists(obj_controller)) {
-        obj_controller.temp[2000] = argument0;
-        with (obj_temp3) {
-            instance_destroy();
-        }
-        with (obj_star) {
-            if (name == obj_controller.temp[2000]) {
-                instance_create(x, y, obj_temp3);
-            }
-        }
-        if (instance_exists(obj_temp3)) {
-            var it;
-            it = instance_nearest(obj_temp3.x, obj_temp3.y, obj_star);
-            if (instance_exists(it)) {
-                if ((it.name == obj_controller.temp[2000]) && (it.dispo[argument1] < 101) && (it.dispo[argument1] >= 0)) {
-                    var onceh;
-                    onceh = 0;
-                    if ((it.dispo[argument1] + argument2 > 100) && (onceh == 0)) {
-                        it.dispo[argument1] = 100;
-                        onceh = 1;
-                    }
-                    if ((it.dispo[argument1] + argument2 < 0) && (onceh == 0)) {
-                        it.dispo[argument1] = 0;
-                        onceh = 1;
-                    }
-                    if ((it.dispo[argument1] + argument2 >= 0) && (onceh == 0) && (it.dispo[argument1] + argument2 <= 100)) {
-                        it.dispo[argument1] += argument2;
-                        onceh = 1;
-                    }
-                }
-            }
-        }
-    }
-    with (obj_temp3) {
-        instance_destroy();
+/// @description Changes a star's planet disposition, clamping the result to 0-100.
+/// @param {String} star_name name of the star system
+/// @param {Real} planet_num planet index
+/// @param {Real} amount amount to change disposition by
+function scr_gov_disp(star_name, planet_num, amount) {
+    if (!instance_exists(obj_star)) {
+        return;
     }
 
-    // 95-100: allied
-    // 101 is reserved for chapter serf governor
+    with (obj_star) {
+        if (name == star_name) {
+            dispo[planet_num] = clamp(dispo[planet_num] + amount, -5000, 100);
+            break;
+        }
+    }
 }

--- a/scripts/scr_imperial_navy_functions/scr_imperial_navy_functions.gml
+++ b/scripts/scr_imperial_navy_functions/scr_imperial_navy_functions.gml
@@ -265,11 +265,11 @@ function imperial_navy_bombard() {
         if (orbiting.p_type[p] != "Daemon") {
             if (orbiting.p_population[p] == 0 && orbiting.p_tyranids[p] > 0) {
                 _bombard = p;
-            } else if (orbiting.p_population[p] == 0 && orbiting.p_orks[p] > 0 && orbiting.p_owner[p] == 7) {
+            } else if (orbiting.p_population[p] == 0 && orbiting.p_orks[p] > 0 && orbiting.p_owner[p] == eFACTION.ORK) {
                 _bombard = p;
-            } else if (orbiting.p_owner[p] == 8 && orbiting.p_tau[p] + orbiting.p_pdf[p] > 0) {
+            } else if (orbiting.p_owner[p] == eFACTION.TAU && orbiting.p_tau[p] + orbiting.p_pdf[p] > 0) {
                 _bombard = p;
-            } else if (orbiting.p_owner[p] == 10 && (orbiting.p_chaos[p] + orbiting.p_traitors[p] + orbiting.p_pdf[p] > 0 || orbiting.p_heresy[p] >= 50)) {
+            } else if (orbiting.p_owner[p] == eFACTION.CHAOS && (orbiting.p_chaos[p] + orbiting.p_traitors[p] + orbiting.p_pdf[p] > 0 || orbiting.p_heresy[p] >= 50)) {
                 _bombard = p;
             } else {
                 var _cults = return_planet_features(orbiting.p_feature[p], eP_FEATURES.GENE_STEALER_CULT);
@@ -683,7 +683,7 @@ function scr_navy_planet_action() {
             }
 
             if (obj_controller.faction_status[eFACTION.IMPERIUM] == "War") {
-                if (orbiting.p_owner[p] == 1 && orbiting.p_player[p] == 0 && highest == 0) {
+                if (orbiting.p_owner[p] == eFACTION.PLAYER && orbiting.p_player[p] == 0 && highest == 0) {
                     selected_planet = p;
                     highest = 0.5;
                 }
@@ -866,7 +866,7 @@ function scr_navy_has_unloaded_guardsmen_turn_end() {
 function scr_navy_recruit_new_guard() {
     var that = 0, te = 0, te_large = 0;
     for (var o = 1; o <= orbiting.planets; o++) {
-        if (orbiting.p_owner[o] <= 5) {
+        if (orbiting.p_owner[o] <= eFACTION.ECCLESIARCHY) {
             var _imp_enemies = has_imperial_enemies(o, orbiting);
             if (_imp_enemies) {
                 continue;

--- a/scripts/scr_inquisition_fleet_functions/scr_inquisition_fleet_functions.gml
+++ b/scripts/scr_inquisition_fleet_functions/scr_inquisition_fleet_functions.gml
@@ -259,8 +259,8 @@ function inquisitor_inspect_base() {
     if (chapter_asset_discovery <= 5) {
         repeat (planets) {
             cur_planet += 1;
-            if ((p_first[cur_planet] == 1) && (p_owner[cur_planet] == 2)) {
-                p_owner[cur_planet] = 1;
+            if ((p_first[cur_planet] == eFACTION.PLAYER) && (p_owner[cur_planet] == eFACTION.IMPERIUM)) {
+                p_owner[cur_planet] = eFACTION.PLAYER;
             }
             if ((p_type[cur_planet] == "Dead") && (array_length(p_upgrades[cur_planet]) > 0)) {
                 if (planet_feature_bool(p_feature[cur_planet], [eP_FEATURES.SECRET_BASE, eP_FEATURES.ARSENAL, eP_FEATURES.GENE_VAULT]) == 0) /*and (string_count(".0|",p_upgrades[cur_planet])>0)*/ {

--- a/scripts/scr_ork_fleet_functions/scr_ork_fleet_functions.gml
+++ b/scripts/scr_ork_fleet_functions/scr_ork_fleet_functions.gml
@@ -101,7 +101,7 @@ function ork_fleet_arrive_target() {
         if (_allow_landing) {
             for (var i = 0; i < planets; i++) {
                 var _planet = _planets[i];
-                if ((p_guardsmen[_planet] + p_pdf[_planet] + p_player[_planet] + p_traitors[_planet] + p_tau[_planet] > 0) || ((p_owner[_planet] != 7) && (p_orks[_planet] <= 0))) {
+                if ((p_guardsmen[_planet] + p_pdf[_planet] + p_player[_planet] + p_traitors[_planet] + p_tau[_planet] > 0) || ((p_owner[_planet] != eFACTION.ORK) && (p_orks[_planet] <= 0))) {
                     if ((p_type[_planet] != "Dead") && (p_orks[_planet] < 4) && (i <= planets)) {
                         p_orks[_planet] += max(2, floor(_ork_fleet.image_index * 0.8));
 

--- a/scripts/scr_planetary_feature/scr_planetary_feature.gml
+++ b/scripts/scr_planetary_feature/scr_planetary_feature.gml
@@ -1006,7 +1006,7 @@ function send_stc_to_adeptus_mech() {
 
         if (obj_ini.fleet_type == ePLAYER_BASE.HOME_WORLD) {
             with (obj_star) {
-                if ((owner == eFACTION.PLAYER) && ((p_owner[1] == 1) || (p_owner[2] == eFACTION.PLAYER))) {
+                if ((owner == eFACTION.PLAYER) && ((p_owner[1] == eFACTION.PLAYER) || (p_owner[2] == eFACTION.PLAYER))) {
                     instance_create(x, y, obj_temp2);
                 }
             }

--- a/scripts/scr_player_fleet_functions/scr_player_fleet_functions.gml
+++ b/scripts/scr_player_fleet_functions/scr_player_fleet_functions.gml
@@ -87,6 +87,7 @@ function cancel_fleet_movement() {
     set_fleet_orbiting(self, nearest_star);
 }
 
+/// @self Id.Instance.obj_p_fleet
 function set_new_player_fleet_course(target_array) {
     if (array_length(target_array) > 0) {
         var target_planet = find_star_by_name(target_array[0]);
@@ -106,6 +107,11 @@ function set_new_player_fleet_course(target_array) {
         } else {
             array_delete(target_array, 0, 1);
         }
+
+        if (from_star) {
+            nearest_planet.present_fleet[1]--;
+        }
+    
         complex_route = target_array;
         var from_x = from_star ? nearest_planet.x : x;
         var from_y = from_star ? nearest_planet.y : y;

--- a/scripts/scr_purge_world/scr_purge_world.gml
+++ b/scripts/scr_purge_world/scr_purge_world.gml
@@ -229,8 +229,8 @@ function scr_purge_world(action_type, action_score) {
 
                 alter_disposition(eFACTION.INQUISITION, obj_controller.demanding ? choose(0, 0, 1) : 1);
 
-                _popup_text = "Your marines scour the underhive of {name()}, spraying mutants down with promethium as they go.  It takes several days but a sizeable dent is put in their numbers.";
-                scr_event_log("", "Inquisition Mission Completed: The mutants of {name()} have been cleansed by promethium.");
+                _popup_text = $"Your marines scour the underhive of {name()}, spraying mutants down with promethium as they go.  It takes several days but a sizeable dent is put in their numbers.";
+                scr_event_log("", $"Inquisition Mission Completed: The mutants of {name()} have been cleansed by promethium.");
                 add_disposition(choose(1, 2, 3));
             }
         } else {
@@ -270,7 +270,7 @@ function scr_purge_world(action_type, action_score) {
                 alter_disposition(eFACTION.INQUISITION, obj_controller.demanding ? choose(0, 0, 1) : 1);
 
                 _popup_text = "Your marines drop fast and hard, blowing through guards and mercenaries with minimal resistance.  Before ten minutes have passed all your targets are executed.";
-                scr_event_log("", "Inquisition Mission Completed: The unruly Nobles of {name()} have been purged.");
+                scr_event_log("", $"Inquisition Mission Completed: The unruly Nobles of {name()} have been purged.");
                 add_disposition(choose(1, 2, 3));
             }
         } else if (_isquest == 0) {

--- a/scripts/scr_quest/scr_quest.gml
+++ b/scripts/scr_quest/scr_quest.gml
@@ -109,7 +109,7 @@ function scr_quest(quest_satus, quest_name, quest_fac, quest_end) {
     if (quick_trade != 0) {
         if (obj_ini.fleet_type == ePLAYER_BASE.HOME_WORLD) {
             with (obj_star) {
-                if ((owner == eFACTION.PLAYER) && ((p_owner[1] == 1) || (p_owner[2] == 1))) {
+                if ((owner == eFACTION.PLAYER) && ((p_owner[1] == eFACTION.PLAYER) || (p_owner[2] == eFACTION.PLAYER))) {
                     instance_create(x, y, obj_temp2);
                 }
             }

--- a/scripts/scr_system_search_helpers/scr_system_search_helpers.gml
+++ b/scripts/scr_system_search_helpers/scr_system_search_helpers.gml
@@ -449,7 +449,7 @@ function scr_faction_string_name(faction) {
 function meet_system_governors(system) {
     with (system) {
         for (var i = 1; i <= planets; i++) {
-            if ((p_first[i] <= 5) && (dispo[i] > -30) && (dispo[i] < 0)) {
+            if ((p_first[i] <= eFACTION.ECCLESIARCHY) && (dispo[i] > -30) && (dispo[i] < 0)) {
                 dispo[i] = min(obj_ini.imperium_disposition, obj_controller.disposition[2]) + irandom(8) - 4;
             }
         }

--- a/scripts/scr_system_spawn_functions/scr_system_spawn_functions.gml
+++ b/scripts/scr_system_spawn_functions/scr_system_spawn_functions.gml
@@ -83,7 +83,7 @@ function player_home_star(home_planet) {
     array_push(p_feature[home_planet], new NewPlanetFeature(eP_FEATURES.MONASTERY));
     p_owner[home_planet] = eFACTION.PLAYER;
 
-    p_first[home_planet] = 1; //monestary
+    p_first[home_planet] = eFACTION.PLAYER; //monestary
     if (obj_ini.homeworld_rule != 1) {
         dispo[home_planet] = -5000;
     }

--- a/scripts/scr_trade/scr_trade.gml
+++ b/scripts/scr_trade/scr_trade.gml
@@ -175,7 +175,7 @@ function TradeAttempt(diplomacy) constructor {
     static find_trade_locations = function() {
         var _stars_with_player_control = [];
         with (obj_star) {
-            if (array_contains(p_owner, 1)) {
+            if (array_contains(p_owner, eFACTION.PLAYER)) {
                 array_push(_stars_with_player_control, id);
             }
         }
@@ -210,10 +210,10 @@ function TradeAttempt(diplomacy) constructor {
                 var ahuh = 0, q = 0;
                 repeat (planets) {
                     q += 1;
-                    if (p_owner[q] == 5) {
+                    if (p_owner[q] == eFACTION.ECCLESIARCHY) {
                         ahuh = 1;
                     }
-                    if ((p_owner[q] < 6) && (planet_feature_bool(p_feature[q], eP_FEATURES.SORORITAS_CATHEDRAL) == 1)) {
+                    if ((p_owner[q] <= eFACTION.ECCLESIARCHY) && (planet_feature_bool(p_feature[q], eP_FEATURES.SORORITAS_CATHEDRAL) == 1)) {
                         ahuh = 1;
                     }
                 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes planet ownership flips by capping disposition at 100 and persists fleet orbit state across saves. Also prevents phantom battle crashes, corrects purge-world messages, and replaces hardcoded faction IDs with the `eFACTION` enum.

- **Bug Fixes**
  - Prevent ownership flips: use `scr_gov_disp(star_name, planet_num, amount)` to cap disposition; remove 101-based owner changes; assassination now sets player disposition to 100 and marks `system.p_first`.
  - Persist fleet orbiting (player and enemy): save an `orbiting` flag, rebuild orbit on load, and decrement `present_fleet[1]` when leaving orbit.
  - Avoid phantom battles: verify `battle_pobject` when scheduling; skip invalid entries; guard in turn-end flow.
  - Fix purge-world logs/popups by using string interpolation.
  - Resolve Forgeworld softlock by using correct faction checks in income/mission logic.

- **Refactors**
  - Replace numeric faction IDs with `eFACTION` across AI, combat, trade, fleets, and UI; add `eFACTION.NONE` and update owner/first resets.

<sup>Written for commit 501993f91409f7f1c1c6404d32718b5bf5f1e740. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

