### PR TITLE
fix: Check monastery features on the correct planet slots

### DIFF
--- a/scripts/scr_income/scr_income.gml
+++ b/scripts/scr_income/scr_income.gml
@@ -118,13 +118,11 @@ function scr_income() {
 
     if (obj_ini.fleet_type == ePLAYER_BASE.HOME_WORLD) {
         with (obj_star) {
-            if (planet_feature_bool(p_feature[1], eP_FEATURES.MONASTERY)) {
-                obj_controller.income += 10;
-                instance_create(x, y, obj_temp1);
-            }
-            if (planet_feature_bool(p_feature[2], eP_FEATURES.MONASTERY)) {
-                obj_controller.income += 10;
-                instance_create(x, y, obj_temp1);
+            for (var i = 1; i <= planets; i++) {
+                if (planet_feature_bool(p_feature[i], eP_FEATURES.MONASTERY)) {
+                    obj_controller.income += 10;
+                    instance_create(x, y, obj_temp1);
+                }
             }
             if (owner == eFACTION.TAU) {
                 obj_controller.tau_stars += 1;

--- a/scripts/scr_income/scr_income.gml
+++ b/scripts/scr_income/scr_income.gml
@@ -150,9 +150,9 @@ function scr_income() {
     }
 
     with (obj_star) {
-        for (var o = 1; o <= 4; o++) {
+        for (var o = 1; o <= planets; o++) {
             if (dispo[o] >= 100) {
-                if (planet_feature_bool(p_feature[1], eP_FEATURES.MONASTERY) == 0) {
+                if (planet_feature_bool(p_feature[o], eP_FEATURES.MONASTERY) == 0) {
                     obj_controller.income_controlled_planets += 1;
                     obj_controller.income_tribute += 1;
                     if (p_type[o] == "Feudal") {


### PR DESCRIPTION
Fixes two hardcoded planet-slot checks in `scr_income.gml` that broke monastery handling. The player's monastery is placed on a random planet slot in their home system at game start (`scr_system_spawn_functions.gml:163-166`), so both blocks only behaved correctly when the monastery happened to land on the slot they hardcoded.

* Bug Fixes
  * Planet tithes: the tribute exemption checked `p_feature[1]` for every planet in the loop, so a monastery on planet slot 1 wrongly exempted the entire system from tithes, while a monastery on planet slot 2+ would incorrectly gift a tithe. Now it checks `p_feature[o]` so each planet is tested individually.
  * Planet tithes: loop bound raised from a hardcoded `4` to `planets`.
  * Monastery income: the HOME_WORLD +10 income block only checked planet slots 1 and 2, so a monastery on planet slot 3+ silently earned nothing. Now loops over all planet slots.

* Testing
  * Verified the game boots, loads, saves, and end-of-turn income processes normally with no obvious issues.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes monastery income and tithe checks to work for any planet slot by iterating over all planets, preventing false exemptions and missing income when the monastery isn’t on slot 1–2.

- **Bug Fixes**
  - Planet tithes: check `p_feature[o]` and loop to `planets` so only the monastery planet is exempt.
  - Home world income: loop all planet slots so monasteries on slots 3+ grant the +10 income.

<sup>Written for commit 8ebd61de435ee2e2444cce4a8fedbdfd4e0e5641. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

