### PR TITLE
refactor: More script cleanings

### DIFF
--- a/objects/obj_controller/Mouse_50.gml
+++ b/objects/obj_controller/Mouse_50.gml
@@ -8,7 +8,7 @@ if ((trading > 0) && (force_goodbye != 0)) {
 
 // ** Reclusium Jail Marines**
 if ((menu == eMENU.RECLUSIAM) && (cooldown <= 0) && (penitorium > 0)) {
-    var behav = 0, r_eta = 0, re = 0;
+    var re = 0;
     for (var qp = 1; qp <= min(36, penitorium); qp++) {
         if ((qp <= penitorium) && (mouse_y >= yy + 100 + ((qp - 1) * 20)) && (mouse_y < yy + 100 + (qp * 20))) {
             if ((mouse_x >= xx + 1433) && (mouse_x < xx + 1497)) {
@@ -16,7 +16,6 @@ if ((menu == eMENU.RECLUSIAM) && (cooldown <= 0) && (penitorium > 0)) {
                 var c = penit_co[qp], e = penit_id[qp];
 
                 if (obj_ini.role[c][e] == obj_ini.role[100][eROLE.CHAPTERMASTER]) {
-                    tek = "c";
                     alarm[7] = 5;
                     global.defeat = 3;
                 }
@@ -175,13 +174,11 @@ if ((menu == eMENU.DIPLOMACY) && (diplomacy > 0) || ((diplomacy < -5) && (diplom
 if ((zoomed == 0) && (cooldown <= 0) && (menu == eMENU.DIPLOMACY) && (diplomacy == 0)) {
     xx += 55;
     yy -= 20;
-    var onceh = 0;
     // Daemon emmissary
     if (point_in_rectangle(mouse_x, mouse_y, xx + 688, yy + 181, xx + 1028, yy + 281)) {
         diplomacy = 10.1;
         diplomacy_pathway = "intro";
         scr_dialogue(diplomacy_pathway);
-        onceh = 1;
         cooldown = 1;
     }
 }
@@ -200,11 +197,6 @@ scr_menu_clear_up(function() {
     }
     // Selecting individual marines
     if ((menu == eMENU.MANAGE) && (managing > 0) || (managing < 0) && (!view_squad || !company_report)) {
-        var unit;
-        var eventing = false, bb = "";
-        var top = man_current, sel, temp1 = "", temp2 = "", temp3 = "", temp4 = "", temp5 = "", squad_sel = 0;
-        var stop = 0;
-
         if (man_size == 0) {
             alll = 0;
         }

--- a/scripts/scr_controller_helpers/scr_controller_helpers.gml
+++ b/scripts/scr_controller_helpers/scr_controller_helpers.gml
@@ -9,7 +9,7 @@ function scr_menu_clear_up(specific_area_function) {
                 exit;
             }
 
-            if (instance_exists(obj_turn_end) && (obj_controller.complex_event != true) && (!instance_exists(obj_temp_meeting)) && array_length(obj_turn_end.audience_stack) == 0) {
+            if (instance_exists(obj_turn_end) && !obj_controller.complex_event && (!instance_exists(obj_temp_meeting)) && array_length(obj_turn_end.audience_stack) == 0) {
                 if ((obj_turn_end.popups_end == 1) && (audience == 0) && (cooldown <= 0)) {
                     with (obj_turn_end) {
                         instance_destroy();
@@ -28,10 +28,6 @@ function scr_menu_clear_up(specific_area_function) {
                     }
                 }
             }
-
-            diyst = 999;
-            xx = camera_get_view_x(view_camera[0]);
-            yy = camera_get_view_y(view_camera[0]);
 
             if (menu == eMENU.DEFAULT) {
                 hide_banner = 0;
@@ -280,16 +276,6 @@ function scr_toggle_armamentarium() {
 function scr_toggle_recruiting() {
     scr_change_menu(eMENU.RECRUITING, function() {
         with (obj_controller) {
-            var geh = 0, good = 0;
-            for (geh = 1; geh <= 50; geh++) {
-                geh += 1;
-                if (good == 0) {
-                    if ((obj_ini.role[10][geh] == obj_ini.role[100][5]) && (obj_ini.name[10][geh] == obj_ini.recruiter_name)) {
-                        good = geh;
-                    }
-                }
-            }
-
             if (menu != eMENU.RECRUITING) {
                 set_up_recruitment_view();
                 hide_banner = 1;
@@ -302,14 +288,6 @@ function scr_toggle_fleet_area() {
     scr_change_menu(eMENU.FLEET, function() {
         with (obj_controller) {
             menu_adept = 0;
-            var geh = 0, good = 0;
-            for (geh = 1; geh <= 50; geh++) {
-                if (good == 0) {
-                    if ((obj_ini.role[4][geh] == obj_ini.role[100][5]) && (obj_ini.name[10][geh] == obj_ini.lord_admiral_name)) {
-                        good = geh;
-                    }
-                }
-            }
             if (menu != eMENU.FLEET) {
                 hide_banner = 1;
                 //TODO rewrite all this shit when fleets finally become OOP
@@ -325,7 +303,10 @@ function scr_toggle_fleet_area() {
                     temp[i] = "";
                 }
 
-                var g = 0, u = 0, m = 0, d = 0;
+                var _ship_index = 0;
+                var _hp_percent = 0;
+                var _total_ships = 0;
+                var _crippled_ships = 0;
                 temp[37] = 0;
                 temp[38] = 0;
                 temp[39] = 0;
@@ -343,32 +324,31 @@ function scr_toggle_fleet_area() {
                     }
                 }
 
-                g = 0;
                 temp[41] = "1";
                 for (var i = 0; i < array_length(obj_ini.ship); i++) {
-                    if ((g != 0) && (obj_ini.ship[i] != "")) {
-                        if ((obj_ini.ship_hp[i] / obj_ini.ship_maxhp[i]) < u) {
-                            g = i;
-                            u = obj_ini.ship_hp[i] / obj_ini.ship_maxhp[i];
+                    if ((_ship_index != 0) && (obj_ini.ship[i] != "")) {
+                        if ((obj_ini.ship_hp[i] / obj_ini.ship_maxhp[i]) < _hp_percent) {
+                            _ship_index = i;
+                            _hp_percent = obj_ini.ship_hp[i] / obj_ini.ship_maxhp[i];
                         }
                     }
-                    if ((g == 0) && (obj_ini.ship[i] != "")) {
-                        g = i;
-                        u = obj_ini.ship_hp[i] / obj_ini.ship_maxhp[i];
+                    if ((_ship_index == 0) && (obj_ini.ship[i] != "")) {
+                        _ship_index = i;
+                        _hp_percent = obj_ini.ship_hp[i] / obj_ini.ship_maxhp[i];
                     }
                     if (obj_ini.ship[i] != "") {
-                        m = i;
+                        _total_ships = i;
                     }
                     if ((obj_ini.ship[i] != "") && ((obj_ini.ship_hp[i] / obj_ini.ship_maxhp[i]) < 0.25)) {
-                        d += 1;
+                        _crippled_ships += 1;
                     }
                 }
-                if (g != 0) {
-                    temp[40] = string(obj_ini.ship_class[g]) + " '" + string(obj_ini.ship[g]) + "'";
-                    temp[41] = string(u);
-                    temp[42] = string(d);
+                if (_ship_index != 0) {
+                    temp[40] = string(obj_ini.ship_class[_ship_index]) + " '" + string(obj_ini.ship[_ship_index]) + "'";
+                    temp[41] = string(_hp_percent);
+                    temp[42] = string(_crippled_ships);
                 }
-                man_max = m;
+                man_max = _total_ships;
                 man_current = 0;
             }
         }
@@ -419,19 +399,13 @@ function scr_end_turn() {
                 menu = eMENU.DEFAULT;
 
                 if (!instance_exists(obj_turn_end)) {
-                    ok = 1;
-                }
-
-                if (ok == 1) {
                     obj_controller.menu = eMENU.DEFAULT;
                     obj_controller.zui = 0;
                     obj_controller.invis = false;
 
-                    if (global.settings.autosave == true) {
-                        // Autosave every 10 turns
-                        if (obj_controller.turn % 10 == 0) {
-                            scr_autosave();
-                        }
+                    // Autosave every 10 turns
+                    if (global.settings.autosave && obj_controller.turn % 10 == 0) {
+                        scr_autosave();
                     }
                     obj_controller.end_turn_insights = {};
                     with (obj_turn_end) {

--- a/scripts/scr_creation_draw_slides/scr_creation_draw_slides.gml
+++ b/scripts/scr_creation_draw_slides/scr_creation_draw_slides.gml
@@ -1,6 +1,3 @@
-// Script assets have changed for v2.3.0 see
-// https://help.yoyogames.com/hc/en-us/articles/360005277377 for more information
-
 enum eCREATION_SLIDES {
     CHAPTERSELECT = 1,
     CHAPTERTRAITS = 2,
@@ -16,7 +13,7 @@ function draw_chapter_select() {
     draw_set_color(CM_GREEN_COLOR);
     draw_set_font(fnt_40k_30b);
     draw_set_halign(fa_center);
-    draw_text(800, 80, string_hash_to_newline("Select Chapter"));
+    draw_text(800, 80, "Select Chapter");
 
     draw_set_font(fnt_40k_30b);
     draw_set_halign(fa_left);
@@ -72,11 +69,9 @@ function draw_chapter_select() {
         },
     };
 
-    /** * Founding Chapters */
-    var i, new_hover, tool;
-    i = 1;
-    new_hover = highlight;
-    tool = 0;
+    //* Founding Chapters *//
+    var i = 1;
+    var tool = 0;
     for (var c = 0; c < array_length(founding_chapters); c++) {
         var chap = founding_chapters[c];
         i = chap.id;
@@ -109,19 +104,15 @@ function draw_chapter_select() {
                         goto_slide = 2;
                         chapter_string = chapter_name;
                         setup_chapter_trait_select();
-                    } else {
-                        // Chapter is borked
-                    }
+                    } // Chapter is borked
                 }
             }
         }
-        // grid.x1 += icon_gap_x;
     }
 
-    /** * Successor Chapters */
+    //* Successor Chapters *//
     grid.new_section(successor_y);
 
-    new_hover = highlight;
     for (var c = 0; c < array_length(successor_chapters); c++) {
         var chap = successor_chapters[c];
         i = chap.id;
@@ -154,17 +145,14 @@ function draw_chapter_select() {
                         goto_slide = 2;
                         chapter_string = chapter_name;
                         setup_chapter_trait_select();
-                    } else {
-                        // borked
-                    }
+                    } // borked
                 }
             }
         }
     }
 
-    /** * Saved Custom Chapters */
+    //* Saved Custom Chapters *//
     grid.new_section(custom_y);
-    new_hover = highlight;
     for (var c = 0; c < array_length(custom_chapters); c++) {
         var chap = custom_chapters[c];
         i = chap.id;
@@ -175,9 +163,8 @@ function draw_chapter_select() {
         if (chap.loaded == false) {
             draw_sprite_stretched(global.chapter_icons_map[? "custom_white"], 0, grid.x1, grid.y1, grid.w, grid.h);
         } else {
-            var spr = -1;
-            spr = scr_load_chapter_icon(chap.icon_name);
-            if (spr == -1) {
+            var spr = scr_load_chapter_icon(chap.icon_name);
+            if (is_undefined(spr)) {
                 draw_sprite_stretched(global.chapter_icons_map[? "unknown"], 0, grid.x1, grid.y1, grid.w, grid.h);
             } else {
                 draw_sprite_stretched(spr, 0, grid.x1, grid.y1, grid.w, grid.h);
@@ -220,17 +207,15 @@ function draw_chapter_select() {
         }
     }
 
-    /** * Other Chapters */
+    //* Other Chapters *//
     grid.new_section(other_y);
 
-    new_hover = highlight;
     for (var c = 0; c < array_length(other_chapters); c++) {
         var chap = other_chapters[c];
         i = chap.id;
 
         grid.new_cell();
         draw_sprite(spr_creation_icon, 0, grid.x1, grid.y1);
-        // draw_sprite_stretched(spr_icon,i,x2,y2,48,48);
         draw_sprite_stretched(global.chapter_icons_map[? chap.icon_name], 0, grid.x1, grid.y1, grid.w, grid.h);
 
         // Hover
@@ -251,19 +236,13 @@ function draw_chapter_select() {
                 if (!chap.disabled) {
                     if (scr_chapter_new(chapter_name)) {
                         scr_load_chapter_icon(chap.icon_name, true);
-                        // global.chapter_icon_sprite = obj_img.image_cache[$ "creation/chapters/icons"][chap.icon_name];
-                        // global.chapter_icon_frame = 0;
-                        // global.chapter_icon_path = $"creation/chapters/icons";
-                        // global.chapter_icon_filename = chap.icon_name;
                         global.chapter_id = chap.id;
                         custom = eCHAPTER_TYPE.PREMADE;
                         change_slide = 1;
                         goto_slide = 2;
                         chapter_string = chapter_name;
                         setup_chapter_trait_select();
-                    } else {
-                        // borked
-                    }
+                    } // borked
                 }
             }
         }
@@ -335,7 +314,6 @@ function draw_chapter_select() {
     if ((tool == 0) && (highlighting > 0)) {
         highlighting -= 1;
     }
-    // if (new_hover=0) then highlight=0;
 
     if (((highlight > 0) && (highlighting > 0)) || ((change_slide > 0) && (goto_slide != 1))) {
         draw_set_alpha(min(slate4 / 30, highlighting / 30));
@@ -351,7 +329,6 @@ function draw_chapter_select() {
         }
         if (highlight <= array_length(all_chapters)) {
             var splash_chapter = all_chapters[highlight];
-            //LOGGER.debug($"highlight {highlight} splash chapter {splash_chapter.id} splash icon {splash_chapter.splash}");
             scr_image("creation/chapters/splash", splash_chapter.splash, 0, 68, 374, 713);
         }
 
@@ -370,7 +347,7 @@ function draw_chapter_select() {
         }
 
         draw_set_alpha(1);
-        draw_set_color(0);
+        draw_set_color(c_black);
         draw_set_halign(fa_left);
 
         if (highlight <= array_length(all_chapters)) {
@@ -443,18 +420,13 @@ function draw_chapter_trait_select() {
 
     obj_cursor.image_index = 0;
     if ((custom != eCHAPTER_TYPE.PREMADE) && (restarted == 0)) {
-        if (scr_hit(436, 74, 436 + 128, 74 + 128) && (popup == "")) {
+        if (scr_hit(436, 74, 564, 202) && (popup == "")) {
             obj_cursor.image_index = 1;
             if (mouse_button_clicked()) {
                 popup = "icons";
             }
         }
     }
-
-    /*if (custom!=eCHAPTER_TYPE.PREMADE) and (restarted=0){
-        draw_sprite_stretched(spr_creation_arrow,0,550,160,32,32);
-        draw_sprite_stretched(spr_creation_arrow,1,597,160,32,32);
-    }*/
 
     draw_set_color(CM_GREEN_COLOR);
     draw_line(445, 200, 1125, 200);
@@ -617,7 +589,7 @@ function draw_chapter_trait_select() {
         }
     } else if (popup == "icons") {
         draw_set_alpha(1);
-        draw_set_color(0);
+        draw_set_color(c_black);
         draw_rectangle(450, 206, 1144, 711, 0);
 
         draw_set_color(CM_GREEN_COLOR);
@@ -630,14 +602,13 @@ function draw_chapter_trait_select() {
         draw_text_transformed(800, 211, "Select an Icon", 0.6, 0.6, 0);
         draw_text_transformed(800, 687, "Cancel", 0.6, 0.6, 0);
 
-        var cw, ch;
-        cw = string_width("Cancel") * 0.6;
-        ch = string_height("Cancel") * 0.6;
+        var cw = string_width("Cancel") * 0.6;
+        var ch = string_height("Cancel") * 0.6;
 
         if (scr_hit(800, 687, 800 + cw, 687 + ch)) {
             draw_set_color(c_white);
             draw_set_alpha(0.25);
-            draw_text_transformed(800, 687, string_hash_to_newline("Cancel"), 0.6, 0.6, 0);
+            draw_text_transformed(800, 687, "Cancel", 0.6, 0.6, 0);
             draw_set_color(CM_GREEN_COLOR);
             draw_set_alpha(1);
 
@@ -677,7 +648,7 @@ function draw_chapter_trait_select() {
             if (scr_hit(real_x3, real_y3, real_x3 + 96, real_y3 + 96)) {
                 gpu_set_blendmode(bm_add);
                 draw_set_alpha(0.25);
-                draw_set_color(16119285);
+                draw_set_color(#F5F5F5);
                 draw_rectangle(x3, y3, x3 + 96, y3 + 96, false);
                 gpu_set_blendmode(bm_normal);
                 draw_set_alpha(1);
@@ -711,7 +682,6 @@ function draw_chapter_trait_select() {
 
 /// @self Asset.GMObject.obj_creation
 function draw_chapter_homeworld_select() {
-    var yar = 0;
     draw_set_color(CM_GREEN_COLOR);
     draw_set_font(fnt_40k_30b);
     draw_set_halign(fa_center);
@@ -722,7 +692,6 @@ function draw_chapter_homeworld_select() {
 
     draw_text(800, 80, chapter_name);
 
-    draw_set_color(CM_GREEN_COLOR);
     draw_rectangle(445, 200, 1125, 202, 0);
 
     scr_creation_home_planet_create();
@@ -754,8 +723,7 @@ function draw_chapter_homeworld_select() {
 
             draw_text_transformed(160, 110, current_trial.name, 0.5, 0.5, 0);
 
-            var asp_info;
-            asp_info = scr_compile_trial_bonus_string(current_trial);
+            var asp_info = scr_compile_trial_bonus_string(current_trial);
 
             draw_set_halign(fa_center);
 

--- a/scripts/scr_creation_home_planet_create/scr_creation_home_planet_create.gml
+++ b/scripts/scr_creation_home_planet_create/scr_creation_home_planet_create.gml
@@ -1,5 +1,3 @@
-// Script assets have changed for v2.3.0 see
-// https://help.yoyogames.com/hc/en-us/articles/360005277377 for more information
 function player_recruit_planet_selection() {
     add_draw_return_values();
     with (obj_creation) {
@@ -26,12 +24,12 @@ function player_recruit_planet_selection() {
         if (custom == eCHAPTER_TYPE.CUSTOM && _recruit_world_type > 0) {
             draw_sprite_stretched(spr_creation_arrow, 0, 1265, 285, 32, 32);
             draw_sprite_stretched(spr_creation_arrow, 1, 1455, 285, 32, 32);
-            recruiting = list_traveler(planet_types, recruiting, [1265, 285, 1265 + 32, 285 + 32], [1455, 285, 1455 + 32, 285 + 32]);
+            recruiting = list_traveler(planet_types, recruiting, [1265, 285, 1297, 317], [1455, 285, 1487, 317]);
         }
 
-        scr_image("ui/planet", _cur_planet_index2, 980 + 333, 244, 128, 128);
+        scr_image("ui/planet", _cur_planet_index2, 1313, 244, 128, 128);
 
-        draw_text_transformed(1044 + 333, 378, recruiting, 0.5, 0.5, 0);
+        draw_text_transformed(1377, 378, recruiting, 0.5, 0.5, 0);
 
         if (_recruit_world_type < 2) {
             recruiting_name = homeworld_name;
@@ -40,25 +38,21 @@ function player_recruit_planet_selection() {
                 recruiting_name = global.name_generator.GenerateFromSet("star", false);
             }
         }
-        var name_bad = 0;
-        if ((fleet_type == 1 && _recruit_world_type < 2) && (homeworld_name == recruiting_name)) {
-            name_bad = 1;
-        }
         //TODO make a centralised logic for player renaming things in the creation screen
-        if (name_bad == 1) {
+        if ((fleet_type == 1 && _recruit_world_type < 2) && (homeworld_name == recruiting_name)) {
             draw_set_color(c_red);
         }
         if ((text_selected != "recruiting_name") || (custom != eCHAPTER_TYPE.CUSTOM)) {
-            draw_text_transformed(1044 + 333, 398, recruiting_name, 0.5, 0.5, 0);
+            draw_text_transformed(1377, 398, recruiting_name, 0.5, 0.5, 0);
         }
         if (custom == eCHAPTER_TYPE.CUSTOM && _recruit_world_type == 2) {
             if ((text_selected == "recruiting_name") && (text_bar > 30)) {
-                draw_text_transformed(1044 + 333, 398, recruiting_name, 0.5, 0.5, 0);
+                draw_text_transformed(1377, 398, recruiting_name, 0.5, 0.5, 0);
             }
             if ((text_selected == "recruiting_name") && (text_bar <= 30)) {
-                draw_text_transformed(1044 + 333, 398, $"{recruiting_name}|", 0.5, 0.5, 0);
+                draw_text_transformed(1377, 398, $"{recruiting_name}|", 0.5, 0.5, 0);
             }
-            if (scr_text_hit(1044 + 333, 398, true, recruiting_name)) {
+            if (scr_text_hit(1377, 398, true, recruiting_name)) {
                 obj_cursor.image_index = 2;
                 if (mouse_button_clicked()) {
                     text_selected = "recruiting_name";
@@ -69,17 +63,17 @@ function player_recruit_planet_selection() {
                 recruiting_name = keyboard_string;
             }
             draw_set_alpha(0.75);
-            draw_rectangle(925 + 333, 398, 1160 + 333, 418, 1);
+            draw_rectangle(1258, 398, 1493, 418, 1);
             draw_set_alpha(1);
 
             if (_recruit_world_type == 2) {
                 var _refresh_rec_name_btn = [
                     1503,
                     398,
-                    1503 + 20,
-                    398 + 20
+                    1523,
+                    418
                 ];
-                draw_unit_buttons(_refresh_rec_name_btn, "?", [1, 1], CM_GREEN_COLOR,, fnt_40k_14b);
+                draw_unit_buttons(_refresh_rec_name_btn, "?", [1, 1], CM_GREEN_COLOR, fa_center, fnt_40k_14b);
                 if (point_and_click(_refresh_rec_name_btn)) {
                     var _new_rec_name = global.name_generator.GenerateFromSet("star", false);
                     recruiting_name = _new_rec_name;
@@ -142,7 +136,7 @@ function scr_creation_home_planet_create() {
         if (custom == eCHAPTER_TYPE.CUSTOM) {
             draw_sprite_stretched(spr_creation_arrow, 0, 525, 285, 32, 32);
             draw_sprite_stretched(spr_creation_arrow, 1, 725, 285, 32, 32);
-            homeworld = list_traveler(planet_types, homeworld, [525, 285, 525 + 32, 285 + 32], [725, 285, 725 + 32, 285 + 32]);
+            homeworld = list_traveler(planet_types, homeworld, [525, 285, 557, 317], [725, 285, 757, 317]);
         }
         var _system_complex = buttons.complex_homeworld;
         _system_complex.update();
@@ -203,11 +197,11 @@ function scr_creation_home_planet_create() {
     right_data_slate.draw(1210, 5, 0.45, 1);
 
     if (recruiting_exists == 0 && homeworld_exists == 1) {
-        scr_image("ui/planet", _cur_planet_index, 580 + 333, 244, 128, 128);
+        scr_image("ui/planet", _cur_planet_index, 913, 244, 128, 128);
 
         draw_set_alpha(0.5);
-        draw_text_transformed(644 + 333, 378, homeworld, 0.5, 0.5, 0);
-        draw_text_transformed(644 + 333, 398, homeworld_name, 0.5, 0.5, 0);
+        draw_text_transformed(977, 378, homeworld, 0.5, 0.5, 0);
+        draw_text_transformed(977, 398, homeworld_name, 0.5, 0.5, 0);
         draw_set_alpha(1);
     }
 

--- a/scripts/scr_diplomacy_helpers/scr_diplomacy_helpers.gml
+++ b/scripts/scr_diplomacy_helpers/scr_diplomacy_helpers.gml
@@ -1,10 +1,7 @@
-// Script assets have changed for v2.3.0 see
-// https://help.yoyogames.com/hc/en-us/articles/360005277377 for more information
 function relationship_hostility_matrix(faction) {
     var _rela = "neutral";
     var _disp = disposition[faction];
     with (obj_controller) {
-        // if (diplomacy!=8){
         if (_disp >= 60) {
             _rela = "friendly";
         }
@@ -14,7 +11,6 @@ function relationship_hostility_matrix(faction) {
         if (_disp < 20) {
             _rela = "hostile";
         }
-        // }
         if (diplomacy == 6) {
             if (_disp >= 60) {
                 _rela = "friendly";
@@ -112,7 +108,6 @@ function basic_diplomacy_screen() {
                 yy += 60;
             }
 
-            var left, top, right, base, opt;
             option_selections = [];
             var diplo_pressed = -1;
             for (var slot = 0; slot < opts; slot++) {
@@ -129,29 +124,16 @@ function basic_diplomacy_screen() {
             if (diplo_pressed > -1) {
                 evaluate_chosen_diplomacy_option(diplo_pressed);
             }
-            yy = camera_get_view_y(view_camera[0]);
         }
         if ((menu == eMENU.DIPLOMACY) && (diplomacy == 10.1)) {
             scr_emmisary_diplomacy_routes();
         }
-        /*if (force_goodbye=1){
-            draw_rectangle(xx+818,yy+796,xx+897,yy+815,0);
-            draw_set_color(0);
-            draw_text(xx+857.5,yy+797,"Exit");
-            draw_set_alpha(0.2);
-            if (mouse_x>=xx+818) and (mouse_y>=yy+796) and (mouse_x<=xx+897) and (mouse_y<=yy+815) then draw_rectangle(xx+818,yy+796,xx+897,yy+815,0);
-            draw_set_alpha(1);
-        }*/
     }
 }
 
 function draw_character_diplomacy() {
     var _diplo_unit = character_diplomacy;
     if (_diplo_unit.allegiance == global.chapter_name) {
-        /*if (advi="flee") {
-            _diplomacy_faction_name="Master of the Fleet "+string(obj_ini.lord_admiral_name);
-        }*/
-        var _splash = "";
         var _specific_splash = 0;
         _diplomacy_faction_name = _diplo_unit.name_role();
         _diplo_unit.IsSpecialist(SPECIALISTS_HEADS);
@@ -167,26 +149,21 @@ function draw_character_diplomacy() {
             _specific_splash = struct_exists(_customs, "forge_master") ? _customs.forge_master : 5;
         }
         scr_image("advisor/splash", _specific_splash, 16, 43, 310, 828);
-        /* else if (advi="") {
-            _diplomacy_faction_name="First Sergeant "+string(recruiter_name); 
-        }*/
     }
 
     var _main_slate = diplo_buttons.main_slate;
     var _meet = diplo_buttons.meet_slate;
     var _cm_slate = diplo_buttons.cm_slate;
-    with (_meet) {
-        XX = 0;
-        YY = 520;
-        width = 520;
-    }
+    _meet.XX = 0;
+    _meet.YY = 520;
+    _meet.width = 520;
 
     _meet.inside_method = function() {
         var _diplo_unit = obj_controller.character_diplomacy;
-        if (!struct_exists(obj_controller, "diplo_image")) {
+        if (!variable_instance_exists(obj_controller, "diplo_image")) {
             obj_controller.diplo_image = _diplo_unit.draw_unit_image();
         }
-        obj_controller.diplo_image.draw(210, 520 - 271, true, 1, 1, 0, CM_GREEN_COLOR, 1);
+        obj_controller.diplo_image.draw(210, 249, true, 1, 1, 0, CM_GREEN_COLOR, 1);
         _diplo_unit.stat_display(false, {x1: 10, y1: 520, w: 569, h: 303}, true);
         draw_sprite(spr_holo_pad, 0, 210, 520);
     };
@@ -201,19 +178,17 @@ function draw_character_diplomacy() {
     draw_text_transformed(622, 104, $"{_diplo_unit.name_role()}", 0.6, 0.6, 0);
     draw_set_halign(fa_left);
 
-    with (_cm_slate) {
-        XX = _main_slate.XX + _main_slate.width;
-        YY = 520;
-    }
+    _cm_slate.XX = _main_slate.XX + _main_slate.width;
+    _cm_slate.YY = 520;
     _cm_slate.inside_method = function() {
         var _master = fetch_unit([0, 0]);
 
-        if (!struct_exists(obj_controller, "master_image")) {
+        if (!variable_instance_exists(obj_controller, "master_image")) {
             obj_controller.master_image = _master.draw_unit_image();
         }
-        obj_controller.master_image.draw(1108 + 200, 520 - 271, true, 1, 1, 0, CM_GREEN_COLOR, 1);
+        obj_controller.master_image.draw(1308, 249, true, 1, 1, 0, CM_GREEN_COLOR, 1);
         _master.stat_display(false, {x1: 1108, y1: 520, w: 569, h: 303}, true);
-        draw_sprite(spr_holo_pad, 0, 1108 + 200, 520);
+        draw_sprite(spr_holo_pad, 0, 1308, 520);
     };
     _cm_slate.draw_with_dimensions();
 

--- a/scripts/scr_ui_diplomacy/scr_ui_diplomacy.gml
+++ b/scripts/scr_ui_diplomacy/scr_ui_diplomacy.gml
@@ -133,7 +133,7 @@ function draw_diplomacy_diplo_text() {
     draw_set_alpha(1);
     draw_set_color(CM_GREEN_COLOR);
     draw_set_halign(fa_left);
-    draw_text_ext(336 + 16, 209, string_hash_to_newline(string(diplo_txt)), -1, 536);
+    draw_text_ext(352, 209, string_hash_to_newline(string(diplo_txt)), -1, 536);
     draw_set_halign(fa_center);
     draw_line(xx + 429, yy + 710, xx + 800, yy + 710);
 }
@@ -462,13 +462,6 @@ function scr_ui_diplomacy() {
             draw_rectangle(xx + 688, yy + 240, xx + 1028, yy + 281, 0);
             draw_set_alpha(1);
         }
-        var x6, y6, x7, y7;
-        x6 = 0;
-        y6 = 0;
-        x7 = 0;
-        y7 = 0;
-        xx -= 55;
-        yy += 20;
 
         #region faction talks/ignore stuff
 
@@ -492,8 +485,7 @@ function scr_ui_diplomacy() {
 
     if (diplomacy > 0) {
         // Diplomacy - Speaking
-        var daemon;
-        daemon = false;
+        var daemon = false;
         if ((diplomacy > 10) && (diplomacy < 11)) {
             daemon = true;
         }
@@ -506,7 +498,7 @@ function scr_ui_diplomacy() {
             }
         }
 
-        if (daemon == false) {
+        if (!daemon) {
             if (diplomacy != eFACTION.ELDAR) {
                 scr_image("diplomacy/splash", diplomacy, xx + 16, yy + 43, 310, 828);
             }
@@ -537,15 +529,15 @@ function scr_ui_diplomacy() {
 
         draw_text_transformed(xx + 622, yy + 66, _diplomacy_faction_name, 1, 1, 0);
 
-        if (daemon == true) {
+        if (daemon) {
             draw_text_transformed(xx + 622, yy + 104, "The Emmmisary", 0.6, 0.6, 0);
             show_stuff = true;
-        } else if (daemon == false) {
+        } else {
             draw_text_transformed(xx + 622, yy + 104, $"{faction_title[diplomacy]} {faction_leader[diplomacy]} {_diplomacy_faction_alligience}", 0.6, 0.6, 0);
         }
 
         draw_set_font(fnt_40k_14);
-        if (daemon == false) {
+        if (!daemon) {
             _disposition_rating = $"Disposition: {faction_disposition_rating_string(diplomacy)} ({disposition[diplomacy]})";
             draw_text(xx + 622, yy + 144, _disposition_rating);
             scr_draw_rainbow(xx + 366, yy + 165, xx + 871, yy + 175, (disposition[diplomacy] / 200) + 0.5);


### PR DESCRIPTION
Some misc scripts not related to combat very much.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleans up non-combat scripts across helpers, creation, and diplomacy to remove dead code, simplify logic, and tighten UI hitboxes/positions. Also standardizes cached image checks and improves autosave reliability.

- **Refactors**
  - Helpers: removed camera resets and unused vars; simplified booleans; consolidated end-turn autosave.
  - Fleet view: clearer ship-health aggregation with named vars; sets `man_max` correctly; dropped recruiter/admiral lookup loops.
  - Creation: replaced `string_hash_to_newline` with literals; used `c_black`/hex colors; simpler hover/selection logic; safer custom icon loading via `is_undefined`; tidied draw positions.
  - Homeworld/Recruit: aligned planet preview and name field; centered “?” refresh button; cleaned text input handling.
  - Diplomacy: consistent slate layout and draw positions; cache character/master images with `variable_instance_exists`; simpler daemon checks.

- **Bug Fixes**
  - Fixed click/hover rectangles for chapter icon picker and planet traveler arrows; aligned “Cancel” and portraits; removed stray `xx/yy` offsets in diplomacy.
  - Autosave now runs every 10 turns when `global.settings.autosave` is enabled.

<sup>Written for commit 916196ba4a4187621bed5cb49ccb9e7cf54adcce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

