### PR TITLE
ci: Move dwnld link to embed top

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -300,6 +300,6 @@ jobs:
           content: "<@&1318332223232938014>"
           embed-title: "${{ needs.prepare_release.outputs.release_name }}"
           embed-description: |
-            ${{ steps.build_changelog.outputs.changelog }}
             **Download:** ${{ steps.create_release.outputs.url }}
+            ${{ steps.build_changelog.outputs.changelog }}
           embed-footer-text: "These builds are auto-generated every 12 hours. Their stability is unpredictable. 20 last builds retained at the same time. You can always revert to an older one."


### PR DESCRIPTION
It was cutting off when the description is too long.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move the “Download” link to the top of the embed description in the release workflow so it stays visible when the changelog is long. This prevents the link from being cut off by embed truncation.

<sup>Written for commit 661e92912580ae35a6160fce5c2734e3dbf29a95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

