### PR TITLE
refactor: Fleet registration, creation, and other stuff

### DIFF
--- a/objects/obj_controller/Alarm_1.gml
+++ b/objects/obj_controller/Alarm_1.gml
@@ -64,8 +64,7 @@ if (did) {
         _current_system.p_player[2] += obj_ini.man_size;
     }
 
-    var fleet = instance_create(_current_system.x, _current_system.y, obj_p_fleet);
-    fleet.owner = eFACTION.PLAYER;
+    var fleet = create_player_fleet(_current_system.x, _current_system.y);
 
     for (var f = 0; f < array_length(obj_ini.ship); f++) {
         add_ship_to_fleet(f, fleet);
@@ -500,14 +499,13 @@ for (var i = 0; i < 100; i++) {
             craft.craftworld = 1;
             array_push(craft.p_feature[1], new NewPlanetFeature(eP_FEATURES.WARLORD6));
     
-            var elforce = instance_create(xx, yy, obj_en_fleet);
+            var elforce = create_enemy_fleet(xx, yy, eFACTION.ELDAR);
+            fleet_register_at_star(elforce, craft);  // craft star has name="" so get_nearest_star in create_enemy_fleet won't find it
             elforce.sprite_index = spr_fleet_eldar;
-            elforce.owner = eFACTION.ELDAR;
             elforce.capital_number = choose(2, 3);
             elforce.frigate_number = choose(4, 5, 6);
             elforce.escort_number = floor(random_range(7, 11)) + 1;
             elforce.image_alpha = 0;
-            elforce.orbiting = craft;
             break;
         }
     }

--- a/objects/obj_controller/Create_0.gml
+++ b/objects/obj_controller/Create_0.gml
@@ -1099,7 +1099,7 @@ if (instance_exists(obj_ini)) {
 }
 //Set player colour
 try {
-    global.star_name_colors[1] = make_color_rgb(body_colour_replace[0], body_colour_replace[1], body_colour_replace[2]);
+    global.star_name_colors[1] = make_color_rgb(col_r[main_color], col_g[main_color], col_b[main_color]);
 } catch (_exception) {
     global.star_name_colors[1] = make_color_rgb(col_r[1], col_g[1], col_b[1]);
 }

--- a/objects/obj_en_fleet/Alarm_1.gml
+++ b/objects/obj_en_fleet/Alarm_1.gml
@@ -5,30 +5,19 @@ try {
         owner = 0;
     }
 
-    //TODO centralise orbiting logic
-    var _is_orbiting = is_orbiting();
     if (action == "" && owner != 0) {
-        if (_is_orbiting) {
-            var orbiting_found = variable_instance_exists(orbiting, "present_fleet");
-            if (orbiting_found) {
-                orbiting.present_fleet[owner] += 1;
-            }
-        } else if (!_is_orbiting) {
-            orbiting = instance_nearest(x, y, obj_star);
-            orbiting.present_fleet[owner]++;
-        }
+        fleet_register_at_nearest_star(id);
     }
     var _khorne_cargo = fleet_has_cargo("warband");
     if (_khorne_cargo && owner == eFACTION.CHAOS) {
         khorne_fleet_cargo();
     }
 
-    if (_is_orbiting) {
+    if (instance_exists(orbiting)) {
         turns_static++;
         if (turns_static > 5 && owner == eFACTION.ORK) {
             if (!irandom(7)) {
                 ork_fleet_move();
-                _is_orbiting = false;
             }
         }
         if (instance_exists(obj_crusade)) {
@@ -43,11 +32,10 @@ try {
     }
 
     var dir = 0;
-    var ret = 0;
 
-    if (navy && action == "" && _is_orbiting) {
+    if (navy && action == "" && instance_exists(orbiting)) {
         navy_orbiting_planet_end_turn_action();
-    } else if (action == "" && _is_orbiting) {
+    } else if (action == "" && instance_exists(orbiting)) {
         var max_dis = 400;
 
         if ((orbiting.owner == eFACTION.PLAYER) && (obj_controller.faction_status[eFACTION.IMPERIUM] == "War") && (owner == eFACTION.IMPERIUM)) {
@@ -212,8 +200,6 @@ try {
                     obj_controller.known[eFACTION.INQUISITION] = 4;
                 }
 
-                orbiting = instance_nearest(x, y, obj_star);
-
                 if (obj_controller.loyalty_hidden <= 0) {
                     var moo = false;
                     if ((obj_controller.penitent == 1) && (moo == false)) {
@@ -228,7 +214,6 @@ try {
                 exit_star = distance_removed_star(x, y, choose(2, 3, 4));
                 action_x = exit_star.x;
                 action_y = exit_star.y;
-                orbiting = exit_star;
                 set_fleet_movement();
                 trade_goods = "|DELETE|";
                 exit;
@@ -316,7 +301,7 @@ try {
                             }
 
                             var new_fleet;
-                            new_fleet = instance_create(x, y, obj_en_fleet);
+                            new_fleet = create_enemy_fleet(x, y, eFACTION.TYRANIDS);
                             new_fleet.capital_number = floor(capital_number * 0.4);
                             new_fleet.frigate_number = floor(frigate_number * 0.4);
                             new_fleet.escort_number = floor(escort_number * 0.4);
@@ -324,8 +309,6 @@ try {
                             capital_number -= new_fleet.capital_number;
                             frigate_number -= new_fleet.frigate_number;
                             escort_number -= new_fleet.escort_number;
-
-                            new_fleet.owner = eFACTION.TYRANIDS;
                             new_fleet.sprite_index = spr_fleet_tyranid;
                             new_fleet.image_index = 1;
 
@@ -374,11 +357,11 @@ try {
 
         var dos = 0;
         dos = point_distance(x, y, action_x, action_y);
-        orbiting = dos / action_eta;
+        var _move_step = dos / action_eta;
         dir = point_direction(x, y, action_x, action_y);
 
-        x = x + lengthdir_x(orbiting, dir);
-        y = y + lengthdir_y(orbiting, dir);
+        x = x + lengthdir_x(_move_step, dir);
+        y = y + lengthdir_y(_move_step, dir);
 
         action_eta -= 1;
 

--- a/objects/obj_en_fleet/Alarm_11.gml
+++ b/objects/obj_en_fleet/Alarm_11.gml
@@ -1,5 +1,0 @@
-if (is_orbiting()) {
-    if (owner != 1) {
-        orbiting.present_fleet[owner] += 1;
-    }
-}

--- a/objects/obj_en_fleet/Alarm_8.gml
+++ b/objects/obj_en_fleet/Alarm_8.gml
@@ -1,6 +1,0 @@
-var wop = instance_nearest(x, y, obj_star);
-if (instance_exists(wop)) {
-    if (point_distance(x, y, wop.x, wop.y) <= 40) {
-        wop.present_fleet[owner] += 1;
-    }
-}

--- a/objects/obj_en_fleet/Create_0.gml
+++ b/objects/obj_en_fleet/Create_0.gml
@@ -6,7 +6,7 @@ guardsmen = 0;
 home_x = 0;
 home_y = 0;
 selected = 0;
-ret = 0;
+tau_fled = 0;
 hurt = 0;
 /// @type {Id.Instance.obj_star}
 orbiting = noone;
@@ -76,8 +76,6 @@ capital_health = 100;
 frigate_health = 100;
 escort_health = 100;
 
-alarm[8] = 1;
-
 #region save/load serialization
 
 /// Called from save function to take all object variables and convert them to a json savable format and return it
@@ -89,7 +87,6 @@ serialize = function() {
         x,
         y,
         cargo_data: cargo_data,
-        orbiting: instance_exists(orbiting) ? true : false,
     };
 
     var excluded_from_save = [
@@ -132,10 +129,6 @@ deserialize = function(save_data) {
             _boss.load_json_data(cargo_data.ork_warboss);
             cargo_data.ork_warboss = _boss;
         }
-    }
-
-    if (save_data.orbiting && (save_data.orbiting != noone)) {
-        orbiting = instance_nearest(x, y, obj_star);
     }
 };
 

--- a/objects/obj_en_fleet/Destroy_0.gml
+++ b/objects/obj_en_fleet/Destroy_0.gml
@@ -1,8 +1,5 @@
-if ((action == "") && (orbiting != noone)) {
-    if (orbiting == instance_nearest(x, y, obj_star)) {
-        orbiting.present_fleet[owner] -= 1;
-    }
-    orbiting = noone;
+if ((action == "") && (instance_exists(orbiting))) {
+    fleet_unregister_from_star(id);
 }
 
 if (instance_exists(obj_controller)) {

--- a/objects/obj_en_fleet/Draw_0.gml
+++ b/objects/obj_en_fleet/Draw_0.gml
@@ -2,6 +2,7 @@ if ((obj_controller.menu != 0) || !instance_exists(obj_star)) {
     exit;
 }
 var scale = obj_controller.scale_mod;
+
 if ((owner == eFACTION.ELDAR) && instance_exists(orbiting) && (obj_controller.is_test_map == true)) {
     draw_set_color(c_red);
     draw_line_width(x, y, orbiting.x, orbiting.y, 1);
@@ -72,18 +73,16 @@ if (obj_controller.zoomed == 1) {
         }
     }
 
+var line_width = 2 * scale;
+var text_size = obj_controller.zoomed ? 2 * scale : scale;
+
 if (action != "") {
     draw_set_halign(fa_left);
     draw_set_alpha(1);
-    draw_set_color(c_white);
-    draw_line_width(x, y, action_x, action_y, 1);
+    draw_set_color(CM_GREEN_COLOR);
+    draw_line_width(x, y, action_x, action_y, line_width);
     draw_set_font(fnt_40k_14b);
-    if (obj_controller.zoomed == 0) {
-        draw_text_transformed(x + 12, y, string_hash_to_newline("ETA " + string(action_eta)), 1, 1, 0);
-    }
-    if (obj_controller.zoomed == 1) {
-        draw_text_transformed(x + 24, y, string_hash_to_newline("ETA " + string(action_eta)), 2, 2, 0);
-    } // was 1.4
+    draw_text_transformed_outline(x + 12, y, $"ETA {action_eta}", text_size, text_size, 0);
 }
 var _has_warboss = false;
 switch (owner) {
@@ -187,6 +186,8 @@ draw_sprite_ext(sprite_index, image_index, x + (coords[0] * scale), y + (coords[
 if (instance_exists(target)) {
     draw_set_color(c_red);
     draw_set_alpha(0.5);
-    draw_line(x, y, target.x, target.y);
+    draw_line_width(x, y, target.x, target.y, line_width);
     draw_set_alpha(1);
 }
+
+draw_set_color(c_white);

--- a/objects/obj_en_fleet/Step_0.gml
+++ b/objects/obj_en_fleet/Step_0.gml
@@ -94,8 +94,7 @@ if ((owner == eFACTION.TAU) && (action == "") && (obj_controller.tau_messenger >
     var good = 0;
 
     var fleet = instance_nearest(x, y, obj_star);
-    fleet.tau_fleets += 1;
-    fleet.present_fleets += 1;
+    obj_controller.tau_fleets += 1;
     instance_deactivate_object(fleet);
 
     fleet = create_enemy_fleet(x, y, eFACTION.TAU);

--- a/objects/obj_en_fleet/Step_0.gml
+++ b/objects/obj_en_fleet/Step_0.gml
@@ -2,18 +2,8 @@ if ((global.load >= 0) || instance_exists(obj_saveload)) {
     exit;
 }
 
-if ((action != "") && (orbiting != noone)) {
-    if (instance_exists(orbiting)) {
-        if (variable_instance_exists(orbiting, "present_fleet")) {
-            orbiting.present_fleet[owner] -= 1;
-            orbiting = noone;
-        } else {
-            orbiting = instance_nearest(x, y, obj_star);
-            var cur_owner_fleet = orbiting.present_fleet[owner];
-            orbiting.present_fleet[owner] = cur_owner_fleet > 0 ? cur_owner_fleet - 1 : cur_owner_fleet == 0;
-            orbiting = noone;
-        }
-    }
+if ((action != "") && (instance_exists(orbiting))) {
+    fleet_unregister_from_star(id);
 }
 
 if (capital_number < 0) {
@@ -108,8 +98,7 @@ if ((owner == eFACTION.TAU) && (action == "") && (obj_controller.tau_messenger >
     fleet.present_fleets += 1;
     instance_deactivate_object(fleet);
 
-    fleet = instance_create(x, y, obj_en_fleet);
-    fleet.owner = eFACTION.TAU;
+    fleet = create_enemy_fleet(x, y, eFACTION.TAU);
     fleet.action_spd = 32;
     fleet.frigate_number = 1;
     fleet.sprite_index = spr_fleet_tau;

--- a/objects/obj_ncombat/Alarm_7.gml
+++ b/objects/obj_ncombat/Alarm_7.gml
@@ -149,6 +149,8 @@ try {
                 with (obj_en_fleet) {
                     if ((navy == 0) && (owner == eFACTION.IMPERIUM) && (point_distance(x, y, obj_temp8.x, obj_temp8.y) < 40)) {
                         owner = eFACTION.CHAOS;
+                        other.battle_object.present_fleet[2] -= 1;
+                        other.battle_object.present_fleet[10] += 1;
                         sprite_index = spr_fleet_chaos;
                         if (image_index <= 2) {
                             escort_number += 3;
@@ -159,8 +161,6 @@ try {
                         }
                     }
                 }
-                battle_object.present_fleet[2] -= 1;
-                battle_object.present_fleet[10] += 1;
             }
             with (obj_temp8) {
                 instance_destroy();

--- a/objects/obj_p_fleet/Alarm_1.gml
+++ b/objects/obj_p_fleet/Alarm_1.gml
@@ -6,9 +6,9 @@ try {
         exit;
     } else if (action == "") {
         var spid = instance_nearest(x, y, obj_star);
-        set_fleet_orbiting(self, spid);
+        fleet_register_at_star(self, spid);
 
-        if ((orbiting != noone) && instance_exists(orbiting)) {
+        if (instance_exists(orbiting)) {
             if (orbiting.visited == 0) {
                 for (var planet_num = 1; planet_num <= orbiting.planets; planet_num += 1) {
                     if (array_length(orbiting.p_feature[planet_num]) != 0) {
@@ -83,8 +83,7 @@ try {
             if (steh.vision == 0) {
                 steh.vision = 1;
             }
-            steh.present_fleet[1] += 1;
-            orbiting = steh;
+            fleet_register_at_star(id, steh);
 
             meet_system_governors(steh);
 

--- a/objects/obj_p_fleet/Alarm_11.gml
+++ b/objects/obj_p_fleet/Alarm_11.gml
@@ -1,4 +1,0 @@
-if ((action == "") && (orbiting != noone)) {
-    orbiting = instance_nearest(x, y, obj_star);
-    orbiting.present_fleet[1] += 1;
-}

--- a/objects/obj_p_fleet/Create_0.gml
+++ b/objects/obj_p_fleet/Create_0.gml
@@ -8,14 +8,6 @@ orbiting = noone;
 warp_able = true;
 ii_check = choose(8, 9, 10, 11, 12);
 
-var wop = instance_nearest(x, y, obj_star);
-if (instance_exists(wop) && (y > 0) && (x > 0)) {
-    if (point_distance(x, y, wop.x, wop.y) <= 40) {
-        orbiting = wop;
-        orbiting.present_fleet[1] += 1;
-    }
-}
-
 point_breakdown = single_loc_point_data();
 image_xscale = 1.25;
 image_yscale = 1.25;
@@ -64,7 +56,6 @@ serialize = function() {
         x,
         y,
         point_breakdown: point_breakdown,
-        orbiting: instance_exists(orbiting) ? true : false,
     };
     var excluded_from_save = [
         "temp",
@@ -97,11 +88,7 @@ deserialize = function(save_data) {
         }
     }
 
-    if (save_data.orbiting && (save_data.orbiting != noone)) {
-        var nearest_star = instance_nearest(x, y, obj_star);
-        set_player_fleet_image();
-        orbiting = nearest_star;
-    }
+    set_player_fleet_image();
 };
 
 #endregion

--- a/objects/obj_p_fleet/Destroy_0.gml
+++ b/objects/obj_p_fleet/Destroy_0.gml
@@ -1,6 +1,3 @@
-if ((action == "") && (orbiting != noone)) {
-    if (instance_exists(orbiting)) {
-        orbiting.present_fleet[1] -= 1;
-    }
-    orbiting = noone;
+if ((action == "") && (instance_exists(orbiting))) {
+    fleet_unregister_from_star(id);
 }

--- a/objects/obj_p_fleet/Draw_0.gml
+++ b/objects/obj_p_fleet/Draw_0.gml
@@ -75,17 +75,17 @@ if (!keyboard_check(vk_shift)) {
         }
     }
 
-var line_width = sqr(scale);
-var text_size = sqr(scale);
+var line_width = 2 * scale;
+var text_size = obj_controller.zoomed ? 2 * scale : scale;
 
 if (action != "") {
     draw_set_halign(fa_left);
     draw_set_alpha(1);
-    draw_set_color(c_white);
+    draw_set_color(CM_GREEN_COLOR);
     draw_line_width(x, y, action_x, action_y, line_width);
     draw_set_font(fnt_40k_14b);
+    draw_text_transformed_outline(x + 12, y, $"ETA {action_eta}", text_size, text_size, 0);
 
-    draw_text_transformed(x + 12, y, string_hash_to_newline("ETA " + string(action_eta)), text_size, text_size, 0);
     if (array_length(complex_route) > 0) {
         var next_loc = instance_nearest(action_x, action_y, obj_star);
         for (var i = 0; i < array_length(complex_route); i++) {
@@ -128,4 +128,5 @@ if ((within == 1) || (selected > 0)) {
     draw_set_alpha(1);
 }
 
+draw_set_color(c_white);
 draw_sprite_ext(sprite_index, image_index, x + (coords[0] * scale), y + (coords[1] * scale), 1 * scale, 1 * scale, 0, c_white, 1);

--- a/objects/obj_p_fleet/Step_0.gml
+++ b/objects/obj_p_fleet/Step_0.gml
@@ -2,10 +2,8 @@ ii_check -= 1;
 if (action == "Lost") {
     exit;
 }
-if ((action != "") && (orbiting != noone)) {
-    orbiting = instance_nearest(x, y, obj_star);
-    orbiting.present_fleet[1] -= 1;
-    orbiting = noone;
+if ((action != "") && (instance_exists(orbiting))) {
+    fleet_unregister_from_star(id);
 }
 
 action_spd = calculate_action_speed();

--- a/objects/obj_pnunit/Alarm_3.gml
+++ b/objects/obj_pnunit/Alarm_3.gml
@@ -99,14 +99,15 @@ try {
                 var norun = 0;
 
                 for (var i = 1; i <= 20; i++) {
-                    if (apa[i] >= 30) {
+                    if (apa[i] > 2) {
                         norun = 1;
+                        break;
                     }
                 }
 
-                if (norun == 0) {
+                if (norun == 0 && x > 10) {
                     x -= 10;
-                    engaged = 0;
+                    engaged = false;
                 }
             }
         }

--- a/objects/obj_star/Alarm_1.gml
+++ b/objects/obj_star/Alarm_1.gml
@@ -170,8 +170,7 @@ if (owner == eFACTION.IMPERIUM || owner == eFACTION.ORK || owner == eFACTION.MEC
 
     if (system_fleet > 0) {
         // DISABLED FOR TESTING FLEET COMBAT
-        fleet = instance_create(x, y, obj_en_fleet);
-        fleet.owner = eFACTION.IMPERIUM;
+        fleet = create_enemy_fleet(x, y, eFACTION.IMPERIUM);
 
         fleet.capital_number = capital;
         fleet.frigate_number = frigate;
@@ -255,8 +254,7 @@ if (owner == eFACTION.TAU) {
         escort = floor(random_range(5, 12));
     }
     if (system_fleet > 0) {
-        fleet = instance_create(x, y, obj_en_fleet);
-        fleet.owner = eFACTION.TAU;
+        fleet = create_enemy_fleet(x, y, eFACTION.TAU);
         // Create ships here
         fleet.sprite_index = spr_fleet_tau;
         fleet.image_speed = 0;

--- a/objects/obj_star/Create_0.gml
+++ b/objects/obj_star/Create_0.gml
@@ -157,7 +157,6 @@ serialize = function() {
         obj: object_get_name(object_index),
         x,
         y,
-        present_fleet: object_star.present_fleet,
         planet_data: planet_data,
     };
 
@@ -172,7 +171,8 @@ serialize = function() {
         "arraysum",
         "system_garrison",
         "system_sabatours",
-        "system_datas"
+        "system_datas",
+        "present_fleet"
     ];
     var excluded_from_save_start = ["p_"];
 
@@ -198,11 +198,6 @@ function deserialize(save_data) {
         }
         var loaded_value = struct_get(save_data, var_name);
         variable_instance_set(id, var_name, loaded_value);
-    }
-
-    // Set explicit vars here
-    if (struct_exists(save_data, "present_fleet")) {
-        variable_instance_set(id, "present_fleet", save_data.present_fleet);
     }
 
     if (struct_exists(save_data, "planet_data")) {

--- a/objects/obj_turn_end/Create_0.gml
+++ b/objects/obj_turn_end/Create_0.gml
@@ -53,7 +53,7 @@ battle = array_create(_popup_size, 0);
 battle_location = array_create(_popup_size, "");
 battle_world = array_create(_popup_size, 0);
 battle_opponent = array_create(_popup_size, 0);
-/// @type {Asset.GMObject.obj_star} 
+/// @type {Array<Id.Instance.obj_star>} 
 battle_object = array_create(_popup_size, noone);
 battle_pobject = array_create(_popup_size, 0);
 battle_special = array_create(_popup_size, "");

--- a/objects/obj_turn_end/Draw_0.gml
+++ b/objects/obj_turn_end/Draw_0.gml
@@ -53,7 +53,7 @@ if ((show > 0) && (current_battle <= battles)) {
     draw_set_font(fnt_40k_14);
     draw_set_halign(fa_left);
 
-    if (battle_world[i] < 0) {
+    if (battle_world[i] == 0) {
         draw_set_font(fnt_40k_14b);
         draw_set_halign(fa_left);
 

--- a/scripts/__init/__init.gml
+++ b/scripts/__init/__init.gml
@@ -187,16 +187,16 @@ function __init() {
     global.star_name_colors = [
         c_gray,
         c_white, // Player
-        c_gray, // Imperium
-        c_red, // Mechanicus
-        CM_GREEN_COLOR, // Inquisition (Default)
+        #7a7a7a, // Imperium
+        #B22222, // Mechanicus
+        c_white, // Inquisition
         c_white, // Ecclesiarchy
         #FF8000, // Eldar
         #009500, // Orks
         #FECB01, // Tau
         #AD5272, // Tyranids
         c_dkgray, // Chaos
-        CM_GREEN_COLOR, // Heretics (Default)
+        c_dkgray, // Heretics
         #AD5272, // why 12 is skipped in general, we will never know
         #80FF00 // Necrons
     ];

--- a/scripts/scr_PlanetData/scr_PlanetData.gml
+++ b/scripts/scr_PlanetData/scr_PlanetData.gml
@@ -898,11 +898,8 @@ function PlanetData(_planet, _system) constructor {
 
                     var locy = $"{name()}";
 
-                    var flit = instance_create(system.x, system.y, obj_p_fleet);
-
                     var _slaughter = new_player_ship("Gloriana", system.name, "Slaughtersong");
-                    add_ship_to_fleet(_slaughter, flit);
-                    flit.oribiting = system.id;
+                    var flit = create_player_fleet(system.x, system.y, [_slaughter]);
 
                     scr_popup($"Ancient Ship Restored", $"The ancient ship within the ruins of {locy} has been fully repaired.  It is determined to be a Gloriana Class vessel and is bristling with golden age weaponry and armour.  Your {string(obj_ini.role[100][16])}s are excited; the Slaughtersong is ready for it's maiden voyage, at your command.", "", "");
                 }
@@ -1749,13 +1746,11 @@ function PlanetData(_planet, _system) constructor {
                             }
                         }
                     } else if (system.present_fleet[eFACTION.NECRONS] == 0) {
-                        necron_fleet = instance_create(x, y, obj_en_fleet);
-                        necron_fleet.owner = eFACTION.NECRONS;
+                        necron_fleet = create_enemy_fleet(x, y, eFACTION.NECRONS);
                         necron_fleet.capital_number = 1;
                         necron_fleet.sprite_index = spr_fleet_necron;
                         necron_fleet.image_speed = 0;
                         necron_fleet.image_index = 1;
-                        system.present_fleet[eFACTION.NECRONS] += 1;
                     }
                     var enemy_fleets = 0;
                     with (necron_fleet) {
@@ -1774,14 +1769,12 @@ function PlanetData(_planet, _system) constructor {
                         }
                     }
                     if (enemy_fleets > 0) {
-                        var necron_fleet2 = instance_create(x, y, obj_en_fleet);
-                        necron_fleet2.owner = eFACTION.NECRONS;
+                        var necron_fleet2 = create_enemy_fleet(x, y, eFACTION.NECRONS);
                         necron_fleet2.sprite_index = spr_fleet_necron;
                         necron_fleet.image_speed = 0;
                         necron_fleet2.capital_number = 1;
                         necron_fleet2.frigate_number = round(necron_fleet.frigate_number / 2);
                         necron_fleet2.escort_number = round(necron_fleet.escort_number / 2);
-                        system.present_fleet[eFACTION.NECRONS] += 1;
 
                         necron_fleet.capital_number -= 1;
                         necron_fleet.frigate_number -= necron_fleet2.frigate_number;

--- a/scripts/scr_cheatcode/scr_cheatcode.gml
+++ b/scripts/scr_cheatcode/scr_cheatcode.gml
@@ -640,12 +640,10 @@ function system_debug_enemy_invasion_spawn() {
         with (obj_star) {
             if ((choose(0, 1, 1) == 1) && (owner != eFACTION.ELDAR) && (owner != 1)) {
                 /// @type {Asset.GMObject.obj_en_fleet}
-                var fleet = instance_create(x, y, obj_en_fleet);
-                fleet.owner = obj_popup.invasion_faction;
+                var fleet = create_enemy_fleet(x, y, obj_popup.invasion_faction);
                 if (obj_popup.invasion_faction == 7) {
                     fleet.sprite_index = spr_fleet_ork;
                     fleet.capital_number = 3;
-                    present_fleet[7] += 1;
                 }
                 if (obj_popup.invasion_faction == 9) {
                     if (present_fleet[1] == 0) {
@@ -655,10 +653,8 @@ function system_debug_enemy_invasion_spawn() {
                     fleet.capital_number = 3;
                     fleet.frigate_number = 6;
                     fleet.escort_number = 16;
-                    present_fleet[9] += 1;
                 }
                 fleet.image_index = 4;
-                fleet.orbiting = id;
             }
         }
         instance_destroy();
@@ -690,28 +686,22 @@ function system_debug_spawn_fleet() {
 /// @self Asset.GMObject.obj_popup
 function debug_spawn_imperium_fleet() {
     /// @type {Asset.GMObject.obj_en_fleet}
-    var fleet = instance_create(star.x, star.y, obj_en_fleet);
-    fleet.owner = eFACTION.IMPERIUM;
+    var fleet = create_enemy_fleet(star.x, star.y, eFACTION.IMPERIUM);
     fleet.sprite_index = spr_fleet_imperial;
     fleet.capital_number = 2;
     fleet.frigate_number = 5;
-    star.present_fleet[2] += 1;
     fleet.image_index = 4;
-    fleet.orbiting = id;
     instance_destroy();
 }
 
 /// @self Asset.GMObject.obj_popup
 function debug_spawn_heretic_fleet() {
     /// @type {Asset.GMObject.obj_en_fleet}
-    var fleet = instance_create(star.x, star.y, obj_en_fleet);
-    fleet.owner = eFACTION.CHAOS;
+    var fleet = create_enemy_fleet(star.x, star.y, eFACTION.CHAOS);
     fleet.sprite_index = spr_fleet_chaos;
     fleet.capital_number = 2;
     fleet.frigate_number = 5;
-    star.present_fleet[10] += 1;
     fleet.image_index = 4;
-    fleet.orbiting = id;
     instance_destroy();
 }
 
@@ -724,28 +714,22 @@ function debug_add_xenos_fleet_options() {
 /// @self Asset.GMObject.obj_popup
 function debug_spawn_ork_fleet() {
     /// @type {Asset.GMObject.obj_en_fleet}
-    var fleet = instance_create(star.x, star.y, obj_en_fleet);
-    fleet.owner = eFACTION.ORK;
+    var fleet = create_enemy_fleet(star.x, star.y, eFACTION.ORK);
     fleet.sprite_index = spr_fleet_ork;
     fleet.capital_number = 2;
     fleet.frigate_number = 5;
-    star.present_fleet[7] += 1;
     fleet.image_index = 4;
-    fleet.orbiting = id;
     instance_destroy();
 }
 
 /// @self Asset.GMObject.obj_popup
 function debug_spawn_tau_fleet() {
     /// @type {Asset.GMObject.obj_en_fleet}
-    var fleet = instance_create(star.x, star.y, obj_en_fleet);
-    fleet.owner = eFACTION.TAU;
+    var fleet = create_enemy_fleet(star.x, star.y, eFACTION.TAU);
     fleet.sprite_index = spr_fleet_tau;
     fleet.capital_number = 2;
     fleet.frigate_number = 5;
-    star.present_fleet[8] += 1;
     fleet.image_index = 4;
-    fleet.orbiting = id;
     instance_destroy();
 }
 

--- a/scripts/scr_controller_helpers/scr_controller_helpers.gml
+++ b/scripts/scr_controller_helpers/scr_controller_helpers.gml
@@ -444,9 +444,7 @@ function scr_end_turn() {
 
                     turn += 1;
                     with (obj_star) {
-                        for (var i = 0; i <= 21; i++) {
-                            present_fleet[i] = 0;
-                        }
+                        present_fleet[20] = 0;
                     }
                     with (obj_p_fleet) {
                         if ((action == "move") && (obj_controller.faction_status[eFACTION.IMPERIUM] == "War")) {

--- a/scripts/scr_enemy_ai_c/scr_enemy_ai_c.gml
+++ b/scripts/scr_enemy_ai_c/scr_enemy_ai_c.gml
@@ -128,13 +128,11 @@ function scr_enemy_ai_c() {
                         if ((contin == 3) && (rando <= 25) && ((obj_controller.chaos_fleets + 15) < instance_number(obj_star))) {
                             // Create a fleet
                             // fleet=instance_create
-                            fleet = instance_create(x, y, obj_en_fleet);
-                            fleet.owner = eFACTION.CHAOS;
+                            fleet = create_enemy_fleet(x, y, eFACTION.CHAOS);
                             fleet.sprite_index = spr_fleet_chaos;
                             fleet.image_index = 1;
                             fleet.frigate_number = 1;
                             fleet.escort_number = 2;
-                            present_fleet[10] += 1;
                             obj_controller.chaos_fleets += 1;
                         }
                     }
@@ -411,12 +409,10 @@ function scr_enemy_ai_c() {
                         }
                         if ((contin == 3) && (rando <= 25) && (obj_controller.tau_fleets < (obj_controller.tau_stars + 1))) {
                             // Create a fleet
-                            fleet = instance_create(x, y, obj_en_fleet);
-                            fleet.owner = eFACTION.TAU;
+                            fleet = create_enemy_fleet(x, y, eFACTION.TAU);
                             fleet.sprite_index = spr_fleet_tau;
                             fleet.image_index = 1;
                             fleet.capital_number = 1;
-                            present_fleet[8] += 1;
                             obj_controller.tau_fleets += 1;
                         }
                     }

--- a/scripts/scr_enemy_ai_d/scr_enemy_ai_d.gml
+++ b/scripts/scr_enemy_ai_d/scr_enemy_ai_d.gml
@@ -135,8 +135,7 @@ function scr_enemy_ai_d() {
 
                     var xx = (random_range(room_width * 1.25, room_width * 2) * choose(-1, 1)) + x;
                     var yy = (random_range(room_height * 1.25, room_height * 2) * choose(-1, 1)) + y;
-                    var fleet = instance_create(xx, yy, obj_en_fleet);
-                    fleet.owner = eFACTION.TYRANIDS;
+                    var fleet = create_enemy_fleet(xx, yy, eFACTION.TYRANIDS);
                     fleet.sprite_index = spr_fleet_tyranid;
                     fleet.image_speed = 0;
 

--- a/scripts/scr_event_code/scr_event_code.gml
+++ b/scripts/scr_event_code/scr_event_code.gml
@@ -96,8 +96,7 @@ function event_end_turn_action() {
                         dirr += irandom_range(50, 100);
                         xx = star_id.x + lengthdir_x(72, dirr);
                         yy = star_id.y + lengthdir_y(72, dirr);
-                        flee = instance_create(xx, yy, obj_en_fleet);
-                        flee.owner = eFACTION.CHAOS;
+                        flee = create_enemy_fleet(xx, yy, eFACTION.CHAOS);
                         flee.sprite_index = spr_fleet_chaos;
                         flee.image_index = 4;
                         flee.capital_number = choose(0, 1);
@@ -129,12 +128,8 @@ function event_end_turn_action() {
                 }
                 if (array_length(active_forges) > 0) {
                     var ship_spawn = active_forges[irandom(array_length(active_forges) - 1)];
-                    var _new_player_fleet = instance_create(ship_spawn.system.x, ship_spawn.system.y, obj_p_fleet);
-
-                    // Creates the ship
                     var last_ship = new_player_ship(new_ship_event, ship_spawn.system.name);
-
-                    add_ship_to_fleet(last_ship, _new_player_fleet);
+                    var _new_player_fleet = create_player_fleet(ship_spawn.system.x, ship_spawn.system.y, [last_ship]);
 
                     // show_message(string(obj_ini.ship_class[last_ship])+":"+string(obj_ini.ship[last_ship]));
 

--- a/scripts/scr_flavor2/scr_flavor2.gml
+++ b/scripts/scr_flavor2/scr_flavor2.gml
@@ -398,7 +398,6 @@ function scr_flavor2(lost_units_count, target_type, hostile_range, hostile_weapo
                 instance_destroy();
             }
         } else {
-            mes_color = eMSG_COLOR.YELLOW;
             mes = m1 + " Fortifications stand strong.";
         }
 

--- a/scripts/scr_fleet_functions/scr_fleet_functions.gml
+++ b/scripts/scr_fleet_functions/scr_fleet_functions.gml
@@ -165,42 +165,31 @@ function get_largest_player_fleet() {
     return chosen_fleet;
 }
 
-/// @self Asset.GMObject.obj_en_fleet|Asset.GMObject.obj_p_fleet
-/// @return {bool}
-function is_orbiting(fleet = noone) {
-    if (fleet == noone) {
-        if (action != "") {
-            return false;
-        }
-        try {
-            var nearest = instance_nearest(x, y, obj_star);
-            if (point_distance(x, y, nearest.x, nearest.y) < 10 && nearest.name != "") {
-                orbiting = nearest.id;
-                return true;
-            }
-            orbiting = noone;
-        } catch (_exception) {
-            return false;
-        }
-        return false;
-    } else {
-        with (fleet) {
-            return is_orbiting();
-        }
+/// @desc Returns the nearest star within max_distance, or noone.
+/// @param {Real} _x
+/// @param {Real} _y
+/// @param {Real} _max_distance  Default 50
+/// @returns {Id.Instance.obj_star|noone}
+function get_nearest_star(_x, _y, _max_distance = 50) {
+    var _near = instance_nearest(_x, _y, obj_star);
+    if (instance_exists(_near) && point_distance(_x, _y, _near.x, _near.y) <= _max_distance && _near.name != "") {
+        return _near;
     }
+
+    return noone;
 }
 
 /// @self Asset.GMObject.obj_en_fleet|Asset.GMObject.obj_p_fleet
 function set_fleet_movement(fastest_route = true, new_action = "move", minimum_eta = 1, maximum_eta = 1000) {
     action = "";
+    var _at_star = instance_exists(orbiting);
 
     if (action == "") {
         turns_static = 0;
-        var mine, fleet;
-        var connected = 0, cont = 0, target_dist = 0;
+        var mine;
         if (fastest_route) {
             mine = instance_nearest(x, y, obj_star);
-            var star_travel = new FastestRouteAlgorithm(x, y, action_x, action_y, self.id, is_orbiting());
+            var star_travel = new FastestRouteAlgorithm(x, y, action_x, action_y, self.id, _at_star);
             var path = star_travel.final_array_path();
             if (array_length(path) > 1) {
                 var targ = find_star_by_name(path[1]);
@@ -226,20 +215,20 @@ function set_fleet_movement(fastest_route = true, new_action = "move", minimum_e
 
             mine = instance_nearest(x, y, obj_star);
 
-            var eta = calculate_fleet_eta(x, y, action_x, action_y, action_spd, _target_is_sys, is_orbiting(), warp_able);
+            var eta = calculate_fleet_eta(x, y, action_x, action_y, action_spd, _target_is_sys, _at_star, warp_able);
             action_eta = eta;
             if ((action_eta <= 0) || (owner != eFACTION.INQUISITION)) {
                 action_eta = eta;
             } else if ((owner == eFACTION.INQUISITION) && (action_eta < 2) && (string_count("_her", trade_goods) == 0)) {
                 action_eta = 2;
             }
-            if (is_orbiting()) {
+            if (_at_star) {
                 if (owner != eFACTION.ELDAR && mine.storm) {
                     action_eta += 10000;
                 }
             }
 
-            orbiting = noone;
+            fleet_unregister_from_star(id);
             action = new_action;
             action_eta = clamp(action_eta, minimum_eta, maximum_eta);
         }
@@ -698,12 +687,11 @@ function fleet_star_draw_offsets() {
 //TODO further split this shite up
 /// @self Asset.GMObject.obj_en_fleet|Asset.GMObject.obj_p_fleet
 function fleet_arrival_logic() {
-    var cur_star, sta, steh_dist, old_x, old_y;
-    cur_star = instance_nearest(action_x, action_y, obj_star);
-    x = cur_star.x;
-    y = cur_star.y;
-    sta = instance_nearest(action_x, action_y, obj_star);
-    is_orbiting();
+    var _dest_star = instance_nearest(action_x, action_y, obj_star);
+    x = _dest_star.x;
+    y = _dest_star.y;
+    var sta = _dest_star;
+    fleet_register_at_star(id, _dest_star);
 
     if (owner == eFACTION.MECHANICUS) {
         if (trade_goods == "mars_spelunk1") {
@@ -722,7 +710,7 @@ function fleet_arrival_logic() {
 
     //TODO create oppertunity to purge new colonisers if they have taint and the player has garrisons or control of the planet
     if (fleet_has_cargo("colonize")) {
-        deploy_colonisers(cur_star);
+        deploy_colonisers(_dest_star);
     }
 
     if (trade_goods == "return") {
@@ -738,7 +726,7 @@ function fleet_arrival_logic() {
 
     if (!navy) {
         if (trade_goods == "merge") {
-            if (is_orbiting()) {
+            if (instance_exists(orbiting)) {
                 var _orbit = orbiting;
                 var _viable_merge = false;
                 var _merge_fleet = false;
@@ -803,23 +791,25 @@ function fleet_arrival_logic() {
     }
 
     if ((owner == eFACTION.INQUISITION) && (string_count("_her", trade_goods) == 0)) {
-        if ((cur_star.owner == eFACTION.PLAYER) && (trade_goods == "cancel_inspection")) {
-            instance_deactivate_object(cur_star);
+        if ((_dest_star.owner == eFACTION.PLAYER) && (trade_goods == "cancel_inspection")) {
+            fleet_unregister_from_star(id); // set_fleet_movement() below also unregisters. Unregister before deactivating the star for lifecycle clarity.
+            instance_deactivate_object(_dest_star);
+            var _pick;
             repeat (choose(1, 2)) {
-                orbiting = instance_nearest(x, y, obj_star);
-                instance_deactivate_object(orbiting);
+                _pick = instance_nearest(x, y, obj_star);
+                instance_deactivate_object(_pick);
             }
 
             repeat (5) {
-                orbiting = instance_nearest(x, y, obj_star);
-                if (orbiting.owner == eFACTION.ELDAR) {
-                    instance_deactivate_object(orbiting);
+                _pick = instance_nearest(x, y, obj_star);
+                if (_pick.owner == eFACTION.ELDAR) {
+                    instance_deactivate_object(_pick);
                 }
             }
 
-            orbiting = instance_nearest(x, y, obj_star);
-            action_x = orbiting.x;
-            action_y = orbiting.y;
+            _pick = instance_nearest(x, y, obj_star);
+            action_x = _pick.x;
+            action_y = _pick.y;
             set_fleet_movement();
             instance_activate_object(obj_star);
             trade_goods += "|DELETE|";
@@ -902,64 +892,44 @@ function fleet_arrival_logic() {
         inquisition_fleet_inspection_chase();
     }
 
-    old_x = x;
-    old_y = y;
+    var old_x = x;
+    var old_y = y;
     x = -100;
     y = -100;
 
-    cur_star = instance_nearest(old_x, old_y, obj_en_fleet);
-    var mergus = false;
+    var _near_fleet = instance_nearest(old_x, old_y, obj_en_fleet);
+    var _arrival_behaviour = _near_fleet.image_index;
 
-    mergus = cur_star.image_index;
-    if (mergus < 3) {
-        mergus = 0;
+    if (_arrival_behaviour < 3) {
+        _arrival_behaviour = 0;
     }
-    if (mergus >= 3) {
-        mergus = 10;
+    if (_arrival_behaviour >= 3) {
+        _arrival_behaviour = 10;
     }
-    if ((owner == eFACTION.TAU) && (mergus >= 3)) {
-        mergus = 0;
+    if ((owner == eFACTION.TAU) && (_arrival_behaviour >= 3)) {
+        _arrival_behaviour = 0;
     }
     if (string_count("_her", trade_goods) == 0) {
-        mergus = 99;
+        _arrival_behaviour = 99;
     } // was 999
 
     // Think this might be causing the crash
-    if ((owner == eFACTION.TAU) && (sta.present_fleet[eFACTION.IMPERIUM] + sta.present_fleet[eFACTION.PLAYER] >= 1) && (sta.present_fleet[eFACTION.TAU] == 1) && (image_index == 1) && (ret == 0)) {
-        mergus = 15;
+    if ((owner == eFACTION.TAU) && (sta.present_fleet[eFACTION.IMPERIUM] + sta.present_fleet[eFACTION.PLAYER] >= 1) && (sta.present_fleet[eFACTION.TAU] == 1) && (image_index == 1) && (tau_fled == 0)) {
+        _arrival_behaviour = 15;
     }
-    if ((cur_star.owner == eFACTION.TAU) && (owner == eFACTION.TAU) && (ret == 1)) {
-        mergus = 0;
-    }
-
-    if ((owner == eFACTION.CHAOS) && fleet_has_cargo("chaos") || fleet_has_cargo("warband")) {
-        mergus = 0;
+    if ((_near_fleet.owner == eFACTION.TAU) && (owner == eFACTION.TAU) && (tau_fled == 1)) {
+        _arrival_behaviour = 0;
     }
 
-    if ((cur_star.x == old_x) && (cur_star.y == old_y) && (cur_star.owner == self.owner) && (cur_star.action == "") && (mergus == 1999)) {
-        // Merge the fleets
-        cur_star.escort_number += self.escort_number;
-        cur_star.frigate_number += self.frigate_number;
-        cur_star.capital_number += self.capital_number;
-        cur_star.guardsmen += self.guardsmen;
+    if ((owner == eFACTION.CHAOS) && (fleet_has_cargo("chaos") || fleet_has_cargo("warband"))) {
+        _arrival_behaviour = 0;
+    }
 
-        cur_star = instance_nearest(old_x, old_y, obj_star);
-        if (owner == eFACTION.TAU) {
-            obj_controller.tau_fleets -= 1;
-            cur_star.tau_fleets -= 1;
-        }
-        if (owner == eFACTION.CHAOS) {
-            obj_controller.chaos_fleets -= 1;
-        }
-
-        instance_destroy();
-    } // End merge fleets
-
-    if ((owner == eFACTION.TAU) && (mergus == 15)) {
+    if ((owner == eFACTION.TAU) && (_arrival_behaviour == 15)) {
         // Get the fuck out
         var new_star = 0;
         var stue = 0;
-        ret = 1;
+        tau_fled = 1;
 
         instance_activate_object(obj_star); // new_star
         stue = instance_nearest(x, y, obj_star);
@@ -1033,7 +1003,7 @@ function fleet_arrival_logic() {
 
     var _chaos = fleet_has_cargo("warband");
 
-    if ((cur_star.x == old_x) && (cur_star.y == old_y) && (cur_star.owner == self.owner) && (cur_star.action == "") && ((owner == eFACTION.TAU) || (owner == eFACTION.CHAOS)) && (mergus == 10) && (!_chaos)) {
+    if ((_near_fleet.x == old_x) && (_near_fleet.y == old_y) && (_near_fleet.owner == self.owner) && (_near_fleet.action == "") && ((owner == eFACTION.TAU) || (owner == eFACTION.CHAOS)) && (_arrival_behaviour == 10) && (!_chaos)) {
         // Move somewhere new
         var stue2 = noone;
         var goood = 0;
@@ -1078,7 +1048,7 @@ function fleet_arrival_logic() {
     // If the connected planet is owned by orks then choose a random one within 400 not owned by orks
 
     if (owner == eFACTION.ORK) {
-        if (is_orbiting()) {
+        if (instance_exists(orbiting)) {
             with (orbiting) {
                 ork_fleet_arrive_target();
             }
@@ -1086,17 +1056,17 @@ function fleet_arrival_logic() {
 
         var kay = 0, temp5 = 0, temp6 = 0, temp7 = 0;
 
-        cur_star = instance_nearest(x, y, obj_star);
+        var _nearest_star = instance_nearest(x, y, obj_star);
 
         // This is the new check to go along code; if doesn't add up to all planets = 7 then they exit
-        if (!is_dead_star(cur_star)) {
+        if (!is_dead_star(_nearest_star)) {
             // KILL the enemy
-            if ((cur_star.present_fleet[1] > 1) || (cur_star.present_fleet[2] > 1)) {
+            if ((_nearest_star.present_fleet[1] > 1) || (_nearest_star.present_fleet[2] > 1)) {
                 exit;
             }
         }
 
-        if (((cur_star.owner == eFACTION.CHAOS) && (image_index >= 5) && (owner == eFACTION.CHAOS)) || ((owner == eFACTION.CHAOS) && (image_index >= 5) && (cur_star.planets == 0))) {
+        if (((_nearest_star.owner == eFACTION.CHAOS) && (image_index >= 5) && (owner == eFACTION.CHAOS)) || ((owner == eFACTION.CHAOS) && (image_index >= 5) && (_nearest_star.planets == 0))) {
             kay = 50;
         }
 
@@ -1136,7 +1106,7 @@ function fleet_arrival_logic() {
 
             instance_activate_object(obj_star);
         } else {
-            cur_star.present_fleet[eFACTION.ORK]++;
+            fleet_register_at_star(id, _nearest_star);
         }
 
         instance_activate_object(obj_star);
@@ -1286,7 +1256,6 @@ function fleet_respond_crusade() {
             action_x = ns.x;
             action_y = ns.y;
             set_fleet_movement();
-            orbiting.present_fleet[owner] -= 1;
             home_x = orbiting.x;
             home_y = orbiting.y;
     
@@ -1355,4 +1324,92 @@ function fleet_respond_crusade() {
         }
         ERROR_HANDLER.handle_exception(_ex);
     }
+}
+
+/// @desc Registers a fleet at a star: sets orbiting and increments present_fleet.
+/// @param {Id.Instance.obj_p_fleet|Id.Instance.obj_en_fleet} _fleet
+/// @param {Id.Instance.obj_star} _star
+function fleet_register_at_star(_fleet, _star) {
+    if (!instance_exists(_star) || !instance_exists(_fleet)) {
+        return;
+    }
+
+    if (_fleet.orbiting == _star) {
+        return;
+    }
+
+    if (instance_exists(_fleet.orbiting)) {
+        fleet_unregister_from_star(_fleet);
+    }
+
+    _fleet.orbiting = _star;
+    var _faction = _fleet.owner ?? eFACTION.PLAYER;
+    _star.present_fleet[_faction] += 1;
+
+    if (_faction == eFACTION.PLAYER && _star.vision == 0) {
+        _star.vision = 1;
+    }
+}
+
+/// @desc Unregisters a fleet from its orbiting star (if there is one), clears orbiting and decrements present_fleet.
+/// @param {Id.Instance.obj_p_fleet|Id.Instance.obj_en_fleet} _fleet
+function fleet_unregister_from_star(_fleet) {
+    if (!instance_exists(_fleet)) {
+        return;
+    }
+    var _star = _fleet.orbiting;
+    if (instance_exists(_star)) {
+        var _faction = _fleet.owner ?? eFACTION.PLAYER;
+        if (_star.present_fleet[_faction] > 0) {
+            _star.present_fleet[_faction] -= 1;
+        }
+    }
+    _fleet.orbiting = noone;
+}
+
+/// @desc Finds the nearest star within _max_distance and registers the fleet there.
+/// @param {Id.Instance.obj_p_fleet|Id.Instance.obj_en_fleet} _fleet  Fleet instance to register
+/// @returns {Id.Instance|noone} The star registered at, or noone if none in range
+function fleet_register_at_nearest_star(_fleet, _max_distance = undefined) {
+    if (!instance_exists(_fleet)) {
+        return noone;
+    }
+
+    var _near = get_nearest_star(_fleet.x, _fleet.y, _max_distance);
+    if (_near != noone) {
+        fleet_register_at_star(_fleet, _near);
+        return _near;
+    }
+
+    return noone;
+}
+
+/// @desc Creates a new player fleet, registering at the nearest star if within 50px.
+/// @param {Real} _x
+/// @param {Real} _y
+/// @param {Array} _ships  Optional array of ship IDs to add to the fleet
+/// @returns {Id.Instance.obj_p_fleet}
+function create_player_fleet(_x, _y, _ships = []) {
+    var _fleet = instance_create(_x, _y, obj_p_fleet);
+    _fleet.owner = eFACTION.PLAYER;
+    fleet_register_at_nearest_star(_fleet);
+
+    for (var _i = 0; _i < array_length(_ships); _i++) {
+        add_ship_to_fleet(_ships[_i], _fleet);
+    }
+
+    return _fleet;
+}
+
+/// @desc Creates a new enemy fleet, registering at the nearest star if within 50px.
+/// @param {Real} _x
+/// @param {Real} _y
+/// @param {Enum.eFACTION} _owner
+/// @returns {Id.Instance.obj_en_fleet}
+function create_enemy_fleet(_x, _y, _owner) {
+    var _fleet = instance_create(_x, _y, obj_en_fleet);
+    _fleet.owner = _owner;
+    fleet_register_at_nearest_star(_fleet);
+
+    return _fleet;
 }

--- a/scripts/scr_forge_world_functions/scr_forge_world_functions.gml
+++ b/scripts/scr_forge_world_functions/scr_forge_world_functions.gml
@@ -104,7 +104,7 @@ function build_planet_defence_fleets() {
             var _imperial_fleet_defence_score = capital_number + (frigate_number / 2) + (escort_number / 4);
             obj_controller.imp_ships += _imperial_fleet_defence_score;
             //log this to prevent double work later figuring out if a planet has an orbiting defence fleet
-            if (!navy && action == "" && is_orbiting()) {
+            if (!navy && action == "" && instance_exists(orbiting)) {
                 _defence_fleet_log[$ orbiting.name] = _imperial_fleet_defence_score;
             }
         }
@@ -191,11 +191,10 @@ function build_planet_defence_fleets() {
                 _defence_fleet = true;
             }
         } else {
-            _current_imperial_fleet = instance_create(forge.x, forge.y, obj_en_fleet);
+            _current_imperial_fleet = create_enemy_fleet(forge.x, forge.y, eFACTION.IMPERIUM);
             _defence_fleet = true;
             with (_current_imperial_fleet) {
                 navy = false;
-                owner = eFACTION.IMPERIUM;
                 choose_fleet_sprite_image();
             }
         }

--- a/scripts/scr_garrison/scr_garrison.gml
+++ b/scripts/scr_garrison/scr_garrison.gml
@@ -190,7 +190,7 @@ function GarrisonForce(system, planet, type = "garrison") constructor {
         if (array_length(garrison_squads) > 1) {
             report_string += $"The garrison is comprised of {array_length(garrison_squads)} squads,";
         } else {
-            report_string += "The garrison is comprised of a single _squad,";
+            report_string += "The garrison is comprised of a single squad,";
         }
 
         report_string += $" with a total man count of {total_garrison}.#";

--- a/scripts/scr_imperial_manage_fleet_functions/scr_imperial_manage_fleet_functions.gml
+++ b/scripts/scr_imperial_manage_fleet_functions/scr_imperial_manage_fleet_functions.gml
@@ -1,6 +1,5 @@
 function new_colony_fleet(doner_star, doner_planet, target, target_planet, mission = "new_colony") {
-    var new_colonise_fleet = instance_create(doner_star.x, doner_star.y, obj_en_fleet);
-    new_colonise_fleet.owner = eFACTION.IMPERIUM;
+    var new_colonise_fleet = create_enemy_fleet(doner_star.x, doner_star.y, eFACTION.IMPERIUM);
     new_colonise_fleet.sprite_index = spr_fleet_civilian;
     new_colonise_fleet.image_index = 3;
     new_colonise_fleet.warp_able = false;

--- a/scripts/scr_imperial_navy_functions/scr_imperial_navy_functions.gml
+++ b/scripts/scr_imperial_navy_functions/scr_imperial_navy_functions.gml
@@ -1,7 +1,6 @@
 /// @self Asset.GMObject.obj_en_fleet
 function navy_orbiting_planet_end_turn_action() {
     end_sequence_finished = false;
-    orbiting = instance_nearest(x, y, obj_star);
 
     var _war_with_player = obj_controller.faction_status[eFACTION.IMPERIUM] == "War";
     if (trade_goods != "player_hold") {
@@ -104,21 +103,15 @@ function check_navy_guard_still_live() {
 
 function build_new_navy_fleet(construction_forge) {
     /// @type {Asset.GMObject.obj_en_fleet}
-    var new_navy_fleet = instance_create(construction_forge.x, construction_forge.y, obj_en_fleet);
+    var new_navy_fleet = create_enemy_fleet(construction_forge.x, construction_forge.y, eFACTION.IMPERIUM);
 
     with (new_navy_fleet) {
-        owner = eFACTION.IMPERIUM;
-
         capital_number = 0;
         frigate_number = 0;
         escort_number = 1;
         home_x = x;
         home_y = y;
         warp_able = true;
-        with (construction_forge) {
-            present_fleet[2] += 1;
-        }
-        orbiting = construction_forge;
         navy = 1;
 
         var total_ships = 0;
@@ -142,7 +135,6 @@ function new_navy_ships_forge() {
         var onceh = 0;
         var advance = false;
 
-        is_orbiting();
         for (var p = 1; p <= orbiting.planets; p++) {
             if (orbiting.p_type[p] == "Forge") {
                 //if no non-imperium,player, or eldar aligned fleets or ground forces, continue
@@ -487,7 +479,7 @@ function navy_attack_player_world() {
 /// @self Asset.GMObject.obj_en_fleet
 function navy_bombard_player_world() {
     var bombard = false;
-    if (orbiting != noone) {
+    if (instance_exists(orbiting)) {
         if (orbiting.object_index == obj_star) {
             bombard = true;
         }
@@ -620,7 +612,7 @@ function fleet_remaining_guard_ratio() {
     var _maxi = fleet_max_guard();
     guardsmen_ratio = 0;
     if (guardsmen_unloaded) {
-        if (is_orbiting()) {
+        if (instance_exists(orbiting)) {
             _curr = array_sum(orbiting.p_guardsmen);
         }
 
@@ -653,7 +645,7 @@ function scr_navy_unload_guard(planet) {
 
 /// @self Asset.GMObject.obj_en_fleet
 function scr_navy_planet_action() {
-    if (action == "" && is_orbiting() && !guardsmen_unloaded) {
+    if (action == "" && !guardsmen_unloaded && instance_exists(orbiting)) {
         // Unload if problem sector, otherwise patrol
         var selected_planet = 0, highest = 0, _target_pop = 0, _popu_large = false;
 
@@ -1064,13 +1056,8 @@ function create_start_imperial_fleets() {
 function setup_start_imperial_navy_fleet(system) {
     var ii = 0;
     /// @type {Asset.GMObject.obj_en_fleet} 
-    var nav = instance_create(system.x, system.y, obj_en_fleet);
-    var _star = system;
-    _star.present_fleet[eFACTION.IMPERIUM] += 1;
+    var nav = create_enemy_fleet(system.x, system.y, eFACTION.IMPERIUM);
     with (nav) {
-        orbiting = system;
-
-        owner = eFACTION.IMPERIUM;
         navy = 1;
 
         capital_number = choose(1, 2, 3);

--- a/scripts/scr_inquisition_fleet_functions/scr_inquisition_fleet_functions.gml
+++ b/scripts/scr_inquisition_fleet_functions/scr_inquisition_fleet_functions.gml
@@ -21,7 +21,7 @@ function radical_inquisitor_mission_ship_arrival() {
     //TODO make a centralised player_fleet present method
     var _p_fleet = instance_nearest(x, y, obj_p_fleet);
     var _intercept_fleet = -1;
-    if (point_distance(x, y, _p_fleet.x, _p_fleet.y) < 10 && is_orbiting(_p_fleet)) {
+    if (point_distance(x, y, _p_fleet.x, _p_fleet.y) < 10 && instance_exists(_p_fleet.orbiting)) {
         _intercept_fleet = _p_fleet;
     }
 
@@ -163,7 +163,7 @@ function new_inquisitor_inspection() {
 
             //get the second or third closest planet to launch inquisitor from
             var from_star = distance_removed_star(target_star.x, target_star.y);
-            var new_inquis_fleet = instance_create(from_star.x, from_star.y, obj_en_fleet);
+            var new_inquis_fleet = create_enemy_fleet(from_star.x, from_star.y, eFACTION.INQUISITION);
 
             with (new_inquis_fleet) {
                 base_inquis_fleet();
@@ -186,7 +186,7 @@ function new_inquisitor_inspection() {
         //get the second or third closest planet to launch inquisitor from
         var from_star = distance_removed_star(target_player_fleet.x, target_player_fleet.y);
 
-        var new_inquis_fleet = instance_create(from_star.x, from_star.y, obj_en_fleet);
+        var new_inquis_fleet = create_enemy_fleet(from_star.x, from_star.y, eFACTION.INQUISITION);
         var obj;
         with (new_inquis_fleet) {
             base_inquis_fleet();
@@ -292,7 +292,7 @@ function inquisitor_inspect_base() {
             launch_planet = nearest_star_with_ownership(x, y, [eFACTION.IMPERIUM, eFACTION.MECHANICUS], self.id);
             if (launch_planet != noone) {
                 if (instance_exists(launch_planet)) {
-                    flee = instance_create(launch_planet.x, launch_planet.y, obj_en_fleet);
+                    flee = create_enemy_fleet(launch_planet.x, launch_planet.y, eFACTION.INQUISITION);
                     with (flee) {
                         base_inquis_fleet();
                     }

--- a/scripts/scr_inquisition_mission/scr_inquisition_mission.gml
+++ b/scripts/scr_inquisition_mission/scr_inquisition_mission.gml
@@ -331,7 +331,7 @@ function init_mission_hunt_inquisitor() {
     }
     scr_event_log("", $"Inquisition Mission Accepted: The radical Inquisitor {pop_data.mission_data.inquisitor_name} enroute to {mission_star.name} must be removed.  Estimated arrival in {pop_data.estimate} months.", mission_star.name);
 
-    var _radical_inquisitor_fleet = instance_create(mission_star.x - irandom_range(-400, 400), mission_star.y - irandom_range(-400, 400), obj_en_fleet);
+    var _radical_inquisitor_fleet = create_enemy_fleet(mission_star.x - irandom_range(-400, 400), mission_star.y - irandom_range(-400, 400), eFACTION.INQUISITION);
     with (_radical_inquisitor_fleet) {
         base_inquis_fleet();
     }

--- a/scripts/scr_khornate_fleet_functions/scr_khornate_fleet_functions.gml
+++ b/scripts/scr_khornate_fleet_functions/scr_khornate_fleet_functions.gml
@@ -2,8 +2,7 @@
 function khorne_fleet_cargo() {
     //This handles khorne fleets killing planet popultions moving planet and then choosing a new target ot chase
     warband = cargo_data.warband;
-    var _is_orbiting = is_orbiting();
-    if (_is_orbiting && (action == "")) {
+    if (action == "" && instance_exists(orbiting)) {
         _orb = orbiting;
         if (_orb.present_fleet[1] + _orb.present_fleet[2] + _orb.present_fleet[3] + _orb.present_fleet[6] + _orb.present_fleet[7] + _orb.present_fleet[9] + _orb.present_fleet[13] == 0) {
             var good = 0;
@@ -215,9 +214,8 @@ function khorne_fleet_cargo() {
 }
 
 function spawn_chaos_fleet_at_system(system) {
-    var _new_fleet = instance_create(system.x, system.y, obj_en_fleet);
+    var _new_fleet = create_enemy_fleet(system.x, system.y, eFACTION.CHAOS);
     with (_new_fleet) {
-        owner = eFACTION.CHAOS;
         sprite_index = spr_fleet_chaos;
         image_index = 9;
     }
@@ -243,9 +241,8 @@ function spawn_chaos_warlord() {
         ox = width / 2 + lengthdir_x(len, fdir);
         oy = height / 2 + lengthdir_y(len, fdir);
 
-        var nfleet = instance_create(ox, oy, obj_en_fleet);
+        var nfleet = create_enemy_fleet(ox, oy, eFACTION.CHAOS);
         with (nfleet) {
-            owner = eFACTION.CHAOS;
             sprite_index = spr_fleet_chaos;
             image_index = 9;
             home_x = x + lengthdir_x(5000, point_direction(x, y, room_width / 2, room_height / 2));

--- a/scripts/scr_load/scr_load.gml
+++ b/scripts/scr_load/scr_load.gml
@@ -120,6 +120,13 @@ function scr_load(save_part, save_id) {
                 deserialize(deserialized);
             }
         }
+
+        with (obj_p_fleet) {
+            if (action == "") {
+                fleet_register_at_nearest_star(id);
+            }
+        }
+
         LOGGER.info("PLAYER FLEET OBJECTS loaded");
     }
 
@@ -134,6 +141,13 @@ function scr_load(save_part, save_id) {
                 deserialize(deserialized);
             }
         }
+
+        with (obj_en_fleet) {
+            if (action == "") {
+                fleet_register_at_nearest_star(id);
+            }
+        }
+
         LOGGER.info("ENEMY FLEET OBJECTS loaded");
 
         LOGGER.info("Loading EVENT LOG");

--- a/scripts/scr_load/scr_load.gml
+++ b/scripts/scr_load/scr_load.gml
@@ -105,7 +105,7 @@ function scr_load(save_part, save_id) {
             scr_shader_initialize();
             armamentarium = new Armamentarium(self);
 
-            global.star_name_colors[1] = make_color_rgb(body_colour_replace[0], body_colour_replace[1], body_colour_replace[2]);
+            global.star_name_colors[1] = make_color_rgb(col_r[main_color], col_g[main_color], col_b[main_color]);
         }
         LOGGER.info("CONTROLLER loaded");
     }

--- a/scripts/scr_map_and_warp_functions/scr_map_and_warp_functions.gml
+++ b/scripts/scr_map_and_warp_functions/scr_map_and_warp_functions.gml
@@ -54,6 +54,10 @@ function scr_map_scale() {
 function draw_warp_lanes() {
     static routes = [];
     static current_seed = global.game_seed;
+
+    var line_width = 2 * obj_controller.scale_mod;
+    var line_alpha = 0.4;
+
     if (array_length(routes) == 0 || current_seed != global.game_seed) {
         current_seed = global.game_seed;
         routes = [];
@@ -65,7 +69,6 @@ function draw_warp_lanes() {
         for (var i = 0; i < total_stars; i++) {
             var cur_star = instance_find(obj_star, star_degrade_list[i]);
             var this_star = cur_star.id;
-            var in_view = true;
 
             if (array_length(cur_star.warp_lanes) > 0) {
                 for (var s = 0; s < total_stars; s++) {
@@ -97,7 +100,9 @@ function draw_warp_lanes() {
         var route_coords = route[0];
 
         if (route[1] < 4) {
-            draw_line(route_coords[0], route_coords[1], route_coords[2], route_coords[3]);
+            draw_set_alpha(line_alpha);
+            draw_line_width(route_coords[0], route_coords[1], route_coords[2], route_coords[3], line_width);
+            draw_set_alpha(1);
         } else if (route[1] == 4) {
             draw_set_color(c_yellow);
             //TODO abstract code as a ratio distance function
@@ -117,7 +122,9 @@ function draw_warp_lanes() {
             var warp_height = sprite_get_height(spr_warp_storm) * 0.75;
 
             for (var s = 0; s < route[1]; s++) {
-                draw_line(route_coords[0], route_coords[1], route_coords[0] + dist_x, route_coords[1] + dist_y);
+                draw_set_alpha(line_alpha);
+                draw_line_width(route_coords[0], route_coords[1], route_coords[0] + dist_x, route_coords[1] + dist_y, line_width);
+                draw_set_alpha(1);
             }
 
             draw_sprite_centered(spr_warp_storm, warp_image + i, route_coords[0] + dist_x, route_coords[1] + dist_y, 0.75, 0.75, 0, c_white, 1);
@@ -161,7 +168,9 @@ function draw_warp_lanes() {
             }
 
             for (var s = 0; s < route[1]; s++) {
-                draw_line(route_coords[2] + s, route_coords[3] + s, (route_coords[2] - dist_x + s), (route_coords[3] + s - dist_y));
+                draw_set_alpha(line_alpha);
+                draw_line_width(route_coords[2] + s, route_coords[3] + s, (route_coords[2] - dist_x + s), (route_coords[3] + s - dist_y), line_width);
+                draw_set_alpha(1);
             }
             draw_sprite_centered(spr_warp_storm, warp_image + i, (route_coords[2] - dist_x), (route_coords[3] - dist_y), 0.75, 0.75, 0, c_white, 1);
 

--- a/scripts/scr_mechanicus_missions/scr_mechanicus_missions.gml
+++ b/scripts/scr_mechanicus_missions/scr_mechanicus_missions.gml
@@ -424,10 +424,9 @@ function mechanicus_mars_mission_target_time_elapsed(planet) {
         var _text = $"Mechanicus Ship departs for the Mars catacombs.  Onboard are {techs_taken} of your {obj_ini.role[100][16]}s.";
         scr_alert("", "mission", _text, 0, 0);
         scr_event_log("green", _text);
-        var flit = instance_create(x, y, obj_en_fleet);
+        var flit = create_enemy_fleet(x, y, eFACTION.MECHANICUS);
 
         with (flit) {
-            owner = eFACTION.MECHANICUS;
             sprite_index = spr_fleet_mechanicus;
             capital_number = 1;
             image_index = 0;

--- a/scripts/scr_ork_fleet_functions/scr_ork_fleet_functions.gml
+++ b/scripts/scr_ork_fleet_functions/scr_ork_fleet_functions.gml
@@ -2,17 +2,11 @@
 // https://help.yoyogames.com/hc/en-us/articles/360005277377 for more information
 
 function new_ork_fleet(xx, yy) {
-    fleet = instance_create(xx, yy, obj_en_fleet);
-    fleet.owner = eFACTION.ORK;
+    fleet = create_enemy_fleet(xx, yy, eFACTION.ORK);
     fleet.sprite_index = spr_fleet_ork;
     fleet.image_index = 1;
     fleet.capital_number = 1;
     fleet.frigate_number = 1;
-    if (!is_struct(self)) {
-        if (object_index == obj_star) {
-            present_fleet[7] = 1;
-        }
-    }
     return fleet;
 }
 

--- a/scripts/scr_ork_planet_functions/scr_ork_planet_functions.gml
+++ b/scripts/scr_ork_planet_functions/scr_ork_planet_functions.gml
@@ -87,8 +87,7 @@ function ork_ship_production(planet) {
         if (contin == 3 && irandom_range(1, 100) <= 25) {
             // Create a fleet
             // fleet=instance_create
-            fleet = instance_create(x, y, obj_en_fleet);
-            fleet.owner = eFACTION.ORK;
+            fleet = create_enemy_fleet(x, y, eFACTION.ORK);
             fleet.sprite_index = spr_fleet_ork;
             fleet.image_index = 1;
             fleet.capital_number = 2;

--- a/scripts/scr_planetary_feature/scr_planetary_feature.gml
+++ b/scripts/scr_planetary_feature/scr_planetary_feature.gml
@@ -1053,9 +1053,7 @@ function send_stc_to_adeptus_mech() {
         }
 
         if (is_struct(_target)) {
-            var _enemy_fleet = instance_create(_target.x, _target.y, obj_en_fleet);
-
-            _enemy_fleet.owner = obj_controller.diplomacy;
+            var _enemy_fleet = create_enemy_fleet(_target.x, _target.y, obj_controller.diplomacy);
             _enemy_fleet.home_x = _target.x;
             _enemy_fleet.home_y = _target.y;
             _enemy_fleet.sprite_index = spr_fleet_mechanicus;

--- a/scripts/scr_player_fleet_functions/scr_player_fleet_functions.gml
+++ b/scripts/scr_player_fleet_functions/scr_player_fleet_functions.gml
@@ -29,8 +29,7 @@ function fleet_engaged(fleet) {
 }
 
 function split_selected_into_new_fleet(start_fleet) {
-    var new_fleet = instance_create(x, y, obj_p_fleet);
-    new_fleet.owner = eFACTION.PLAYER;
+    var new_fleet = create_player_fleet(x, y);
     with (start_fleet) {
         // Pass over ships to the new fleet, if they are selected
         var cap_number = array_length(capital);
@@ -63,16 +62,6 @@ function split_selected_into_new_fleet(start_fleet) {
     return new_fleet;
 }
 
-/// @param {Id.Instance.obj_p_fleet} _fleet
-/// @param {Id.Instance.obj_star} _star
-function set_fleet_orbiting(_fleet, _star) {
-    _star.present_fleet[1] += 1;
-    if (_star.vision == 0) {
-        _star.vision = 1;
-    }
-    _fleet.orbiting = _star;
-}
-
 /// @self Id.Instance.obj_p_fleet
 function cancel_fleet_movement() {
     var nearest_star = instance_nearest(x, y, obj_star);
@@ -84,18 +73,17 @@ function cancel_fleet_movement() {
     complex_route = [];
     just_left = false;
     set_fleet_location(nearest_star.name);
-    set_fleet_orbiting(self, nearest_star);
+    fleet_register_at_star(self, nearest_star);
 }
 
 /// @self Id.Instance.obj_p_fleet
 function set_new_player_fleet_course(target_array) {
     if (array_length(target_array) > 0) {
         var target_planet = find_star_by_name(target_array[0]);
-        var nearest_planet = instance_nearest(x, y, obj_star);
-        var from_star = point_distance(nearest_planet.x, nearest_planet.y, x, y) < 75;
+        var from_star = instance_exists(orbiting);
         var valid = target_planet != noone;
         if (valid) {
-            valid = !(target_planet.id == nearest_planet.id && from_star);
+            valid = !(from_star && target_planet.id == orbiting.id);
         }
         if (!valid) {
             if (array_length(target_array) > 1) {
@@ -108,19 +96,19 @@ function set_new_player_fleet_course(target_array) {
             array_delete(target_array, 0, 1);
         }
 
-        if (from_star) {
-            nearest_planet.present_fleet[1]--;
-        }
-    
         complex_route = target_array;
-        var from_x = from_star ? nearest_planet.x : x;
-        var from_y = from_star ? nearest_planet.y : y;
+        var from_x = from_star ? orbiting.x : x;
+        var from_y = from_star ? orbiting.y : y;
         action_eta = calculate_fleet_eta(from_x, from_y, target_planet.x, target_planet.y, action_spd, from_star, true, warp_able);
         action_x = target_planet.x;
         action_y = target_planet.y;
         action = "move";
         just_left = true;
-        orbiting = noone;
+
+        if (from_star) {
+            fleet_unregister_from_star(id);
+        }
+
         x = x + lengthdir_x(48, point_direction(x, y, action_x, action_y));
         y = y + lengthdir_y(48, point_direction(x, y, action_x, action_y));
         set_fleet_location("Warp");

--- a/scripts/scr_player_ship_functions/scr_player_ship_functions.gml
+++ b/scripts/scr_player_ship_functions/scr_player_ship_functions.gml
@@ -17,8 +17,7 @@ function return_lost_ship() {
             }
         }
         var _star = instance_find(obj_star, irandom(instance_number(obj_star) - 1));
-        var _new_fleet = instance_create(_star.x, _star.y, obj_p_fleet);
-        _new_fleet.owner = eFACTION.PLAYER;
+        var _new_fleet = create_player_fleet(_star.x, _star.y);
         if (_lost_fleet != noone) {
             find_and_move_ship_between_fleets(_lost_fleet, _new_fleet, _return_id);
             if (player_fleet_ship_count(_lost_fleet) == 0) {
@@ -200,8 +199,7 @@ function loose_ship_to_warp_event() {
         }
     }
     if (_lost_ship_fleet == noone) {
-        _lost_ship_fleet = instance_create(-500, -500, obj_p_fleet);
-        _lost_ship_fleet.owner = eFACTION.PLAYER;
+        _lost_ship_fleet = create_player_fleet(-500, -500);
     }
 
     find_and_move_ship_between_fleets(_fleet, _lost_ship_fleet, _ship_index);
@@ -228,6 +226,7 @@ function loose_ship_to_warp_event() {
     }
 
     _lost_ship_fleet.action = "Lost";
+    fleet_unregister_from_star(_lost_ship_fleet);
     _lost_ship_fleet.alarm[1] = 2;
 
     scr_popup("Ship Lost", text, "lost_warp", "");

--- a/scripts/scr_punit_combat_heplers/scr_punit_combat_heplers.gml
+++ b/scripts/scr_punit_combat_heplers/scr_punit_combat_heplers.gml
@@ -37,7 +37,7 @@ function target_block_is_valid(target, desired_type) {
             return _is_valid;
         }
         if (instance_exists(target)) {
-            if (target.x > 0 && target.object_index == desired_type) {
+            if (target.x > -100 && target.object_index == desired_type) {
                 if (target.men + target.veh + target.dreads > 0) {
                     _is_valid = true;
                 } else {
@@ -63,7 +63,7 @@ function get_rightmost(block_type = obj_pnunit, include_flanking = true, include
                 if (!include_main_force && !flank) {
                     continue;
                 }
-                if (x <= 0) {
+                if (x < -100) {
                     continue;
                 }
                 if (block_type == obj_pnunit) {
@@ -73,8 +73,8 @@ function get_rightmost(block_type = obj_pnunit, include_flanking = true, include
                         continue;
                     }
                 }
-                if (rightmost == noone && x > 0) {
-                    rightmost = block_type.id;
+                if (rightmost == noone && x > -100) {
+                    rightmost = id;
                 } else {
                     if (x > rightmost.x) {
                         rightmost = id;
@@ -104,7 +104,7 @@ function get_leftmost(block_type = obj_pnunit, include_flanking = true) {
                 if (!include_flanking && flank) {
                     continue;
                 }
-                if (x <= 0) {
+                if (x < -100) {
                     continue;
                 }
                 if (block_type == obj_pnunit) {
@@ -114,10 +114,10 @@ function get_leftmost(block_type = obj_pnunit, include_flanking = true) {
                         continue;
                     }
                 }
-                if (left_most == noone && x > 0) {
-                    left_most = block_type.id;
+                if (left_most == noone && x > -100) {
+                    left_most = id;
                 } else {
-                    if (x < left_most.x && x > 0) {
+                    if (x < left_most.x && x > -100) {
                         left_most = id;
                     }
                 }

--- a/scripts/scr_punit_combat_heplers/scr_punit_combat_heplers.gml
+++ b/scripts/scr_punit_combat_heplers/scr_punit_combat_heplers.gml
@@ -41,8 +41,8 @@ function target_block_is_valid(target, desired_type) {
                 if (target.men + target.veh + target.dreads > 0) {
                     _is_valid = true;
                 } else {
-                    x = -5000;
-                    instance_deactivate_object(id);
+                    target.x = -5000;
+                    instance_deactivate_object(target);
                 }
             }
         }

--- a/scripts/scr_quest/scr_quest.gml
+++ b/scripts/scr_quest/scr_quest.gml
@@ -162,8 +162,7 @@ function scr_quest(quest_satus, quest_name, quest_fac, quest_end) {
             targ = instance_nearest(obj_ground_mission.x, obj_ground_mission.y, obj_temp3);
         }
 
-        var flit = instance_create(targ.x, targ.y, obj_en_fleet);
-        flit.owner = quick_trade;
+        var flit = create_enemy_fleet(targ.x, targ.y, quick_trade);
 
         if (quick_trade == 2) {
             flit.sprite_index = spr_fleet_imperial;

--- a/scripts/scr_start_load/scr_start_load.gml
+++ b/scripts/scr_start_load/scr_start_load.gml
@@ -245,9 +245,7 @@ function scr_start_load(fleet, load_from_star, load_options) {
                     array_push(_empty_ships, i);
                 } else {
                     var _star = array_pop(_imperial_stars);
-                    _new_fleet = instance_create(_star.x, _star.y, obj_p_fleet);
-                    _new_fleet.owner = eFACTION.PLAYER;
-                    add_ship_to_fleet(i, _new_fleet);
+                    var _new_fleet = create_player_fleet(_star.x, _star.y, [i]);
                     array_push(_fleets, _new_fleet);
                 }
             }

--- a/scripts/scr_system_search_helpers/scr_system_search_helpers.gml
+++ b/scripts/scr_system_search_helpers/scr_system_search_helpers.gml
@@ -122,7 +122,7 @@ function stars_with_faction_fleets(search_faction) {
             instance_destroy();
             continue;
         }
-        if (is_orbiting()) {
+        if (instance_exists(orbiting)) {
             if (struct_exists(_stars_with_fleets, orbiting.name)) {
                 array_push(_stars_with_fleets[$ orbiting.name], id);
             } else {

--- a/scripts/scr_trade_dep/scr_trade_dep.gml
+++ b/scripts/scr_trade_dep/scr_trade_dep.gml
@@ -45,10 +45,9 @@ function scr_trade_dep() {
 }
 
 function setup_ai_trade_fleet(start_place, faction) {
-    var flit = instance_create(start_place.x, start_place.y, obj_en_fleet);
+    var flit = create_enemy_fleet(start_place.x, start_place.y, faction);
 
     with (flit) {
-        owner = faction;
         home_x = start_place.x;
         home_y = start_place.y;
 

--- a/scripts/scr_unit_quick_find_pane/scr_unit_quick_find_pane.gml
+++ b/scripts/scr_unit_quick_find_pane/scr_unit_quick_find_pane.gml
@@ -851,7 +851,7 @@ function HelpfulPlaces() constructor {
             remaining_guard: $"{_guard_percentage}%",
             action: trade_goods,
         };
-        if (is_orbiting()) {
+        if (instance_exists(orbiting)) {
             _data.location = orbiting.name;
         }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Centralizes fleet creation and star registration with new helpers and factories, replacing ad‑hoc logic across the game. Fixes fleet presence desyncs and battle/UI issues, improves save/load, and polishes map/ETA visuals and faction colors.

- **Refactors**
  - Added `create_player_fleet`/`create_enemy_fleet` and `fleet_register_at_star`/`fleet_unregister_from_star`/`fleet_register_at_nearest_star`; adopted across AI, missions, events, cheats, start/load.
  - Removed `is_orbiting`; use `instance_exists(orbiting)`; cleaned arrival logic (renamed `_arrival_behaviour`, `tau_fled`, `_dest_star`) and removed unreachable merge path.
  - Save/load: stop serializing `present_fleet`; auto‑register fleets on load; added `get_nearest_star`; stopped zeroing `present_fleet` each turn.
  - UI: thicker, zoom‑scaled warp lanes with alpha; green, zoom‑scaled ETA lines/text; reset draw color; player star name uses `main_color`; adjusted faction colors.

- **Bug Fixes**
  - Battle screen “no world” check now uses `battle_world == 0`; improved `battle_object` typing.
  - Prevented `present_fleet` underflows/nulls via centralized register/unregister; ensured fleets register on spawn/load, including unnamed Eldar craftworld stars.
  - Ground combat: fixed enemies disabling themselves on invalid targets; reduced player blocks walking backwards; fixed targeting of the last player blocks.
  - Garrison report: fixed “single _squad” typo.

<sup>Written for commit 62e4c91d917d8d88785a37b91fe66efe932b5a40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

