### PR TITLE
fix: Disable Deathwatch chapter; Add enum member

### DIFF
--- a/objects/obj_creation/Create_0.gml
+++ b/objects/obj_creation/Create_0.gml
@@ -271,6 +271,7 @@ enum eCHAPTERS {
     CUSTOM_8 = 28,
     CUSTOM_9 = 29,
     CUSTOM_10 = 30,
+    DEATHWATCH = 33,
 }
 enum eCHAPTER_ORIGINS {
     NONE,
@@ -389,6 +390,7 @@ all_chapters[eCHAPTERS.UNKNOWN].disabled = true; //this should always be disable
 all_chapters[eCHAPTERS.EMPERORS_NIGHTMARE].disabled = true;
 all_chapters[eCHAPTERS.STAR_KRAKENS].disabled = true;
 all_chapters[eCHAPTERS.CONSERVATORS].disabled = true;
+all_chapters[eCHAPTERS.DEATHWATCH].disabled = true;
 
 founding_chapters = array_filter(all_chapters, function(item) {
     return item.origin == eCHAPTER_ORIGINS.FOUNDING;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added DEATHWATCH to the chapter enum (value 33) and disabled the chapter so it can’t be selected or generated.
Reserves the ID while keeping incomplete content hidden.

<sup>Written for commit 420077951f5359bbb22ec7245ef82e7a9dd0485c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

