### PR TITLE
refactor: Remove unused income_controlled_planets variable

### DIFF
--- a/objects/obj_controller/Alarm_5.gml
+++ b/objects/obj_controller/Alarm_5.gml
@@ -618,21 +618,6 @@ try {
         }
     }
 
-    // ** Income **
-    // if (income_controlled_planets>0){
-
-    //     var tithe_string = income_controlled_planets==1? $"-{income_tribute} Requisition granted by tithes from 1 planet.": $"-{income_tribute} Requisition granted by tithes from {income_controlled_planets} planets.";
-    //     scr_alert("yellow", "planet_tithe", tithe_string);
-    //     instance_activate_object(obj_p_fleet);
-
-    //     with(obj_star){
-    //         if (x<-10000){
-    //             x+=20000;
-    //             y+=20000;
-    //         }
-    //     }
-    // }
-
     //research and forge related actions
 
     research_end();

--- a/objects/obj_controller/Create_0.gml
+++ b/objects/obj_controller/Create_0.gml
@@ -795,7 +795,6 @@ income_fleet = 0;
 income_trade = 0;
 income_leader = 0;
 income_tribute = 0;
-income_controlled_planets = 0;
 // ** Extra variables **
 info_chips = 0;
 inspection_passes = 0;

--- a/scripts/scr_income/scr_income.gml
+++ b/scripts/scr_income/scr_income.gml
@@ -4,7 +4,6 @@ function scr_income() {
 
     income_base = 32;
     income_tribute = 0;
-    income_controlled_planets = 0;
     if (obj_ini.fleet_type != ePLAYER_BASE.HOME_WORLD) {
         income_base = 40;
     }
@@ -153,7 +152,6 @@ function scr_income() {
         for (var o = 1; o <= planets; o++) {
             if (dispo[o] >= 100) {
                 if (planet_feature_bool(p_feature[o], eP_FEATURES.MONASTERY) == 0) {
-                    obj_controller.income_controlled_planets += 1;
                     obj_controller.income_tribute += 1;
                     if (p_type[o] == "Feudal") {
                         obj_controller.income_tribute += 1;

--- a/scripts/scr_income/scr_income.gml
+++ b/scripts/scr_income/scr_income.gml
@@ -119,7 +119,7 @@ function scr_income() {
         with (obj_star) {
             for (var i = 1; i <= planets; i++) {
                 if (planet_feature_bool(p_feature[i], eP_FEATURES.MONASTERY)) {
-                    obj_controller.income += 10;
+                    obj_controller.income_home += 10;
                     instance_create(x, y, obj_temp1);
                 }
             }


### PR DESCRIPTION
***EDIT*** I didn't mean to add the fix to this, that was an accident. But now that it got added to explain, adding to raw income doesn't work and will just get overwritten when the income is calculated on turn end. So previously that line did nothing, now it should add to the displayed fortress monastery income.

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the unused `income_controlled_planets` variable and cleaned up dead references. Fixed monastery income to correctly add to `income_home`.

- **Refactors**
  - Removed `income_controlled_planets` setup and increment in `objects/obj_controller/Create_0.gml` and `scripts/scr_income/scr_income.gml`.
  - Pruned the commented tithe alert block from `objects/obj_controller/Alarm_5.gml`.

- **Bug Fixes**
  - Monastery feature now adds +10 to `income_home` instead of `income`.

<sup>Written for commit 955ecc1d1bcb9d251fe2f7215641f3ddf6b7b574. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

