### PR TITLE
fix: Dreadnought Assault Cannon sprite

### DIFF
--- a/scripts/scr_culture_visuals/scr_culture_visuals.gml
+++ b/scripts/scr_culture_visuals/scr_culture_visuals.gml
@@ -2579,7 +2579,7 @@ global.weapon_visual_data = {
                 sprite: spr_weapon_assca,
             },
             {
-                sprite: spr_weapon_assca,
+                sprite: spr_dread_assault_cannon,
                 body_types: [3],
                 armours: ["Dreadnought"],
                 single_left_right_profile: true,


### PR DESCRIPTION
Assault cannon was using the wrong sprite.

<!--- YOU CAN DELETE ALL OF THIS AFTER READING. -->

<!--- Make use of markdown lists. They make stuff much easier to read through. -->
<!--- Explain why and what your changes do in simple terms. --->
<!--- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. --->

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->

<!--- "Inspired" by the CDDA PR template -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the Dreadnought assault cannon from `spr_weapon_assca` to `spr_dread_assault_cannon`, fixing the incorrect weapon sprite.

<sup>Written for commit 6c336ae590809e200ab31e3a61091c6f007c451c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

