### PR TITLE
fix(ui): Close event popup with follow-up popups

### DIFF
--- a/scripts/scr_planetary_feature/scr_planetary_feature.gml
+++ b/scripts/scr_planetary_feature/scr_planetary_feature.gml
@@ -757,6 +757,7 @@ function ground_forces_collect_artifact() {
         obj_controller.menu = 0;
         instance_destroy();
     }
+    instance_destroy();
 }
 
 function governor_negotiate_artifact() {

--- a/scripts/scr_popup_functions/scr_popup_functions.gml
+++ b/scripts/scr_popup_functions/scr_popup_functions.gml
@@ -223,8 +223,25 @@ function draw_popup_options() {
                     press = i;
                     if (_is_struct && struct_exists(_opt, "choice_func")) {
                         if (is_callable(_opt.choice_func)) {
+                            var _newest_popup = noone;
+                            with (obj_popup) {
+                                if (id > _newest_popup) {
+                                    _newest_popup = id;
+                                }
+                            }
                             script_execute(_opt.choice_func);
                             press = -1;
+                            if (instance_exists(id)) {
+                                var _replaced = false;
+                                with (obj_popup) {
+                                    if (id > _newest_popup) {
+                                        _replaced = true;
+                                    }
+                                }
+                                if (_replaced) {
+                                    instance_destroy();
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Fixes event popups (reported with "Artifact Located") where picking an option that opens a result popup left the first window open. The result window spawned behind the stuck one and, since result popups close on any click, the next click silently dismissed it — so the outcome ("Artifact Recovered!" etc.) was never visible.

* What Caused
   * Popup option handlers run with `self` = the popup, and are expected to close it with a bare `instance_destroy()`.
   * `ground_forces_collect_artifact()` wraps its whole body in `with (obj_ground_mission)`, so its
  final `instance_destroy()` destroyed the ground mission instead of the popup. The
  "Artifact Located" window was never closed.
   * All popups poll the mouse independently and draw at the same screen position/depth, so the
  hidden result popup ate the clicks aimed at the lingering first popup.

* Fixes
   * `scripts/scr_planetary_feature/scr_planetary_feature.gml`: `ground_forces_collect_artifact()` now destroys the calling popup outside the `with (obj_ground_mission)` block, matching the pattern already used by `remove_stc_from_planet()` and `ground_mission_leave_it_function()`.
   * `scripts/scr_popup_functions/scr_popup_functions.gml`: `draw_popup_options()` added a general safeguard: after an option's `choice_func` runs, if the popup is still alive **and** the handler spawned a newer popup, the old popup closes itself. This covers the same latent bug in other option handlers (e.g. the STC Mechanicus-Forge ambush branch) without touching each one. Handlers that close themselves, or that rewrite the existing popup in place without spawning a new one, are unaffected.

* Testing
   * Tested in game with only the artifact specific fix: "Artifact Located" closes on selecting
  "Swiftly take the Artifact" and "Artifact Recovered!" is shown and dismisses normally.
   * Tested in game with only the general safeguard: same correct behavior.
   * Tested with both applied: no issues or regressions found
   * Tested STC Mechanicus-Forge ambush which does crash but it doesn't because of this fix. The event gui popups work correct but there is some bug going from that branch to combat unrelated to this. I verified the crash is unrelated by compiling the current main and doing the same event and it still crashes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stuck event popups by closing the original when an option opens a follow-up result popup, so outcomes like "Artifact Recovered!" are visible. Also ensures `ground_forces_collect_artifact()` destroys the popup instead of the ground mission.

- **Bug Fixes**
  - `ground_forces_collect_artifact()`: moved the popup `instance_destroy()` outside the `with (obj_ground_mission)` block.
  - `draw_popup_options()`: after `choice_func` runs, if the current popup is still alive and a newer popup was spawned, auto-close the current popup.

<sup>Written for commit b44490252845c97061cbdd80a7600ca8428522b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

