### PR TITLE
fix: diplomacy draw crash and manage-selection state desync errors

### DIFF
--- a/objects/obj_controller/Draw_64.gml
+++ b/objects/obj_controller/Draw_64.gml
@@ -43,6 +43,8 @@ try {
 draw_set_alpha(1);
 draw_set_valign(fa_top);
 draw_set_halign(fa_left);
+
+try {
 if (menu == eMENU.DIPLOMACY) {
     add_draw_return_values();
     if (diplomacy > 0) {
@@ -67,6 +69,12 @@ if (menu == eMENU.DIPLOMACY) {
     }
     pop_draw_return_values();
 }
+} catch (_exception) {
+    ERROR_HANDLER.handle_exception(_exception);
+    menu = eMENU.DEFAULT;
+    menu_lock = false;
+}
+
 // Main UI
 if (!zoomed && !zui) {
     add_draw_return_values();

--- a/objects/obj_controller/Draw_64.gml
+++ b/objects/obj_controller/Draw_64.gml
@@ -261,6 +261,9 @@ function draw_line(x1, y1, y_slide, variable) {
 
 try {
     if (menu == eMENU.MANAGE) {
+        if (managing == -1 && !is_struct(selection_data)) {
+            main_map_defaults();
+        } else {
         if (managing != 0) {
             draw_sprite_and_unit_equip_data();
         }
@@ -269,6 +272,7 @@ try {
         }
         if (managing > 0) {
             company_specific_management();
+        }
         }
     } else if (menu == eMENU.LIBRARIUM) {
         scr_librarium_gui();

--- a/objects/obj_controller/Draw_64.gml
+++ b/objects/obj_controller/Draw_64.gml
@@ -32,7 +32,7 @@ if (is_test_map == true) {
 try {
     if (menu == eMENU.ARMAMENTARIUM) {
         armamentarium.draw();
-    } else if (menu >= eMENU.SETTINGS && menu <= eMENU.FORMATIONS_SETTINGS){
+    } else if (menu >= eMENU.SETTINGS && menu <= eMENU.FORMATIONS_SETTINGS) {
         draw_sprite(spr_settings_bg, 0, 0, 0);
     }
 } catch (_exception) {
@@ -45,30 +45,30 @@ draw_set_valign(fa_top);
 draw_set_halign(fa_left);
 
 try {
-if (menu == eMENU.DIPLOMACY) {
-    add_draw_return_values();
-    if (diplomacy > 0) {
-        draw_diplomacy_diplo_text();
-        if (trading == true) {
-            if ((diplomacy > 1) && is_struct(trade_attempt)) {
-                try {
-                    trade_attempt.draw_trade_screen();
-                } catch (_exception) {
-                    ERROR_HANDLER.handle_exception(_exception);
-                    delete trade_attempt;
-                    trading = false;
+    if (menu == eMENU.DIPLOMACY) {
+        add_draw_return_values();
+        if (diplomacy > 0) {
+            draw_diplomacy_diplo_text();
+            if (trading == true) {
+                if ((diplomacy > 1) && is_struct(trade_attempt)) {
+                    try {
+                        trade_attempt.draw_trade_screen();
+                    } catch (_exception) {
+                        ERROR_HANDLER.handle_exception(_exception);
+                        delete trade_attempt;
+                        trading = false;
+                    }
                 }
+            } else if (diplomacy != 10.1) {
+                draw_character_diplomacy_base_page();
             }
-        } else if (diplomacy != 10.1) {
-            draw_character_diplomacy_base_page();
+        } else if (diplomacy == -1) {
+            if (is_struct(character_diplomacy)) {
+                draw_character_diplomacy();
+            }
         }
-    } else if (diplomacy == -1) {
-        if (is_struct(character_diplomacy)) {
-            draw_character_diplomacy();
-        }
+        pop_draw_return_values();
     }
-    pop_draw_return_values();
-}
 } catch (_exception) {
     ERROR_HANDLER.handle_exception(_exception);
     menu = eMENU.DEFAULT;
@@ -264,15 +264,15 @@ try {
         if (managing == -1 && !is_struct(selection_data)) {
             main_map_defaults();
         } else {
-        if (managing != 0) {
-            draw_sprite_and_unit_equip_data();
-        }
-        if (managing == -1) {
-            scr_manage_task_selector();
-        }
-        if (managing > 0) {
-            company_specific_management();
-        }
+            if (managing != 0) {
+                draw_sprite_and_unit_equip_data();
+            }
+            if (managing == -1) {
+                scr_manage_task_selector();
+            }
+            if (managing > 0) {
+                company_specific_management();
+            }
         }
     } else if (menu == eMENU.LIBRARIUM) {
         scr_librarium_gui();

--- a/objects/obj_controller/Draw_64.gml
+++ b/objects/obj_controller/Draw_64.gml
@@ -44,9 +44,9 @@ draw_set_alpha(1);
 draw_set_valign(fa_top);
 draw_set_halign(fa_left);
 
-try {
     if (menu == eMENU.DIPLOMACY) {
         add_draw_return_values();
+    try {
         if (diplomacy > 0) {
             draw_diplomacy_diplo_text();
             if (trading == true) {
@@ -67,12 +67,12 @@ try {
                 draw_character_diplomacy();
             }
         }
-        pop_draw_return_values();
+    } catch (_exception) {
+        ERROR_HANDLER.handle_exception(_exception);
+        menu = eMENU.DEFAULT;
+        menu_lock = false;
     }
-} catch (_exception) {
-    ERROR_HANDLER.handle_exception(_exception);
-    menu = eMENU.DEFAULT;
-    menu_lock = false;
+    pop_draw_return_values();
 }
 
 // Main UI

--- a/scripts/scr_controller_helpers/scr_controller_helpers.gml
+++ b/scripts/scr_controller_helpers/scr_controller_helpers.gml
@@ -78,6 +78,7 @@ function scr_change_menu(wanted_menu, specific_area_function = undefined) {
 function main_map_defaults() {
     with (obj_controller) {
         menu = eMENU.DEFAULT;
+        menu_lock = false;
         hide_banner = 0;
         location_viewer.update_garrison_log();
         managing = 0;

--- a/scripts/scr_controller_helpers/scr_controller_helpers.gml
+++ b/scripts/scr_controller_helpers/scr_controller_helpers.gml
@@ -165,9 +165,9 @@ function scr_toggle_setting() {
                 popup = 0;
                 selected = 0;
                 hide_banner = 1;
-                try{
+                try {
                     setup_ui_chapter_settings();
-                } catch (_exception){
+                } catch (_exception) {
                     ERROR_HANDLER.handle_exception(_exception);
                     scr_toggle_setting();
                 }

--- a/scripts/scr_ui_diplomacy/scr_ui_diplomacy.gml
+++ b/scripts/scr_ui_diplomacy/scr_ui_diplomacy.gml
@@ -135,7 +135,7 @@ function draw_diplomacy_diplo_text() {
     draw_set_halign(fa_left);
     draw_text_ext(352, 209, string_hash_to_newline(string(diplo_txt)), -1, 536);
     draw_set_halign(fa_center);
-    draw_line(xx + 429, yy + 710, xx + 800, yy + 710);
+    draw_line(429, 710, 800, 710);
 }
 
 function set_up_diplomacy_buttons() {

--- a/scripts/scr_ui_manage/scr_ui_manage.gml
+++ b/scripts/scr_ui_manage/scr_ui_manage.gml
@@ -630,7 +630,7 @@ function draw_sprite_and_unit_equip_data() {
             var button_coords;
             var _allow_alternative_views = managing >= 0;
             if (!_allow_alternative_views) {
-                _allow_alternative_views = selection_data.purpose_code == "manage";
+                _allow_alternative_views = is_struct(selection_data) && selection_data.purpose_code == "manage";
             }
             if (_allow_alternative_views) {
                 alternative_manage_views(xx + 5, yy + 6);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes crashes in the diplomacy dialog and manage-selection UI, adds safe recovery back to the map, and prevents draw-state leaks on errors.

- **Bug Fixes**
  - Wrap diplomacy draw in try/catch; on error, switch to `eMENU.DEFAULT`, clear `menu_lock` (also in `main_map_defaults()`), and always restore draw state.
  - If in ad‑hoc manage (`managing == -1`) and `selection_data` isn’t a struct, call `main_map_defaults()` to exit cleanly.
  - Guard `selection_data.purpose_code` with `is_struct(selection_data)` in the unit panel.
  - Draw diplomacy separator with absolute coords (`draw_line(429, 710, 800, 710)`), removing `xx/yy`.

- **Refactors**
  - Ran `gobo` to format updated code; no functional changes.

<sup>Written for commit c24b6810ca14aa2e2e45e5b71fcc81b681dfa097. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

