### PR TITLE
fix: Missed comma in scr_culture_visuals

### DIFF
--- a/scripts/scr_culture_visuals/scr_culture_visuals.gml
+++ b/scripts/scr_culture_visuals/scr_culture_visuals.gml
@@ -1878,7 +1878,7 @@ global.modular_drawing_items = [
 		body_types: [0],
         sprite: spr_artificer_thorax,
         shadows: spr_artificer_thorax_shadow,
-    }
+    },
 	//Dreadnought Sprites
 	{
         position: "armour",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a missing comma in `scripts/scr_culture_visuals/scr_culture_visuals.gml` to fix a syntax error. This ensures the `global.modular_drawing_items` array parses correctly and that subsequent entries (including Dreadnought sprites) load as expected.

<sup>Written for commit 2a55f545c9bf6e09bedcb091d23e9874c1123a93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

