### PR TITLE
chore: Remove version lock from Gobo workflow

### DIFF
--- a/.github/workflows/gobo_format.yml
+++ b/.github/workflows/gobo_format.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Download Gobo
         run: |
-          gh release download v0.1.0 --repo EttyKitty/GoboCat --pattern "gobo-ubuntu.zip"
+          gh release download --repo EttyKitty/GoboCat --pattern "gobo-ubuntu.zip"
           unzip gobo-ubuntu.zip
           chmod +x ./gobo
         env:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the version pin in the Gobo formatting workflow so it downloads the latest release artifact instead of `v0.1.0`. This keeps CI up to date and avoids failures when versions change.

<sup>Written for commit d725a9c25020a02065ed46de1c70d075e92be1ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

