### PR TITLE
ci: Update Gobo download pattern to gobo-linux-x64.zip

### DIFF
--- a/.github/workflows/gobo_format.yml
+++ b/.github/workflows/gobo_format.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Download Gobo
         run: |
-          gh release download --repo EttyKitty/GoboCat --pattern "gobo-ubuntu.zip"
+          gh release download --repo EttyKitty/GoboCat --pattern "gobo-linux-x64.zip"
           unzip gobo-ubuntu.zip
           chmod +x ./gobo
         env:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch the GitHub Actions Gobo download to `gobo-linux-x64.zip` to match the current release asset in `EttyKitty/GoboCat`. This keeps the formatting job using the correct Linux x64 binary.

<sup>Written for commit b6d3060744967300e766b6a2c87c0e07e208a87e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

