### PR TITLE
ci: Fix gobo unzip name as well

### DIFF
--- a/.github/workflows/gobo_format.yml
+++ b/.github/workflows/gobo_format.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Download Gobo
         run: |
           gh release download --repo EttyKitty/GoboCat --pattern "gobo-linux-x64.zip"
-          unzip gobo-ubuntu.zip
+          unzip gobo-linux-x64.zip
           chmod +x ./gobo
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix the unzip command in the Gobo format CI workflow to extract `gobo-linux-x64.zip` (the downloaded asset). This prevents the step from failing and ensures the `gobo` binary is available and executable.

<sup>Written for commit fcca601ef1db0a97200ce431304f7940ff95c4ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

