### PR TITLE
ci: Add JSON formatter workflow

### DIFF
--- a/.github/workflows/json_format.yml
+++ b/.github/workflows/json_format.yml
@@ -16,8 +16,9 @@ jobs:
 
       - name: Format and Sort JSON Files
         run: |
-          # Find all .json files, excluding node_modules and package-lock.json
-          find . -type f -name "*.json" ! -path "*/node_modules/*" ! -name "package-lock.json" -print0 | while IFS= read -r -d '' file; do
+          set -o pipefail
+
+          find . -type f -name "*.json" ! -path "*/node_modules/*" ! -path "*/.git/*" ! -name "package-lock.json" -print0 | while IFS= read -r -d '' file; do
             echo "Processing $file..."
             
             # 1. json5 parses lenient JSON (fixing trailing commas/comments) and outputs standard JSON
@@ -25,7 +26,7 @@ jobs:
             if npx json5 "$file" 2>/dev/null | jq --indent 4 -S . > "$file.tmp"; then
               mv "$file.tmp" "$file"
             else
-              echo "Warning: Could not process $file. It may contain syntax errors other than trailing commas."
+              echo "Warning: Could not process $file. It may contain syntax errors."
               rm -f "$file.tmp"
             fi
           done

--- a/.github/workflows/json_format.yml
+++ b/.github/workflows/json_format.yml
@@ -1,0 +1,43 @@
+name: JSON Formatter
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  format-json:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Format and Sort JSON Files
+        run: |
+          # Find all .json files, excluding node_modules and package-lock.json
+          find . -type f -name "*.json" ! -path "*/node_modules/*" ! -name "package-lock.json" -print0 | while IFS= read -r -d '' file; do
+            echo "Processing $file..."
+            
+            # 1. json5 parses lenient JSON (fixing trailing commas/comments) and outputs standard JSON
+            # 2. jq sorts the keys (-S) and formats it with 4-space indentation
+            if npx json5 "$file" 2>/dev/null | jq --indent 4 -S . > "$file.tmp"; then
+              mv "$file.tmp" "$file"
+            else
+              echo "Warning: Could not process $file. It may contain syntax errors other than trailing commas."
+              rm -f "$file.tmp"
+            fi
+          done
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "style: Format and sort JSON files"
+          title: "style: Automated JSON format and sort"
+          body: "This is an automated PR containing formatting and sorting updates for JSON files."
+          branch: automation/json-format
+          delete-branch: true
+          author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+          committer: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a `JSON Formatter` GitHub Actions workflow that normalizes and sorts JSON files on demand, then opens an automated PR with the changes. This keeps JSON consistent and fixes minor lenient JSON syntax like trailing commas and comments.

- **New Features**
  - Triggered via `workflow_dispatch`.
  - Skips `node_modules`, `.git`, and `package-lock.json`.
  - Formats with `npx json5` and sorts keys using `jq -S` with 4-space indent.

<sup>Written for commit 5a15941d50a33b9c68f67d571240863e61e042e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

