### PR TITLE
ci: File name case insensitive JSON formatter

### DIFF
--- a/.github/workflows/json_format.yml
+++ b/.github/workflows/json_format.yml
@@ -18,9 +18,9 @@ jobs:
         run: |
           set -o pipefail
 
-          find . -type f -name "*.json" ! -path "*/node_modules/*" ! -path "*/.git/*" ! -name "package-lock.json" -print0 | while IFS= read -r -d '' file; do
+          find . -type f -iname "*.json" ! -path "*/node_modules/*" ! -path "*/.git/*" ! -name "package-lock.json" -print0 | while IFS= read -r -d '' file; do
             echo "Processing $file..."
-            
+
             # 1. json5 parses lenient JSON (fixing trailing commas/comments) and outputs standard JSON
             # 2. jq sorts the keys (-S) and formats it with 4-space indentation
             if npx json5 "$file" 2>/dev/null | jq --indent 4 -S . > "$file.tmp"; then


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update the JSON formatter CI step to search for JSON files case-insensitively. Switches the `find` command from `-name` to `-iname` so `.JSON` and mixed-case extensions are also formatted.

<sup>Written for commit e7117daec63353f091f4f8932d7db35d8fcc02df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

