### PR TITLE
refactor: Standardize equipment keys

### DIFF
--- a/scripts/scr_after_combat/scr_after_combat.gml
+++ b/scripts/scr_after_combat/scr_after_combat.gml
@@ -403,15 +403,15 @@ function after_combat_dead_marine_equipment_recovered(unit) {
         }
 
         switch (_slot) {
-            case "armour_data":
+            case "armour":
                 unit.update_armour("", false, _recover);
-            case "weapon_one_data":
+            case "wep1":
                 unit.weapon_one("", false, _recover);
-            case "weapon_two_data":
+            case "wep2":
                 unit.update_weapon_two("", false, _recover);
-            case "gear_data":
+            case "gear":
                 unit.update_gear("", false, _recover);
-            case "mobility_item_data":
+            case "mobi":
                 unit.update_mobility_item("", false, _recover);
         }
     }

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -720,11 +720,11 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
         var weapon_one_data = get_weapon_one_data();
         var weapon_two_data = get_weapon_two_data();
         var equip_data = {
-            armour_data: armour_data,
-            gear_data: gear_data,
-            mobility_data: mobility_data,
-            weapon_one_data: weapon_one_data,
-            weapon_two_data: weapon_two_data,
+            armour: armour_data,
+            gear: gear_data,
+            mobi: mobility_data,
+            wep1: weapon_one_data,
+            wep2: weapon_two_data,
         };
         return equip_data;
     };

--- a/scripts/scr_ui_manage/scr_ui_manage.gml
+++ b/scripts/scr_ui_manage/scr_ui_manage.gml
@@ -146,7 +146,7 @@ function reset_manage_unit_constants(unit) {
 
         //armour
         var _data = {
-            tooltip: $"==Armour==\n {is_struct(_equip_data.armour_data) ? _equip_data.armour_data.item_tooltip_desc_gen() : ""}",
+            tooltip: $"==Armour==\n {is_struct(_equip_data.armour) ? _equip_data.armour.item_tooltip_desc_gen() : ""}",
             colour: quality_color(unit.armour_quality),
             max_width: 187,
         };
@@ -157,7 +157,7 @@ function reset_manage_unit_constants(unit) {
         // Gear
 
         _data = {
-            tooltip: $"==Gear==\n{is_struct(_equip_data.gear_data) ? _equip_data.gear_data.item_tooltip_desc_gen() : ""}",
+            tooltip: $"==Gear==\n{is_struct(_equip_data.gear) ? _equip_data.gear.item_tooltip_desc_gen() : ""}",
             colour: quality_color(unit.gear_quality),
             max_width: 187,
         };
@@ -166,7 +166,7 @@ function reset_manage_unit_constants(unit) {
 
         //mobility
         _data = {
-            tooltip: $"==Back/Mobilitiy==\n{is_struct(_equip_data.mobility_data) ? _equip_data.mobility_data.item_tooltip_desc_gen() : ""}",
+            tooltip: $"==Back/Mobilitiy==\n{is_struct(_equip_data.mobi) ? _equip_data.mobi.item_tooltip_desc_gen() : ""}",
             colour: quality_color(unit.mobility_item_quality),
             max_width: 187,
         };
@@ -174,7 +174,7 @@ function reset_manage_unit_constants(unit) {
         unit_manage_constants.mobi_string = new ReactiveString(unit.equipments_qual_string("mobi", true), 0, 0, _data);
 
         _data = {
-            tooltip: $"==First Weapon==\n{is_struct(_equip_data.weapon_one_data) ? _equip_data.weapon_one_data.item_tooltip_desc_gen() : ""}",
+            tooltip: $"==First Weapon==\n{is_struct(_equip_data.wep1) ? _equip_data.wep1.item_tooltip_desc_gen() : ""}",
             colour: quality_color(unit.weapon_one_quality),
             max_width: 187,
         };
@@ -183,7 +183,7 @@ function reset_manage_unit_constants(unit) {
 
         //mobility
         _data = {
-            tooltip: $"==Second Weapon==\n{is_struct(_equip_data.weapon_two_data) ? _equip_data.weapon_two_data.item_tooltip_desc_gen() : ""}",
+            tooltip: $"==Second Weapon==\n{is_struct(_equip_data.wep2) ? _equip_data.wep2.item_tooltip_desc_gen() : ""}",
             colour: quality_color(unit.weapon_two_quality),
             max_width: 187,
         };


### PR DESCRIPTION
<!--- YOU CAN DELETE ALL OF THIS AFTER READING. -->

<!--- Make use of markdown lists. They make stuff much easier to read through. -->
<!--- Explain why and what your changes do in simple terms. --->
<!--- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. --->

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->

<!--- "Inspired" by the CDDA PR template -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized equipment keys across marine stats, UI, and post-combat recovery to use shorter names. Prevents key mismatches without changing behavior.

- **Refactors**
  - Renamed keys: armour_data→armour, gear_data→gear, mobility_data/mobility_item_data→mobi, weapon_one_data→wep1, weapon_two_data→wep2.
  - Updated usages in `TTRPG_stats` (equip struct), `reset_manage_unit_constants` (tooltips/colors), and `after_combat_dead_marine_equipment_recovered` to use the new keys.

<sup>Written for commit de9a122a45971cb3708001bb9a2739ac27f845cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

