### PR TITLE
fix(diplomacy): Restore on-world artifact negotiation and trading

### DIFF
--- a/objects/obj_controller/Mouse_50.gml
+++ b/objects/obj_controller/Mouse_50.gml
@@ -164,7 +164,7 @@ if ((menu == eMENU.DIPLOMACY) && (diplomacy > 0) || ((diplomacy < -5) && (diplom
                 }
                 if (trading_artifact == 2 && instance_exists(obj_ground_mission)) {
                     with (obj_ground_mission) {
-                        recieve_artifact_in_discussion();
+                        receive_artifact_in_discussion();
                     }
                 }
                 exit;

--- a/objects/obj_controller/Mouse_50.gml
+++ b/objects/obj_controller/Mouse_50.gml
@@ -158,7 +158,9 @@ if ((menu == eMENU.DIPLOMACY) && (diplomacy > 0) || ((diplomacy < -5) && (diplom
                     instance_destroy();
                 }
                 if (trading_artifact != 2) {
-                    obj_ground_mission.alarm[1] = 1;
+                    with (obj_ground_mission) {
+                        instance_destroy();
+                    }
                 }
                 if (trading_artifact == 2 && instance_exists(obj_ground_mission)) {
                     with (obj_ground_mission) {

--- a/objects/obj_controller/Step_0.gml
+++ b/objects/obj_controller/Step_0.gml
@@ -393,7 +393,12 @@ try {
     }
     // Diplomacy options
     if (diplomacy == 0) {
-        trading_artifact = 0;
+        if (trading_artifact != 0) {
+            with (obj_ground_mission) {
+                instance_destroy();
+            }
+            trading_artifact = 0;
+        }
     }
 
     if ((trading_artifact == 0) && (trading == 0) && (trading_artifact == 0) && (faction_justmet == 1) && (questing == 0) && (trading_demand == 0) && (complex_event == false)) {

--- a/scripts/scr_dialogue/scr_dialogue.gml
+++ b/scripts/scr_dialogue/scr_dialogue.gml
@@ -1610,7 +1610,7 @@ function scr_dialogue(diplo_keyphrase, data = {}) {
             }
             if (diplo_keyphrase == "artifact") {
                 if (rela != "hostile") {
-                    add_diplomacy_option({option_text: "Propose a trade for the Artifact.", choice_func: open_artifact_trade});
+                    add_diplomacy_option({option_text: "Propose a trade for the Artifact.", choice_func: open_trade_screen});
                     add_diplomacy_option({option_text: "Leave it be; Exit.", choice_func: leave_artifact_negotiation, is_exit: true});
                     diplo_text = "The Adeptus Mechanicus is aware of the Artifact.  Do not concern yourself with that which is rightly within our territory.";
                 }
@@ -2008,7 +2008,7 @@ function scr_dialogue(diplo_keyphrase, data = {}) {
                 diplo_text = "Make me an offer and I shall consider it, both for its value and its potential heresy.";
             }
             if (diplo_keyphrase == "artifact") {
-                add_diplomacy_option({option_text: "Propose a trade for the Artifact.", choice_func: open_artifact_trade});
+                add_diplomacy_option({option_text: "Propose a trade for the Artifact.", choice_func: open_trade_screen});
                 add_diplomacy_option({option_text: "Leave it be; Exit.", choice_func: leave_artifact_negotiation, is_exit: true});
                 diplo_text = "The Inquisition is, of course, aware of the artifact in question. What, precisely, are you offering for it?";
             }
@@ -2378,7 +2378,7 @@ function scr_dialogue(diplo_keyphrase, data = {}) {
             }
 
             if (diplo_keyphrase == "artifact") {
-                add_diplomacy_option({option_text: create_dialogue_string(_diag_set, "propose_arti_trade", _diag_data), choice_func: open_artifact_trade});
+                add_diplomacy_option({option_text: create_dialogue_string(_diag_set, "propose_arti_trade", _diag_data), choice_func: open_trade_screen});
                 add_diplomacy_option({option_text: create_dialogue_string(_diag_set, "leave_it", _diag_data), choice_func: leave_artifact_negotiation, is_exit: true});
             }
 

--- a/scripts/scr_dialogue/scr_dialogue.gml
+++ b/scripts/scr_dialogue/scr_dialogue.gml
@@ -1610,8 +1610,8 @@ function scr_dialogue(diplo_keyphrase, data = {}) {
             }
             if (diplo_keyphrase == "artifact") {
                 if (rela != "hostile") {
-                    add_diplomacy_option({option_text: "Propose a trade for the Artifact."});
-                    add_diplomacy_option({option_text: "Leave it be; Exit.", is_exit: true});
+                    add_diplomacy_option({option_text: "Propose a trade for the Artifact.", choice_func: open_artifact_trade});
+                    add_diplomacy_option({option_text: "Leave it be; Exit.", choice_func: leave_artifact_negotiation, is_exit: true});
                     diplo_text = "The Adeptus Mechanicus is aware of the Artifact.  Do not concern yourself with that which is rightly within our territory.";
                 }
                 if (rela == "hostile") {
@@ -2008,8 +2008,8 @@ function scr_dialogue(diplo_keyphrase, data = {}) {
                 diplo_text = "Make me an offer and I shall consider it, both for its value and its potential heresy.";
             }
             if (diplo_keyphrase == "artifact") {
-                add_diplomacy_option({option_text: "Propose a trade for the Artifact."});
-                add_diplomacy_option({option_text: "Leave it be; Exit."});
+                add_diplomacy_option({option_text: "Propose a trade for the Artifact.", choice_func: open_artifact_trade});
+                add_diplomacy_option({option_text: "Leave it be; Exit.", choice_func: leave_artifact_negotiation, is_exit: true});
                 diplo_text = "The Inquisition is, of course, aware of the artifact in question. What, precisely, are you offering for it?";
             }
             if (diplo_keyphrase == "artifact_thanks") {
@@ -2378,8 +2378,8 @@ function scr_dialogue(diplo_keyphrase, data = {}) {
             }
 
             if (diplo_keyphrase == "artifact") {
-                add_diplomacy_option({option_text: create_dialogue_string(_diag_set, "propose_arti_trade", _diag_data)});
-                add_diplomacy_option({option_text: create_dialogue_string(_diag_set, "leave_it", _diag_data)});
+                add_diplomacy_option({option_text: create_dialogue_string(_diag_set, "propose_arti_trade", _diag_data), choice_func: open_artifact_trade});
+                add_diplomacy_option({option_text: create_dialogue_string(_diag_set, "leave_it", _diag_data), choice_func: leave_artifact_negotiation, is_exit: true});
             }
 
             if (diplo_keyphrase == "artifact_daemon") {

--- a/scripts/scr_diplomacy_helpers/scr_diplomacy_helpers.gml
+++ b/scripts/scr_diplomacy_helpers/scr_diplomacy_helpers.gml
@@ -90,6 +90,26 @@ function add_diplomacy_option(option = {}) {
     array_push(obj_controller.diplo_option, _button);
 }
 
+/// @desc Opens the trade screen during an artifact negotiation; TradeAttempt pre-lists the artifact while trading_artifact == 1.
+/// @returns {undefined}
+function open_artifact_trade() {
+    with (obj_controller) {
+        trading = 1;
+        scr_dialogue("open_trade");
+        cooldown = 8;
+        click2 = 1;
+        trade_attempt = new TradeAttempt(diplomacy);
+    }
+}
+
+/// @desc Leaves the artifact negotiation and cleans up the associated objects.
+/// @returns {undefined}
+function leave_artifact_negotiation() {
+    with (obj_ground_mission) {
+        instance_destroy();
+    }
+}
+
 function basic_diplomacy_screen() {
     var xx = camera_get_view_x(view_camera[0]);
     var yy = camera_get_view_y(view_camera[0]);

--- a/scripts/scr_diplomacy_helpers/scr_diplomacy_helpers.gml
+++ b/scripts/scr_diplomacy_helpers/scr_diplomacy_helpers.gml
@@ -90,9 +90,9 @@ function add_diplomacy_option(option = {}) {
     array_push(obj_controller.diplo_option, _button);
 }
 
-/// @desc Opens the trade screen during an artifact negotiation; TradeAttempt pre-lists the artifact while trading_artifact == 1.
+/// @desc Opens the trade screen for the current diplomacy faction.
 /// @returns {undefined}
-function open_artifact_trade() {
+function open_trade_screen() {
     with (obj_controller) {
         trading = 1;
         scr_dialogue("open_trade");

--- a/scripts/scr_planetary_feature/scr_planetary_feature.gml
+++ b/scripts/scr_planetary_feature/scr_planetary_feature.gml
@@ -799,7 +799,6 @@ function governor_negotiate_artifact() {
             with (obj_controller) {
                 scr_dialogue("artifact");
             }
-            instance_destroy();
             instance_destroy(obj_popup);
         }
     }

--- a/scripts/scr_planetary_feature/scr_planetary_feature.gml
+++ b/scripts/scr_planetary_feature/scr_planetary_feature.gml
@@ -935,7 +935,7 @@ function remove_stc_from_planet() {
     instance_destroy();
 }
 
-function recieve_artifact_in_discussion() {
+function receive_artifact_in_discussion() {
     scr_return_ship(loc, self, num);
 
     var ship_id = get_valid_player_ship("", loc);

--- a/scripts/scr_trade/scr_trade.gml
+++ b/scripts/scr_trade/scr_trade.gml
@@ -8,6 +8,7 @@ function TradeAttempt(diplomacy) constructor {
         "License: Crusade": 1500,
         "Castellax Battle Automata": 1200,
         "Minor Artifact": 250,
+        "Artifact": 0, // For planetary artifacts
         "Skitarii": 15,
         "Techpriest": 450,
         //"Condemnor Boltgun" : 20,

--- a/scripts/scr_trade/scr_trade.gml
+++ b/scripts/scr_trade/scr_trade.gml
@@ -170,15 +170,18 @@ function TradeAttempt(diplomacy) constructor {
             }
         }
 
-        var flit = setup_ai_trade_fleet(trade_from_star, diplomacy_faction);
+        var _has_cargo = array_length(struct_get_names(trading_object)) > 0;
+        if (_has_cargo) {
+            var flit = setup_ai_trade_fleet(trade_from_star, diplomacy_faction);
 
-        flit.cargo_data.player_goods = trading_object;
+            flit.cargo_data.player_goods = trading_object;
 
-        flit.target = trade_to_obj;
-        with (flit) {
-            action_x = target.x;
-            action_y = target.y;
-            set_fleet_movement();
+            flit.target = trade_to_obj;
+            with (flit) {
+                action_x = target.x;
+                action_y = target.y;
+                set_fleet_movement();
+            }
         }
     };
 

--- a/scripts/scr_trade/scr_trade.gml
+++ b/scripts/scr_trade/scr_trade.gml
@@ -96,6 +96,12 @@ function TradeAttempt(diplomacy) constructor {
                 };
             } else if (_opt.trade_type == "arti") {
                 scr_add_artifact("random", "minor", true);
+            } else if (_opt.trade_type == "planet_arti") {
+                if (instance_exists(obj_ground_mission)) {
+                    with (obj_ground_mission) {
+                        receive_artifact_in_discussion();
+                    }
+                }
             } else if (_opt.trade_type == "vehic") {
                 if (!struct_exists(trading_object, "vehicles")) {
                     trading_object.vehicles = {};
@@ -413,6 +419,11 @@ function TradeAttempt(diplomacy) constructor {
             new_demand_buttons(-100, "Ork Sniper", "merc", 50);
             new_demand_buttons(-100, "Flash Git", "merc", 50);
             break;
+    }
+
+    if (obj_controller.trading_artifact == 1 && instance_exists(obj_ground_mission)) {
+        new_demand_buttons(-100, "Artifact", "planet_arti", 1);
+        demand_options[array_length(demand_options) - 1].number = 1;
     }
 
     static new_offer_option = function(trade_disp = -100, name, trade_type, max_count = 1) {

--- a/scripts/scr_trade/scr_trade.gml
+++ b/scripts/scr_trade/scr_trade.gml
@@ -344,14 +344,6 @@ function TradeAttempt(diplomacy) constructor {
             trading = 0;
             scr_dialogue("trade_close");
             click2 = 1;
-            if (trading_artifact != 0) {
-                scr_toggle_diplomacy();
-                with (obj_popup) {
-                    instance_destroy();
-                }
-                obj_ground_mission.alarm[1] = 1;
-                exit;
-            }
         }
     };
     exit_button.bind_scope = self;

--- a/scripts/scr_ui_diplomacy/scr_ui_diplomacy.gml
+++ b/scripts/scr_ui_diplomacy/scr_ui_diplomacy.gml
@@ -70,7 +70,7 @@ function exit_diplomacy_dialogue() {
         cooldown = 8;
         if (trading_artifact == 2 && instance_exists(obj_ground_mission)) {
             with (obj_ground_mission) {
-                recieve_artifact_in_discussion();
+                receive_artifact_in_discussion();
             }
         }
         trading_artifact = 0;

--- a/scripts/scr_ui_diplomacy/scr_ui_diplomacy.gml
+++ b/scripts/scr_ui_diplomacy/scr_ui_diplomacy.gml
@@ -154,11 +154,7 @@ function set_up_diplomacy_buttons() {
     });
     diplo_buttons.trade.bind_method = function() {
         if ((audience == 0) && (force_goodbye == 0)) {
-            trading = 1;
-            scr_dialogue("open_trade");
-            cooldown = 8;
-            click2 = 1;
-            trade_attempt = new TradeAttempt(diplomacy);
+            open_trade_screen();
         }
     };
 

--- a/scripts/scr_ui_diplomacy/scr_ui_diplomacy.gml
+++ b/scripts/scr_ui_diplomacy/scr_ui_diplomacy.gml
@@ -74,8 +74,10 @@ function exit_diplomacy_dialogue() {
             }
         }
         trading_artifact = 0;
+        with (obj_ground_mission) {
+            instance_destroy();
+        }
         with (obj_popup) {
-            obj_ground_mission.alarm[1] = 1;
             instance_destroy();
         }
     }


### PR DESCRIPTION
Requesting an audience about an artifact found on a faction's world soft-locked the game: the two dialogue options "Propose a trade for the Artifact" / "Leave it be; Exit." rendered but did nothing when clicked, and the Exit button is hidden while dialogue options exist, so there was no way out.

- Wire the artifact dialogue options for the Mechanicus, Inquisition, and Ecclesiarchy:
  - "Leave it be; Exit." exits the conversation cleanly. The Artifact will stay on the planet in this case and can be interacted with again.
  - "Propose a trade for the Artifact" opens the trade screen with the Artifact pre-listed on the faction's side. Trade prices unchanged so existing per-faction price barriers apply; a successful trade hands it over via `receive_artifact_in_discussion()`.
- Keep `obj_ground_mission` alive during the negotiation as it holds the planet/ship context every resolution path needs. Then destroy it on every exit path, with a leak guard in `obj_controller` Step.
- Remove/guard stale `obj_ground_mission.alarm[1]` references — unguarded static refs that could crash, targeting an alarm event that no longer exists.
- Rename `recieve_artifact_in_discussion` to `receive_artifact_in_discussion` fixing the typo.
- Skip the trade delivery fleet when the cargo is empty. Previously instant granted trades (ex: requisition, licenses, artifacts) spawned a fleet with nothing to deliver that idled forever.

## Testing

- Tested in game for both the Mechanicus and the Ecclesiarchy: both dialogue options now work as expected, with no soft-lock and no other obvious issues in the surrounding flows.
- Traded for the artifact with the Mechanicus: the artifact is granted immediately and no empty delivery fleet spawns; trades including goods that need delivered still send the delivery fleet.
- The Inquisition shares the identical wiring but I truly don't know how to trigger this screen with Inquisition. So it should work if it is reachable but it might be unreachable in-game and thus not need to exist at all.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores on-world artifact negotiation and trading and fixes the soft-lock when requesting an audience about an artifact. Players can now propose a trade that opens the trade screen with the artifact pre-listed or exit cleanly; no empty delivery fleets spawn.

- **Bug Fixes**
  - Wired artifact dialogue for Mechanicus, Inquisition, and Ecclesiarchy: trade opens with the artifact pre-listed; exit works; per-faction price barriers apply; successful trades grant via `receive_artifact_in_discussion`.
  - Kept `obj_ground_mission` alive during negotiation and destroyed it on all exit paths; guarded stale references and removed `alarm[1]` usage to prevent crashes and soft-locks.
  - Added trade handling for planet-based artifacts (`planet_arti`) and only spawn a delivery fleet when cargo exists; instant-grant trades now skip the empty fleet.
  - Renamed `recieve_artifact_in_discussion` to `receive_artifact_in_discussion`.

- **Refactors**
  - Centralized trade screen opening and artifact-exit cleanup in `open_trade_screen` and `leave_artifact_negotiation`; reused across dialogue and the diplomacy UI.

<sup>Written for commit 883b0bc9605695fd92db65ee259f244325e6373c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

