### PR TITLE
style: Fix formatting in controller/Alarm_1

### DIFF
--- a/objects/obj_controller/Alarm_1.gml
+++ b/objects/obj_controller/Alarm_1.gml
@@ -208,7 +208,7 @@ with (obj_star) {
         if (rando) {
             owner = eFACTION.CHAOS;
             for (var i = 1; i <= planets; i++) {
-                p_owner [i] = eFACTION.CHAOS;
+                p_owner[i] = eFACTION.CHAOS;
                 p_heresy[i] = floor(random_range(75, 100));
                 p_traitors[i] = 6;
                 p_fortified[i] = choose(4, 5, 5, 4, 4, 3, 6);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix spacing in array indexing in objects/obj_controller/Alarm_1.gml (p_owner[i]) to match project style and avoid linter warnings.

<sup>Written for commit 7f4e567f7a942f40ec73b4288120324c338ab771. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

