### PR TITLE
fix: Mirrored bionic visuals

### DIFF
--- a/scripts/scr_culture_visuals/scr_culture_visuals.gml
+++ b/scripts/scr_culture_visuals/scr_culture_visuals.gml
@@ -297,6 +297,18 @@ function set_up_visual_overides() {
                     }
                 }
             }
+
+            if (struct_exists(_flip_mod, "body_parts")) {
+                var _bp_keys = struct_get_names(_flip_mod.body_parts);
+                for (var b = 0; b < array_length(_bp_keys); b++) {
+                    var _bp_key = _bp_keys[b];
+                    if (struct_exists(flip_components, _bp_key)) {
+                        _flip_mod.body_parts[$ flip_components[$ _bp_key]] = _flip_mod.body_parts[$ _bp_key];
+                        struct_remove(_flip_mod.body_parts, _bp_key);
+                    }
+                }
+            }
+
             if (struct_exists(_flip_mod, "overides")) {
                 var _overides_name = struct_get_names(_flip_mod.overides);
                 for (var o = 0; o < array_length(_overides_name); o++) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes mirrored bionic visuals so left/right body parts render on the correct side when flipped. The `set_up_visual_overides` function now remaps `body_parts` keys using `flip_components` and removes the original entries to prevent duplicates.

<sup>Written for commit 463fc27ac77c2e08c2ac3d90df42008eb9d40331. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

