### PR TITLE
refactor: Safer bilateral handling

### DIFF
--- a/scripts/scr_culture_visuals/scr_culture_visuals.gml
+++ b/scripts/scr_culture_visuals/scr_culture_visuals.gml
@@ -299,14 +299,17 @@ function set_up_visual_overides() {
             }
 
             if (struct_exists(_flip_mod, "body_parts")) {
+                var _new_body_parts = {};
                 var _bp_keys = struct_get_names(_flip_mod.body_parts);
                 for (var b = 0; b < array_length(_bp_keys); b++) {
                     var _bp_key = _bp_keys[b];
                     if (struct_exists(flip_components, _bp_key)) {
-                        _flip_mod.body_parts[$ flip_components[$ _bp_key]] = _flip_mod.body_parts[$ _bp_key];
-                        struct_remove(_flip_mod.body_parts, _bp_key);
+                        _new_body_parts[$ flip_components[$ _bp_key]] = _flip_mod.body_parts[$ _bp_key];
+                    } else {
+                        _new_body_parts[$ _bp_key] = _flip_mod.body_parts[$ _bp_key];
                     }
                 }
+                _flip_mod.body_parts = _new_body_parts;
             }
 
             if (struct_exists(_flip_mod, "overides")) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reworks body part flip logic in `set_up_visual_overides` to avoid in-place edits and safely handle bilateral parts. Prevents dropped or mis-mapped body parts when mirroring, fixing visual issues with bionic limbs.

- **Bug Fixes**
  - Build a new `body_parts` map instead of mutating while iterating, preventing key removal/overwrite issues.
  - Preserve unmapped parts and only remap keys found in `flip_components`.

<sup>Written for commit 601d6a41509596683d3bc9780354f5270b70f0ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

