### PR TITLE
fix(fleet): correct off-map fleet handling around space battles and prevent phantom fleets

### DIFF
--- a/objects/obj_en_fleet/Step_0.gml
+++ b/objects/obj_en_fleet/Step_0.gml
@@ -24,6 +24,14 @@ if ((owner == eFACTION.TAU) && ((x < 0) || (y < 0))) {
     instance_destroy();
 }
 
+// Garbage-collect stationary fleets leaked off-map (e.g. an exception between a coordinate displacement and its restore). 
+// Fleets in transit may legitimately be off-map.
+if ((action == "") && !in_room()) {
+    LOGGER.error($"Destroying stranded off-map fleet: owner {owner} at ({x}, {y})");
+    instance_destroy();
+    exit;
+}
+
 if ((target > 0) && instance_exists(target)) {
     target_x = target.x;
     target_y = target.y;

--- a/objects/obj_en_fleet/Step_0.gml
+++ b/objects/obj_en_fleet/Step_0.gml
@@ -20,7 +20,7 @@ if ((owner != eFACTION.INQUISITION) && (capital_number + frigate_number + escort
     instance_destroy();
 }
 
-if ((owner == eFACTION.TAU) && (x < 0) || (y < 0)) {
+if ((owner == eFACTION.TAU) && ((x < 0) || (y < 0))) {
     instance_destroy();
 }
 

--- a/objects/obj_fleet/Alarm_4.gml
+++ b/objects/obj_fleet/Alarm_4.gml
@@ -36,6 +36,7 @@ with (obj_en_husk) {
 }
 
 instance_activate_all();
+recalculate_fleet_presence();
 obj_controller.combat = 0;
 instance_activate_object(obj_turn_end);
 

--- a/objects/obj_fleet/Alarm_7.gml
+++ b/objects/obj_fleet/Alarm_7.gml
@@ -59,10 +59,12 @@ try {
         if ((enemy[op] != 0) && (enemy[op] != 4)) {
             obj_controller.temp[1071] = enemy[op];
 
+            // Park every fleet not fighting at the battle star offmap so the instance_nearest() loop below only finds participants.
+            // Restore after losses are applied.
             with (obj_en_fleet) {
                 if ((owner != obj_controller.temp[1071]) || (orbiting != obj_controller.temp[1070])) {
-                    x -= 10000;
-                    y -= 10000;
+                    x -= FLEET_BATTLE_DISPLACEMENT;
+                    y -= FLEET_BATTLE_DISPLACEMENT;
                 }
             }
 
@@ -73,7 +75,7 @@ try {
                     if (ofleet.trade_goods == "player_hold") {
                         ofleet.trade_goods = "";
                     }
-                    if ((ofleet.x > -7000) && (ofleet.y > -7000) && (ofleet.owner == enemy[op])) {
+                    if (in_room(ofleet) && (ofleet.owner == enemy[op])) {
                         if (en_capital_lost[op] + en_frigate_lost[op] + en_escort_lost[op] >= ofleet.capital_number + ofleet.frigate_number + ofleet.escort_number) {
                             en_capital_lost[op] -= ofleet.capital_number;
                             en_frigate_lost[op] -= ofleet.frigate_number;
@@ -106,9 +108,9 @@ try {
             }
 
             with (obj_en_fleet) {
-                if ((x < -7000) && (y < -7000)) {
-                    x += 10000;
-                    y += 10000;
+                if (!in_room()) {
+                    x += FLEET_BATTLE_DISPLACEMENT;
+                    y += FLEET_BATTLE_DISPLACEMENT;
                 }
             }
         }
@@ -117,8 +119,8 @@ try {
             obj_controller.temp[1071] = enemy[op];
             with (obj_en_fleet) {
                 if ((owner != obj_controller.temp[1071]) || (orbiting != obj_controller.temp[1070])) {
-                    x -= 10000;
-                    y -= 10000;
+                    x -= FLEET_BATTLE_DISPLACEMENT;
+                    y -= FLEET_BATTLE_DISPLACEMENT;
                 }
             }
             var ofleet = instance_nearest(room_width / 2, room_height / 2, obj_en_fleet);
@@ -129,8 +131,10 @@ try {
                 instance_destroy();
             }
             with (obj_en_fleet) {
-                x += 10000;
-                y += 10000;
+                if (!in_room()) {
+                    x += FLEET_BATTLE_DISPLACEMENT;
+                    y += FLEET_BATTLE_DISPLACEMENT;
+                }
             }
         }
     }

--- a/objects/obj_turn_end/Create_0.gml
+++ b/objects/obj_turn_end/Create_0.gml
@@ -1,6 +1,7 @@
 instance_deactivate_object(obj_star_select);
 instance_deactivate_object(obj_drop_select);
 instance_deactivate_object(obj_bomb_select);
+recalculate_fleet_presence();
 
 keywords = "";
 last_open = 1;

--- a/scripts/macros/macros.gml
+++ b/scripts/macros/macros.gml
@@ -18,6 +18,9 @@
 // Ground combat message log: per-stage frame timeout before force-advancing.
 #macro COMBAT_STAGE_TIMEOUT_FRAMES 1200
 
+// Offmap shove distance for non-combatant fleets during battle resolution; must exceed room size so they read as !in_room().
+#macro FLEET_BATTLE_DISPLACEMENT 100000
+
 #macro STR_ANY_POWER_ARMOUR "Any Power Armour"
 #macro STR_ANY_TERMINATOR_ARMOUR "Any Terminator Armour"
 

--- a/scripts/scr_fleet_functions/scr_fleet_functions.gml
+++ b/scripts/scr_fleet_functions/scr_fleet_functions.gml
@@ -1359,6 +1359,26 @@ function fleet_unregister_from_star(_fleet) {
     _fleet.orbiting = noone;
 }
 
+/// @desc Rebuilds every star's present_fleet counters from current fleet positions.
+///       Counts only stationary fleets (action == ""), fleets in warp are intentionally not counted.
+/// @returns {undefined}
+function recalculate_fleet_presence() {
+    // Zero only the faction slots; higher indices are maintained elsewhere and must survive the rebuild.
+    with (obj_star) {
+        for (var _i = 0; _i < eFACTION._COUNT; _i++) {
+            present_fleet[_i] = 0;
+        }
+    }
+
+    // Clear orbiting before re-registering: fleet_register_at_star() early-returns when orbiting already matches the target star, which would skip the increment after the zeroing above.
+    with (obj_all_fleet) {
+        orbiting = noone;
+        if (action == "") {
+            fleet_register_at_nearest_star(id);
+        }
+    }
+}
+
 /// @desc Finds the nearest star within _max_distance and registers the fleet there.
 /// @param {Id.Instance.obj_p_fleet|Id.Instance.obj_en_fleet} _fleet  Fleet instance to register
 /// @returns {Id.Instance|noone} The star registered at, or noone if none in range

--- a/scripts/scr_load/scr_load.gml
+++ b/scripts/scr_load/scr_load.gml
@@ -120,13 +120,6 @@ function scr_load(save_part, save_id) {
                 deserialize(deserialized);
             }
         }
-
-        with (obj_p_fleet) {
-            if (action == "") {
-                fleet_register_at_nearest_star(id);
-            }
-        }
-
         LOGGER.info("PLAYER FLEET OBJECTS loaded");
     }
 
@@ -141,14 +134,10 @@ function scr_load(save_part, save_id) {
                 deserialize(deserialized);
             }
         }
-
-        with (obj_en_fleet) {
-            if (action == "") {
-                fleet_register_at_nearest_star(id);
-            }
-        }
-
         LOGGER.info("ENEMY FLEET OBJECTS loaded");
+
+        // All fleets exist now so recalculate star presence for player and enemy fleets together.
+        recalculate_fleet_presence();
 
         LOGGER.info("Loading EVENT LOG");
         if (!instance_exists(obj_event_log)) {


### PR DESCRIPTION
NPC fleets uninvolved in a space battle (e.g: Inquisitors, Orks, Tau, etc) sometimes silently vanished whenever any space battle resolved. This was due to two bugs interacting: battle resolution sometimes stranded bystander fleets off-map, and an operator-precedence bug then destroyed them. Resolving the two among other things means Tau fleets work again.

## Changes

- Battle resolution in `obj_fleet\Alarm_7` parks non-participant fleets offmap but only restored those past −7000 on both axes, permanently stranding any fleet beyond (3000, 3000). It now uses an `in_room()` boolean check and a standard `FLEET_BATTLE_DISPLACEMENT` macro large enough so that any fleets meant to spawn offmap (i.e the broken hive fleets) could never accidentally get put in map.
    - Also fixes minor thing in the inquisitor kill branch by adding a condition to the unguarded restore. In theory having no guard should not be a problem but there is also zero cost to adding the condition check just in case.
- Fix operator precedence in the Tau offmap cleanup `obj_en_fleet\Step` the `y < 0` check applied to every faction, and would delete the stranded fleets.
    - To note I do not think this check is needed at all but I left the fixed version around just in case.
- Add a fail loud collector: stationary fleets leaked off-map (e.g. by an exception between a coordinate displacement and its restore) are logged via `LOGGER.error` and destroyed instead of lingering invisibly. In-transit fleets are exempt.
    - In case any more issues with fleets getting stuck off map happen this will make debugging easier.
- Add `recalculate_fleet_presence()` and run it at end-turn start and post-battle, so `present_fleet` counters can no longer drift from actual fleets. Prevents phantom fleet bugs from occurring.
- Refactor `scr_load` to use `recalculate_fleet_presence()`, avoids creating duplicated logic. Also centralizes the fleet presence calculations and fleet star registrations to run only once after both player and enemy fleets have loaded.

## Testing

- Played through space battles and most space interactions (I could reliably get to happen), including the Tau ones. Everything functions normally and the fleet vanishing act no longer reproduces as far as I could observe.
- Tested for phantom fleets by altering the code to force every space battle to replicate the error and `recalculate_fleet_presence()` would still prevent phantom fleets from popping up.
- Saved and loaded: loading works fine and restores fleets/orbits as normal.

### Note

- I did not run any performance testing but I also did not notice anything running slower so if there is a regression in performance it is negligible, probably.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes space battle handling that stranded or deleted non-participant NPC fleets, and stops phantom fleets by rebuilding presence counters after battles and at turn start.

- **Bug Fixes**
  - Displace non-combatant fleets off-map with FLEET_BATTLE_DISPLACEMENT and restore via an in-room check; removes the -7000/-7000 edge case. Also guards the Inquisition restore path.
  - Correct Tau off-map cleanup operator precedence so deletion applies only to Tau and only when truly off-map.
  - Add a fail-loud cleanup: log and destroy stationary fleets found off-map; fleets in transit are ignored.

- **Refactors**
  - Add recalculate_fleet_presence() and call it after space battles, at turn start, and after loading to keep present_fleet accurate.
  - Replace per-fleet post-load registration with a single presence rebuild once all fleets are loaded.
  - Introduce FLEET_BATTLE_DISPLACEMENT macro for consistent off-map displacement.

<sup>Written for commit b62e6754306d2544c9c0c27be6eb8841266a29a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

