### PR TITLE
feat: Quality flags and full override capabilities

### DIFF
--- a/scripts/macros/macros.gml
+++ b/scripts/macros/macros.gml
@@ -27,6 +27,8 @@
 
 #macro UNIT_EQUIP_SLOTS_DISPLAY [ "First Weapon", "Second Weapon", "Armour", "Gear", "Back/Mobility", "ALL"]
 
+#macro EQUIPMENT_QUALITITES ["shoddy", "standard", "master_crafted", "artifact"]
+
 // Basic, because we don't include Artificer Armour
 global.list_basic_power_armour = ["MK7 Aquila", "MK6 Corvus", "MK5 Heresy", "MK8 Errant", "MK4 Maximus", "MK3 Iron Armour","Power Armour"];
 global.list_terminator_armour = ["Terminator Armour", "Tartaros","Cataphractii"];

--- a/scripts/macros/macros.gml
+++ b/scripts/macros/macros.gml
@@ -27,7 +27,7 @@
 
 #macro UNIT_EQUIP_SLOTS_DISPLAY [ "First Weapon", "Second Weapon", "Armour", "Gear", "Back/Mobility", "ALL"]
 
-#macro EQUIPMENT_QUALITITES ["shoddy", "standard", "master_crafted", "artifact"]
+#macro EQUIPMENT_QUALITIES ["shoddy", "standard", "master_crafted", "artifact"]
 
 // Basic, because we don't include Artificer Armour
 global.list_basic_power_armour = ["MK7 Aquila", "MK6 Corvus", "MK5 Heresy", "MK8 Errant", "MK4 Maximus", "MK3 Iron Armour","Power Armour"];

--- a/scripts/scr_ComplexSet/scr_ComplexSet.gml
+++ b/scripts/scr_ComplexSet/scr_ComplexSet.gml
@@ -99,7 +99,7 @@ function ComplexSet(_unit) constructor {
     unit = _unit;
     draw_helms = instance_exists(obj_creation) ? obj_creation.draw_helms : obj_controller.draw_helms;
 
-    //unit_equipment_data = unit.unit_equipment_data();
+    equipment_data = unit.unit_equipment_data();
 
     current_texture_draws = {};
     _has_exceptions = false;
@@ -519,6 +519,7 @@ function ComplexSet(_unit) constructor {
                 }
             }
         }
+
 
         if (struct_exists(_mod, "equipment_has_tag")) {
             var _viable = false;

--- a/scripts/scr_ComplexSet/scr_ComplexSet.gml
+++ b/scripts/scr_ComplexSet/scr_ComplexSet.gml
@@ -525,7 +525,7 @@ function ComplexSet(_unit) constructor {
                 var _area = _tag_check_areas[i];
 
                 if (!array_contains(equipment_data.present_items, _area)){
-                    break;
+                    continue;
                 }
 
                 var _item = equipment_data.get_item(_area);

--- a/scripts/scr_ComplexSet/scr_ComplexSet.gml
+++ b/scripts/scr_ComplexSet/scr_ComplexSet.gml
@@ -976,9 +976,10 @@ function ComplexSet(_unit) constructor {
                     var _sprite = _final_component.sprite;
                     if (_sub_choice_final >= _choice_count && _sub_choice_final < _choice_count + sprite_get_number(_sprite)) {
                         var _final_index = _sub_choice_final - _choice_count ?? 0;
-                        if (struct_exists(_final_component, "shadows")){
-                            set_draw_shadows(_sprite, _final_index,_final_component.shadows, _final_index);
+                        if (struct_exists(_final_component, "shadows")) {
+                            set_draw_shadows(_sprite, _final_index, _final_component.shadows, _final_index);
                         }
+                        shader_set_uniform_i(use_shadow_uniform, shadow_enabled);
                         if (flip_x) {
                             draw_sprite_flipped(_sprite, _sub_choice_final - _choice_count ?? 0, component_final_draw_x, component_final_draw_y);
                         } else {

--- a/scripts/scr_ComplexSet/scr_ComplexSet.gml
+++ b/scripts/scr_ComplexSet/scr_ComplexSet.gml
@@ -744,7 +744,7 @@ function ComplexSet(_unit) constructor {
 
     /// @param {Array<Struct>} modulars
     /// @param {String} position
-    static assign_modulars = function(modulars = global.modular_drawing_items, position = "") {
+    static assign_modulars = function(modulars = global.modular_drawing_items, position = "", replace_by_default = false) {
         try {
             for (var i = 0; i < array_length(modulars); i++) {
                 _sub_comps = "none";
@@ -768,7 +768,12 @@ function ComplexSet(_unit) constructor {
                             array_push(left_arm_data, _mod.weapon_data);
                         }
                     } else {
-                        add_to_area(_mod.position, _mod.sprite, _overides, _sub_comps, _shadows);
+                        if (replace_by_default){
+                            replace_area(_mod.position, _mod.sprite, _overides, _sub_comps, _shadows);
+                        } else {
+                            add_to_area(_mod.position, _mod.sprite, _overides, _sub_comps, _shadows);
+                        }
+                        
                     }
                 }
                 if (struct_exists(_mod, "prevent_others")) {
@@ -791,28 +796,34 @@ function ComplexSet(_unit) constructor {
     /// @param {String} component_name
     /// @param {Real} choice
     static check_component_overides = function(component_name, choice) {
-        if (struct_exists(overides, component_name)) {
-            var _overide_set = overides[$ component_name];
-            for (var i = 0; i < array_length(_overide_set); i++) {
-                var _spec_over = _overide_set[i];
-                if (_spec_over[0] <= choice && _spec_over[1] > choice) {
-                    var _override_data = _spec_over[2];
-                    if (struct_exists(_override_data, "overides")) {
-                        _override_areas = struct_get_names(_override_data.overides);
-                        var _overs = _override_data.overides;
-                        for (var j = 0; j < array_length(_override_areas); j++) {
-                            replace_area(_override_areas[j], _overs[$ _override_areas[j]]);
-                        }
+        if (!struct_exists(overides, component_name)) {
+            return false;
+        }
+
+        var _overide_set = overides[$ component_name];
+        for (var i = 0; i < array_length(_overide_set); i++) {
+            var _spec_over = _overide_set[i];
+            if (_spec_over[0] <= choice && _spec_over[1] > choice) {
+                var _override_data = _spec_over[2];
+                if (struct_exists(_override_data, "overides")) {
+                    _override_areas = struct_get_names(_override_data.overides);
+                    var _overs = _override_data.overides;
+                    for (var j = 0; j < array_length(_override_areas); j++) {
+                        var _area = _override_areas[j]
+                        var _override_packet = _overs[$ _area];
+                        _override_packet = is_struct(_override_packet) ? _override_packet : {sprite : _override_packet};
+                        assign_modulars([_override_packet], _area, true);
                     }
-                    if (struct_exists(_override_data, "offsets")) {
-                        var _offsets = _override_data.offsets;
-                        component_final_draw_x += _offsets[0];
-                        component_final_draw_y += _offsets[1];
-                    }
-                    break;
                 }
+                if (struct_exists(_override_data, "offsets")) {
+                    var _offsets = _override_data.offsets;
+                    component_final_draw_x += _offsets[0];
+                    component_final_draw_y += _offsets[1];
+                }
+                break;
             }
         }
+  
     };
 
     /// @desc Resolves a global frame choice for an area into (source_sprite, local_frame)

--- a/scripts/scr_ComplexSet/scr_ComplexSet.gml
+++ b/scripts/scr_ComplexSet/scr_ComplexSet.gml
@@ -96,11 +96,10 @@ function ComplexSet(_unit) constructor {
     overides = {};
     subcomponents = {};
     unit_armour = _unit.armour();
-    unit = _unit;
+    draw_unit = _unit;
     draw_helms = instance_exists(obj_creation) ? obj_creation.draw_helms : obj_controller.draw_helms;
 
-    equipment_data = unit.unit_equipment_data();
-
+    equipment_data = draw_unit.unit_equipment_data();
     current_texture_draws = {};
     _has_exceptions = false;
     exceptions = [];
@@ -136,54 +135,54 @@ function ComplexSet(_unit) constructor {
     blocked = [];
     banned = [];
     variation_map = {
-        backpack: unit.get_body_data("backpack_variation", "torso"),
-        armour: unit.get_body_data("armour_choice", "torso"),
-        chest_variants: unit.get_body_data("chest_variation", "torso"),
-        thorax_variants: unit.get_body_data("thorax_variation", "torso"),
-        leg_variants: unit.get_body_data("leg_variants", "left_leg"),
-        left_leg: unit.get_body_data("leg_variants", "left_leg"),
-        right_leg: unit.get_body_data("leg_variants", "right_leg"),
-        left_shin: unit.get_body_data("shin_variant", "left_leg"),
-        right_shin: unit.get_body_data("shin_variant", "right_leg"),
-        left_knee: unit.get_body_data("knee_variant", "left_leg"),
-        right_knee: unit.get_body_data("knee_variant", "right_leg"),
-        left_trim: unit.get_body_data("trim_variation", "left_arm"),
-        right_trim: unit.get_body_data("trim_variation", "right_arm"),
-        left_arm: unit.get_body_data("variation", "left_arm"),
-        right_arm: unit.get_body_data("variation", "right_arm"),
-        gorget: unit.get_body_data("variant", "throat"),
-        right_pauldron_icons: unit.get_body_data("pad_variation", "right_arm"),
-        left_pauldron_icons: unit.get_body_data("pad_variation", "left_arm"),
-        right_pauldron_base: unit.get_body_data("pad_variation", "right_arm"),
-        left_pauldron_base: unit.get_body_data("pad_variation", "left_arm"),
-        right_pauldron_embeleshments: unit.get_body_data("pad_variation", "right_arm"),
-        left_pauldron_embeleshments: unit.get_body_data("pad_variation", "left_arm"),
-        right_pauldron_hangings: unit.get_body_data("pad_variation", "right_arm"),
-        left_pauldron_hangings: unit.get_body_data("pad_variation", "left_arm"),
-        left_personal_livery: unit.get_body_data("personal_livery", "left_arm"),
-        tabbard: unit.get_body_data("tabbard_variation", "torso"),
-        robe: unit.get_body_data("tabbard_variation", "torso"),
-        crest: unit.get_body_data("crest_variation", "head"),
-        head: unit.get_body_data("variation", "head"),
-        bare_head: unit.get_body_data("variation", "head"),
-        bare_neck: unit.get_body_data("variation", "head"),
-        bare_eyes: unit.get_body_data("variation", "head"),
-        mouth_variants: unit.get_body_data("variant", "jaw"),
-        left_eye: unit.get_body_data("variant", "left_eye"),
-        right_eye: unit.get_body_data("variant", "right_eye"),
-        crown: unit.get_body_data("crown_variation", "head"),
-        forehead: unit.get_body_data("forehead_variation", "head"),
-        backpack_decoration: unit.get_body_data("backpack_decoration_variation", "torso"),
-        belt: unit.get_body_data("belt_variation", "torso"),
-        cloak: unit.get_body_data("variant", "cloak"),
-        cloak_image: unit.get_body_data("image_0", "cloak"),
-        cloak_trim: unit.get_body_data("image_1", "cloak"),
-        backpack_augment: unit.get_body_data("backpack_augment_variation", "torso"),
-        chest_fastening: unit.get_body_data("chest_fastening", "torso"),
-        left_weapon: unit.get_body_data("weapon_variation", "left_arm"),
-        right_weapon: unit.get_body_data("weapon_variation", "right_arm"),
-        necklace: unit.get_body_data("hanging_variant", "throat"),
-        foreground_item: unit.get_body_data("variant", "throat"),
+        backpack: draw_unit.get_body_data("backpack_variation", "torso"),
+        armour: draw_unit.get_body_data("armour_choice", "torso"),
+        chest_variants: draw_unit.get_body_data("chest_variation", "torso"),
+        thorax_variants: draw_unit.get_body_data("thorax_variation", "torso"),
+        leg_variants: draw_unit.get_body_data("leg_variants", "left_leg"),
+        left_leg: draw_unit.get_body_data("leg_variants", "left_leg"),
+        right_leg: draw_unit.get_body_data("leg_variants", "right_leg"),
+        left_shin: draw_unit.get_body_data("shin_variant", "left_leg"),
+        right_shin: draw_unit.get_body_data("shin_variant", "right_leg"),
+        left_knee: draw_unit.get_body_data("knee_variant", "left_leg"),
+        right_knee: draw_unit.get_body_data("knee_variant", "right_leg"),
+        left_trim: draw_unit.get_body_data("trim_variation", "left_arm"),
+        right_trim: draw_unit.get_body_data("trim_variation", "right_arm"),
+        left_arm: draw_unit.get_body_data("variation", "left_arm"),
+        right_arm: draw_unit.get_body_data("variation", "right_arm"),
+        gorget: draw_unit.get_body_data("variant", "throat"),
+        right_pauldron_icons: draw_unit.get_body_data("pad_variation", "right_arm"),
+        left_pauldron_icons: draw_unit.get_body_data("pad_variation", "left_arm"),
+        right_pauldron_base: draw_unit.get_body_data("pad_variation", "right_arm"),
+        left_pauldron_base: draw_unit.get_body_data("pad_variation", "left_arm"),
+        right_pauldron_embeleshments: draw_unit.get_body_data("pad_variation", "right_arm"),
+        left_pauldron_embeleshments: draw_unit.get_body_data("pad_variation", "left_arm"),
+        right_pauldron_hangings: draw_unit.get_body_data("pad_variation", "right_arm"),
+        left_pauldron_hangings: draw_unit.get_body_data("pad_variation", "left_arm"),
+        left_personal_livery: draw_unit.get_body_data("personal_livery", "left_arm"),
+        tabbard: draw_unit.get_body_data("tabbard_variation", "torso"),
+        robe: draw_unit.get_body_data("tabbard_variation", "torso"),
+        crest: draw_unit.get_body_data("crest_variation", "head"),
+        head: draw_unit.get_body_data("variation", "head"),
+        bare_head: draw_unit.get_body_data("variation", "head"),
+        bare_neck: draw_unit.get_body_data("variation", "head"),
+        bare_eyes: draw_unit.get_body_data("variation", "head"),
+        mouth_variants: draw_unit.get_body_data("variant", "jaw"),
+        left_eye: draw_unit.get_body_data("variant", "left_eye"),
+        right_eye: draw_unit.get_body_data("variant", "right_eye"),
+        crown: draw_unit.get_body_data("crown_variation", "head"),
+        forehead: draw_unit.get_body_data("forehead_variation", "head"),
+        backpack_decoration: draw_unit.get_body_data("backpack_decoration_variation", "torso"),
+        belt: draw_unit.get_body_data("belt_variation", "torso"),
+        cloak: draw_unit.get_body_data("variant", "cloak"),
+        cloak_image: draw_unit.get_body_data("image_0", "cloak"),
+        cloak_trim: draw_unit.get_body_data("image_1", "cloak"),
+        backpack_augment: draw_unit.get_body_data("backpack_augment_variation", "torso"),
+        chest_fastening: draw_unit.get_body_data("chest_fastening", "torso"),
+        left_weapon: draw_unit.get_body_data("weapon_variation", "left_arm"),
+        right_weapon: draw_unit.get_body_data("weapon_variation", "right_arm"),
+        necklace: draw_unit.get_body_data("hanging_variant", "throat"),
+        foreground_item: draw_unit.get_body_data("variant", "throat"),
     };
 
     component_final_draw_x = 0;
@@ -212,9 +211,9 @@ function ComplexSet(_unit) constructor {
 
     base_armour();
 
-    if (unit.IsSpecialist(SPECIALISTS_TECHS)) {
+    if (draw_unit.IsSpecialist(SPECIALISTS_TECHS)) {
         if (array_contains(["MK5 Heresy", "MK6 Corvus", "MK7 Aquila", "MK8 Errant", "Artificer Armour"], unit_armour)) {
-            if (unit.has_trait("tinkerer")) {
+            if (draw_unit.has_trait("tinkerer")) {
                 add_group({"armour": spr_techmarine_complex});
             }
         }
@@ -364,7 +363,7 @@ function ComplexSet(_unit) constructor {
             var _min = 0;
             if (struct_exists(_exp_data, "min")) {
                 _min = _exp_data.min;
-                if (unit.experience < _exp_data.min) {
+                if (draw_unit.experience < _exp_data.min) {
                     if (!check_exception("min_exp")) {
                         return false;
                     }
@@ -375,7 +374,7 @@ function ComplexSet(_unit) constructor {
                 var _increment_count = max(1, floor(_mod.max_saturation / 5));
                 var _increments = (_m_exp - _min) / _increment_count;
                 var _sat_roof = _mod.max_saturation;
-                var _unit_exp = unit.experience;
+                var _unit_exp = draw_unit.experience;
 
                 if (_unit_exp >= _m_exp) {
                     spawn_chance = _mod.max_saturation;
@@ -413,7 +412,7 @@ function ComplexSet(_unit) constructor {
             var _viable = false;
             for (var a = 0; a < array_length(_mod.role_type); a++) {
                 var _r_t = _mod.role_type[a];
-                _viable = unit.IsSpecialist(_r_t);
+                _viable = draw_unit.IsSpecialist(_r_t);
                 if (_viable) {
                     break;
                 }
@@ -425,7 +424,7 @@ function ComplexSet(_unit) constructor {
             }
         }
         if (struct_exists(_mod, "roles")) {
-            if (!array_contains(_mod.roles, unit.role())) {
+            if (!array_contains(_mod.roles, draw_unit.role())) {
                 if (!check_exception("roles")) {
                     return false;
                 }
@@ -439,12 +438,13 @@ function ComplexSet(_unit) constructor {
             }
         }
         if (struct_exists(_mod, "company")) {
-            if (!array_contains(_mod.company, unit.company)) {
+            if (!array_contains(_mod.company, draw_unit.company)) {
                 if (!check_exception("company")) {
                     return false;
                 }
             }
         }
+
         if (struct_exists(_mod, "armours")) {
             if (!array_contains(_mod.armours, unit_armour)) {
                 if (!check_exception("armours")) {
@@ -490,14 +490,14 @@ function ComplexSet(_unit) constructor {
             }
         }
         if (struct_exists(_mod, "stats")) {
-            if (!stat_valuator(_mod.stats, unit)) {
+            if (!stat_valuator(_mod.stats, draw_unit)) {
                 if (!check_exception("stats")) {
                     return false;
                 }
             }
         }
         if (struct_exists(_mod, "equipped")) {
-            if (!unit.has_equipped(_mod.equipped)) {
+            if (!draw_unit.has_equipped(_mod.equipped)) {
                 if (!check_exception("equipped")) {
                     return false;
                 }
@@ -508,7 +508,7 @@ function ComplexSet(_unit) constructor {
             var _viable = false;
             for (var a = 0; a < array_length(_mod.traits); a++) {
                 var _trait = _mod.traits[a];
-                _viable = unit.has_trait(_trait);
+                _viable = draw_unit.has_trait(_trait);
                 if (_viable) {
                     break;
                 }
@@ -526,8 +526,17 @@ function ComplexSet(_unit) constructor {
             var _tag_check_areas = struct_get_names(_mod.equipment_has_tag);
             for (var i = 0; i < array_length(_tag_check_areas); i++) {
                 var _area = _tag_check_areas[i];
+
+                if (!array_contains(equipment_data.present_items, _area)){
+                    break;
+                }
+
+                var _item = equipment_data.get_item(_area);
+                
                 var _tag = _mod.equipment_has_tag[$ _area];
-                _viable = unit.equipment_has_tag(_tag, _area);
+
+                _viable = _item.has_tag(_tag)
+
                 if (_viable) {
                     break;
                 }
@@ -538,19 +547,59 @@ function ComplexSet(_unit) constructor {
                 }
             }
         }
-        /*if (struct_exists(_mod, "equipment_has_rarity")){
-            var _rarities = _mod.equipment_has_rarity
-            var _items = struct_get_names(_rarities);
-            for (var i = 0; i < array_length(_items); i++){
-                switch ()
-                {
-                    case :
-                        
-                    default:
-                        break;
+
+        if (struct_exists(_mod, "min_quality")) {
+            var _viable = false;
+            var _quality_check_areas = struct_get_names(_mod.min_quality);
+            for (var i = 0; i < array_length(_quality_check_areas); i++) {
+                var _area = _quality_check_areas[i];
+                if (!array_contains(equipment_data.present_items, _area)) {
+                    break;
+                }
+                var _item = equipment_data.get_item(_area);
+
+                var _required_quality = _mod.min_quality[$ _area];
+                var _required_index = array_get_index(EQUIPMENT_QUALITITES, _required_quality);
+                var _item_index = array_get_index(EQUIPMENT_QUALITITES, _item.quality);
+
+                _viable = (_item_index >= _required_index);
+                if (_viable) {
+                    break;
                 }
             }
-        }*/
+            if (!_viable) {
+                if (!check_exception("min_quality")) {
+                    return false;
+                }
+            }
+        }
+
+        if (struct_exists(_mod, "max_quality")) {
+            var _viable = false;
+            var _quality_check_areas = struct_get_names(_mod.max_quality);
+            for (var i = 0; i < array_length(_quality_check_areas); i++) {
+                var _area = _quality_check_areas[i];
+                if (!array_contains(equipment_data.present_items, _area)) {
+                    break;
+                }
+                var _item = equipment_data.get_item(_area);
+
+                var _required_quality = _mod.max_quality[$ _area];
+                var _required_index = array_get_index(EQUIPMENT_QUALITITES, _required_quality);
+                var _item_index = array_get_index(EQUIPMENT_QUALITITES, _item.quality);
+
+                _viable = (_item_index <= _required_index);
+                if (_viable) {
+                    break;
+                }
+            }
+            if (!_viable) {
+                if (!check_exception("max_quality")) {
+                    return false;
+                }
+            }
+        }
+
         if (struct_exists(_mod, "chapter")) {
             var chap_name = instance_exists(obj_creation) ? obj_creation.chapter_name : global.chapter_name;
             if (chap_name != _mod.chapter) {
@@ -608,7 +657,7 @@ function ComplexSet(_unit) constructor {
             var _body_areas = struct_get_names(_mod.body_parts);
             for (var b = 0; b < array_length(_body_areas); b++) {
                 var _area = _body_areas[b];
-                if (!struct_exists(unit.body[$ _area], _mod.body_parts[$ _area])) {
+                if (!struct_exists(draw_unit.body[$ _area], _mod.body_parts[$ _area])) {
                     _viable = false;
                     break;
                 }
@@ -677,7 +726,7 @@ function ComplexSet(_unit) constructor {
             if (_unit_tier == 8) {
                 for (var t = 0; t < array_length(tiers); t++) {
                     var tier = tiers[t];
-                    if (array_contains(tier, unit.role())) {
+                    if (array_contains(tier, draw_unit.role())) {
                         _unit_tier = t;
                     }
                 }
@@ -712,10 +761,10 @@ function ComplexSet(_unit) constructor {
                 if (_mod.position != "") {
                     if (_mod.position == "weapon") {
                         var _weapon_map = _mod.weapon_map;
-                        if (unit.weapon_one() == _weapon_map) {
+                        if (draw_unit.weapon_one() == _weapon_map) {
                             array_push(right_arm_data, _mod.weapon_data);
                         }
-                        if (unit.weapon_two() == _weapon_map) {
+                        if (draw_unit.weapon_two() == _weapon_map) {
                             array_push(left_arm_data, _mod.weapon_data);
                         }
                     } else {
@@ -1055,7 +1104,7 @@ function ComplexSet(_unit) constructor {
                 }
 
                 var _arm_string = _right_left == 0 ? "right_arm" : "left_arm";
-                var _bionic_arm = unit.get_body_data("bionic", _arm_string);
+                var _bionic_arm = draw_unit.get_body_data("bionic", _arm_string);
                 var _bio = [];
                 if (eARMOUR_TYPE.TERMINATOR == armour_type) {
                     if (_variant == 2) {
@@ -1276,7 +1325,7 @@ function ComplexSet(_unit) constructor {
         var prep_surface = surface_create(600, 600);
         surface_set_target(prep_surface);
 
-        var _texture_draws = setup_complex_livery_shader(unit.role(), unit);
+        var _texture_draws = setup_complex_livery_shader(draw_unit.role(), draw_unit);
 
         draw_cloaks();
 
@@ -1297,7 +1346,7 @@ function ComplexSet(_unit) constructor {
         ];
         for (var i = 0; i <= 1; i++) {
             var _arm = arms_data[i];
-            var _wep = i == 0 ? unit.weapon_one() : unit.weapon_two();
+            var _wep = i == 0 ? draw_unit.weapon_one() : draw_unit.weapon_two();
             if (struct_exists(_arm, "display_type")) {
                 if (struct_exists(weapon_preset_data, _arm.display_type)) {
                     var _preset = weapon_preset_data[$ _arm.display_type];
@@ -1367,7 +1416,7 @@ function ComplexSet(_unit) constructor {
         }
         draw_unit_arms(_texture_draws);
         var _complex_helm = false;
-        var _unit_role = unit.role();
+        var _unit_role = draw_unit.role();
         var _role = active_roles();
         var _comp_helms = instance_exists(obj_creation) ? obj_creation.complex_livery_data : obj_ini.complex_livery_data;
         if (_unit_role == _role[eROLE.SERGEANT]) {
@@ -1376,7 +1425,7 @@ function ComplexSet(_unit) constructor {
             _complex_helm = _comp_helms.vet_sgt;
         } else if (_unit_role == _role[eROLE.CAPTAIN]) {
             _complex_helm = _comp_helms.captain;
-        } else if (_unit_role == _role[eROLE.VETERAN] || (_unit_role == _role[eROLE.TERMINATOR] && unit.company == 1)) {
+        } else if (_unit_role == _role[eROLE.VETERAN] || (_unit_role == _role[eROLE.TERMINATOR] && draw_unit.company == 1)) {
             _complex_helm = _comp_helms.veteran;
         } else if (struct_exists(_comp_helms, "all_others")) {
             // there's probably room to improve this but consecrators demand the stripe
@@ -1489,9 +1538,9 @@ function ComplexSet(_unit) constructor {
         //TODO imprvoe this logic to be more extendable
 
         if (armour_type == eARMOUR_TYPE.NORMAL || armour_type == eARMOUR_TYPE.TERMINATOR) {
-            var _body = unit.body;
+            var _body = draw_unit.body;
             var _torso_data = _body[$ "torso"];
-            var _exp = unit.experience;
+            var _exp = draw_unit.experience;
             var _x_offset = x_surface_offset + (armour_type == eARMOUR_TYPE.NORMAL ? 0 : -7);
             var _y_offset = y_surface_offset + (armour_type == eARMOUR_TYPE.NORMAL ? 0 : -38);
             if (struct_exists(_torso_data, "purity_seal")) {
@@ -1681,7 +1730,7 @@ function ComplexSet(_unit) constructor {
                 add_group(mk7_bits);
                 break;
         }
-        var type = unit.get_body_data("type", "cloak");
+        var type = draw_unit.get_body_data("type", "cloak");
         if (type != "none" && armour_type != eARMOUR_TYPE.SCOUT) {
             static _cloaks = {
                 "scale": spr_cloak_scale,
@@ -1695,12 +1744,12 @@ function ComplexSet(_unit) constructor {
             }
         }
         assign_modulars();
-        var wep_opts = format_weapon_visuals(unit.weapon_one());
+        var wep_opts = format_weapon_visuals(draw_unit.weapon_one());
         if (array_length(wep_opts)) {
             assign_modulars(wep_opts, "weapon");
         }
-        if (unit.weapon_one() != unit.weapon_two()) {
-            var wep_opts = format_weapon_visuals(unit.weapon_two());
+        if (draw_unit.weapon_one() != draw_unit.weapon_two()) {
+            var wep_opts = format_weapon_visuals(draw_unit.weapon_two());
             if (array_length(wep_opts)) {
                 assign_modulars(wep_opts, "weapon");
             }

--- a/scripts/scr_ComplexSet/scr_ComplexSet.gml
+++ b/scripts/scr_ComplexSet/scr_ComplexSet.gml
@@ -209,16 +209,6 @@ function ComplexSet(_unit) constructor {
         global.base_component_surface = surface_create(600, 600);
     }
 
-    base_armour();
-
-    if (draw_unit.IsSpecialist(SPECIALISTS_TECHS)) {
-        if (array_contains(["MK5 Heresy", "MK6 Corvus", "MK7 Aquila", "MK8 Errant", "Artificer Armour"], unit_armour)) {
-            if (draw_unit.has_trait("tinkerer")) {
-                add_group({"armour": spr_techmarine_complex});
-            }
-        }
-    }
-
     static mk7_bits = {
         armour: spr_mk7_complex,
         left_trim: spr_mk7_left_trim,
@@ -347,16 +337,23 @@ function ComplexSet(_unit) constructor {
         var _mod = mod_item;
         exceptions = [];
 
-        if (array_contains(blocked, _mod.position)) {
-            return false;
+        if (struct_exists(_mod, "position")) {
+            if (array_contains(blocked, _mod.position)) {
+                return false;
+            }
+        } else {
+            _mod.position = "";
         }
 
         if (struct_exists(_mod, "allow_either")) {
             _has_exceptions = true;
             exceptions = variable_clone(_mod.allow_either);
         }
-        if (struct_exists(_mod, "max_saturation")) {
-            var _max_sat = _mod.max_saturation;
+		var _max_sat = 100;
+        var _control_max_sat = struct_exists(_mod, "max_saturation");
+
+        if (_control_max_sat) {
+            _max_sat = _mod.max_saturation;
         }
         if (struct_exists(_mod, "exp")) {
             var _exp_data = _mod.exp;
@@ -385,7 +382,7 @@ function ComplexSet(_unit) constructor {
                 }
             }
         }
-        if (struct_exists(_mod, "max_saturation")) {
+        if (_control_max_sat) {
             if (struct_exists(variation_map, _mod.position)) {
                 if (variation_map[$ _mod.position] >= _max_sat) {
                     if (!check_exception("max_saturation")) {
@@ -548,7 +545,10 @@ function ComplexSet(_unit) constructor {
             }
         }
 
-        if (struct_exists(_mod, "min_quality")) {
+        var _is_weapon = _mod.position == "weapon";
+
+        var _is_weapon = false;
+        if (!_is_weapon && struct_exists(_mod, "min_quality")) {
             var _viable = false;
             var _quality_check_areas = struct_get_names(_mod.min_quality);
             for (var i = 0; i < array_length(_quality_check_areas); i++) {
@@ -558,11 +558,7 @@ function ComplexSet(_unit) constructor {
                 }
                 var _item = equipment_data.get_item(_area);
 
-                var _required_quality = _mod.min_quality[$ _area];
-                var _required_index = array_get_index(EQUIPMENT_QUALITITES, _required_quality);
-                var _item_index = array_get_index(EQUIPMENT_QUALITITES, _item.quality);
-
-                _viable = (_item_index >= _required_index);
+                _viable = compare_qualities(_item.quality, _mod.min_quality[$ _area], "more");
                 if (_viable) {
                     break;
                 }
@@ -574,7 +570,7 @@ function ComplexSet(_unit) constructor {
             }
         }
 
-        if (struct_exists(_mod, "max_quality")) {
+        if (!_is_weapon && struct_exists(_mod, "max_quality")) {
             var _viable = false;
             var _quality_check_areas = struct_get_names(_mod.max_quality);
             for (var i = 0; i < array_length(_quality_check_areas); i++) {
@@ -584,11 +580,7 @@ function ComplexSet(_unit) constructor {
                 }
                 var _item = equipment_data.get_item(_area);
 
-                var _required_quality = _mod.max_quality[$ _area];
-                var _required_index = array_get_index(EQUIPMENT_QUALITITES, _required_quality);
-                var _item_index = array_get_index(EQUIPMENT_QUALITITES, _item.quality);
-
-                _viable = (_item_index <= _required_index);
+                _viable = compare_qualities(_item.quality, _mod.max_quality[$ _area], "less");
                 if (_viable) {
                     break;
                 }
@@ -670,7 +662,7 @@ function ComplexSet(_unit) constructor {
         }
 
         if (struct_exists(_mod, "prevent_others")) {
-            replace_area(_mod.position, _mod.sprite, _overides, _sub_comps);
+            replace_area(_mod.position, _mod.sprite, _overides, _sub_comps, _shadows);
             array_push(blocked, _mod.position);
             if (struct_exists(_mod, "ban")) {
                 for (var b = 0; b < array_length(_mod.ban); b++) {
@@ -761,10 +753,28 @@ function ComplexSet(_unit) constructor {
                 if (_mod.position != "") {
                     if (_mod.position == "weapon") {
                         var _weapon_map = _mod.weapon_map;
-                        if (draw_unit.weapon_one() == _weapon_map) {
+                        var _weapon_one = equipment_data.get_item("wep1");
+                        var _weapon_two = equipment_data.get_item("wep2");
+
+                        var _quality_ok = function(_item, _mod) {
+                            if (struct_exists(_mod, "min_quality")) {
+                                if (!compare_qualities(_item.quality, _mod.min_quality, "more")) {
+                                    return false;
+                                }
+                            }
+                            if (struct_exists(_mod, "max_quality")) {
+                                if (!compare_qualities(_item.quality, _mod.max_quality, "less")) {
+                                    return false;
+                                }
+                            }
+                            return true;
+                        };
+
+                        if (_weapon_one.name == _weapon_map && _quality_ok(_weapon_one, _mod)) {
                             array_push(right_arm_data, _mod.weapon_data);
                         }
-                        if (draw_unit.weapon_two() == _weapon_map) {
+
+                        if (_weapon_two.name == _weapon_map && _quality_ok(_weapon_two, _mod)) {
                             array_push(left_arm_data, _mod.weapon_data);
                         }
                     } else {
@@ -895,36 +905,39 @@ function ComplexSet(_unit) constructor {
                 if (_spec_shadow[0] <= choice && _spec_shadow[1] > choice) {
                     var _shadow_item = _spec_shadow[2];
                     var _final_shadow_index = choice - _spec_shadow[0];
-
-                    // Compute UV transform for this shadow texture
-                    if (!sprite_exists(resolved_sprite) || !sprite_exists(_shadow_item)) {
-                        exit;
-                    }
-
-                    var _shadow_transform_data = sprite_get_uvs_transformed(resolved_sprite, resolved_frame, _shadow_item, _final_shadow_index);
-
-                    if (valid_sprite_transform_data(_shadow_transform_data)) {
-                        shader_set_uniform_f_array(shadow_transform_uniform, _shadow_transform_data);
-
-                        shader_set_uniform_f_array(texture_shadow_transform_uniform, _shadow_transform_data);
-                    }
-
-                    // Bind shadow texture
-                    var _shadow_tex = sprite_get_texture(_shadow_item, _final_shadow_index);
-                    texture_set_stage(shadow_sampler, _shadow_tex);
-                    texture_set_stage(armour_shadow_sampler, _shadow_tex);
-
-                    // Trigger the draw to apply shadow (shader mixes it)
-                    //draw_sprite(_sprite, _choice ?? 0, component_final_draw_x, component_final_draw_y);
-
-                    shadow_enabled = 1;
-                    break;
+                    set_draw_shadows(resolved_sprite, resolved_frame, _shadow_item, _final_shadow_index);
+					break;
                 }
             }
         }
     };
 
-    /// @param {String} component_name
+    static set_draw_shadows = function(sprite, resolved_frame, _shadow_item, _final_shadow_index){
+        // Compute UV transform for this shadow texture
+        if (!sprite_exists(sprite) || !sprite_exists(_shadow_item)) {
+            exit;
+        }
+
+        var _shadow_transform_data = sprite_get_uvs_transformed(sprite, resolved_frame, _shadow_item, _final_shadow_index);
+
+        if (valid_sprite_transform_data(_shadow_transform_data)) {
+            shader_set_uniform_f_array(shadow_transform_uniform, _shadow_transform_data);
+
+            shader_set_uniform_f_array(texture_shadow_transform_uniform, _shadow_transform_data);
+        }
+
+        // Bind shadow texture
+        var _shadow_tex = sprite_get_texture(_shadow_item, _final_shadow_index);
+        texture_set_stage(shadow_sampler, _shadow_tex);
+        texture_set_stage(armour_shadow_sampler, _shadow_tex);
+
+        // Trigger the draw to apply shadow (shader mixes it)
+        //draw_sprite(_sprite, _choice ?? 0, component_final_draw_x, component_final_draw_y);
+
+        shadow_enabled = true;        
+    }
+
+/// @param {String} component_name
     /// @param {Real} choice
     static handle_component_subcomponents = function(component_name, choice, flip_x = false, component_map_choice = 3) {
         if (struct_exists(subcomponents, component_name)) {
@@ -938,33 +951,44 @@ function ComplexSet(_unit) constructor {
                     _component_set = _spec_over[2];
                 }
             }
-
             if (_subcomponents_found) {
-                for (var i = 0; i < array_length(_component_set); i++) {
-                    var _subcomponents = _component_set[i];
-                    var _sub_choice = (component_map_choice * 1315423911) & $7FFFFFFF;
+                evaluate_sub_components(_component_set, component_map_choice, flip_x);
+            }
+        }
+    };
 
-                    var _total_options = 0;
-                    for (var s = 0; s < array_length(_subcomponents); s++) {
-                        _total_options += sprite_get_number(_subcomponents[s]);
-                    }
+    /// @param {Array<Array>} _component_set
+    /// @param {Real} component_map_choice
+    /// @param {Bool} flip_x
+    static evaluate_sub_components = function(_component_set, component_map_choice, flip_x) {
+        for (var i = 0; i < array_length(_component_set); i++) {
+            shadow_enabled = false;
+            var _subcomponents = _component_set[i];
 
-                    if (_total_options > 0) {
-                        var _sub_choice_final = _sub_choice % _total_options;
-
-                        var _choice_count = 0;
-                        for (var s = 0; s < array_length(_subcomponents); s++) {
-                            if (_sub_choice_final >= _choice_count && _sub_choice_final < _choice_count + sprite_get_number(_subcomponents[s])) {
-                                if (flip_x) {
-                                    draw_sprite_flipped(_subcomponents[s], _sub_choice_final - _choice_count ?? 0, component_final_draw_x, component_final_draw_y);
-                                } else {
-                                    draw_sprite(_subcomponents[s], _sub_choice_final - _choice_count ?? 0, component_final_draw_x, component_final_draw_y);
-                                }
-                                break;
-                            } else {
-                                _choice_count += sprite_get_number(_subcomponents[s]);
-                            }
+            var _sub_choice = (component_map_choice * 1315423911) & $7FFFFFFF;
+            var _total_options = 0;
+            for (var s = 0; s < array_length(_subcomponents); s++) {
+                _total_options += sprite_get_number(_subcomponents[s].sprite);
+            }
+            if (_total_options > 0) {
+                var _sub_choice_final = _sub_choice % _total_options;
+                var _choice_count = 0;
+                for (var s = 0; s < array_length(_subcomponents); s++) {
+                    var _final_component = _subcomponents[s];
+                    var _sprite = _final_component.sprite;
+                    if (_sub_choice_final >= _choice_count && _sub_choice_final < _choice_count + sprite_get_number(_sprite)) {
+                        var _final_index = _sub_choice_final - _choice_count ?? 0;
+                        if (struct_exists(_final_component, "shadows")){
+                            set_draw_shadows(_sprite, _final_index,_final_component.shadows, _final_index);
                         }
+                        if (flip_x) {
+                            draw_sprite_flipped(_sprite, _sub_choice_final - _choice_count ?? 0, component_final_draw_x, component_final_draw_y);
+                        } else {
+                            draw_sprite(_sprite, _sub_choice_final - _choice_count ?? 0, component_final_draw_x, component_final_draw_y);
+                        }
+                        break;
+                    } else {
+                        _choice_count += sprite_get_number(_sprite);
                     }
                 }
             }
@@ -1055,7 +1079,7 @@ function ComplexSet(_unit) constructor {
             return;
         }
         if (struct_exists(self, component_name)) {
-            shadow_enabled = 0;
+            shadow_enabled = false;
             current_texture_draws = texture_draws;
 
             component_final_draw_x = x_surface_offset;
@@ -1136,7 +1160,7 @@ function ComplexSet(_unit) constructor {
                 }
                 if (_bionic_arm && !array_length(_bio)) {
                     if (armour_type == eARMOUR_TYPE.NORMAL) {
-                        var _bio = [
+                        _bio = [
                             spr_bionic_right_arm,
                             spr_bionic_left_arm,
                         ];
@@ -1760,12 +1784,14 @@ function ComplexSet(_unit) constructor {
             assign_modulars(wep_opts, "weapon");
         }
         if (draw_unit.weapon_one() != draw_unit.weapon_two()) {
-            var wep_opts = format_weapon_visuals(draw_unit.weapon_two());
+            wep_opts = format_weapon_visuals(draw_unit.weapon_two());
             if (array_length(wep_opts)) {
                 assign_modulars(wep_opts, "weapon");
             }
         }
     };
+
+    base_armour();
 
     static draw_cloaks = function() {
         var _shader_set_multiply_blend = function(_r, _g, _b) {
@@ -1791,64 +1817,63 @@ function ComplexSet(_unit) constructor {
     /// @param {Struct} sub_components Sub-component data for this sprite's frame range
     /// @param {Asset.GMSprite} shadow Shadow data for this sprite's frame range
     static add_to_area = function(area, add_sprite, overide_data = "none", sub_components = "none", shadow = "none") {
-        if (sprite_exists(add_sprite)) {
-            var _add_sprite_length = sprite_get_number(add_sprite);
-            if (!struct_exists(self, area)) {
-                self[$ area] = {
-                    sources: [add_sprite],
-                    offsets: [0],
-                    source_frames: [_add_sprite_length],
-                    total: _add_sprite_length,
-                };
-                var _overide_start = 0;
+        if (!sprite_exists(add_sprite)) {
+            return;
+        }
+        var _overide_start = 0;
+        var _add_sprite_length = sprite_get_number(add_sprite);
+        if (!struct_exists(self, area)) {
+            self[$ area] = {
+                sources: [add_sprite],
+                offsets: [0],
+                source_frames: [_add_sprite_length],
+                total: _add_sprite_length,
+            };
+        } else {
+            var _existing_data = self[$ area];
+            if (is_struct(_existing_data)) {
+                _overide_start = _existing_data.total;
+                array_push(_existing_data.sources, add_sprite);
+                array_push(_existing_data.offsets, _overide_start);
+                array_push(_existing_data.source_frames, _add_sprite_length);
+                _existing_data.total += _add_sprite_length;
             } else {
-                var _existing_data = self[$ area];
-                if (is_struct(_existing_data)) {
-                    var _overide_start = _existing_data.total;
-                    array_push(_existing_data.sources, add_sprite);
-                    array_push(_existing_data.offsets, _overide_start);
-                    array_push(_existing_data.source_frames, _add_sprite_length);
-                    _existing_data.total += _add_sprite_length;
+                if (sprite_exists(_existing_data)) {
+                    _overide_start = sprite_get_number(_existing_data);
+                    self[$ area] = {
+                        sources: [
+                            _existing_data,
+                            add_sprite,
+                        ],
+                        offsets: [
+                            0,
+                            _overide_start,
+                        ],
+                        source_frames: [
+                            sprite_get_number(_existing_data),
+                            _add_sprite_length,
+                        ],
+                        total: _overide_start + _add_sprite_length,
+                    };
                 } else {
-                    var _overide_start = 0;
-                    if (sprite_exists(_existing_data)) {
-                        _overide_start = sprite_get_number(_existing_data);
-                        self[$ area] = {
-                            sources: [
-                                _existing_data,
-                                add_sprite,
-                            ],
-                            offsets: [
-                                0,
-                                _overide_start,
-                            ],
-                            source_frames: [
-                                sprite_get_number(_existing_data),
-                                _add_sprite_length,
-                            ],
-                            total: _overide_start + _add_sprite_length,
-                        };
-                    } else {
-                        self[$ area] = {
-                            sources: [add_sprite],
-                            offsets: [0],
-                            source_frames: [_add_sprite_length],
-                            total: _add_sprite_length,
-                        };
-                        var _overide_start = 0;
-                    }
+                    self[$ area] = {
+                        sources: [add_sprite],
+                        offsets: [0],
+                        source_frames: [_add_sprite_length],
+                        total: _add_sprite_length,
+                    };
                 }
             }
+        }
 
-            if (overide_data != "none") {
-                add_overide(area, _overide_start, _add_sprite_length, overide_data);
-            }
-            if (sub_components != "none") {
-                add_sub_components(area, _overide_start, _add_sprite_length, sub_components);
-            }
-            if (shadow != "none" && sprite_exists(shadow)) {
-                add_shadow_set(area, _overide_start, _add_sprite_length, shadow);
-            }
+        if (overide_data != "none") {
+            add_overide(area, _overide_start, _add_sprite_length, overide_data);
+        }
+        if (sub_components != "none") {
+            add_sub_components(area, _overide_start, _add_sprite_length, sub_components);
+        }
+        if (shadow != "none" && sprite_exists(shadow)) {
+            add_shadow_set(area, _overide_start, _add_sprite_length, shadow);
         }
     };
 
@@ -1897,17 +1922,19 @@ function ComplexSet(_unit) constructor {
                 if (is_struct(_subby)) {
                     var _allow = base_modulars_checks(_subby);
                     if (_allow) {
-                        array_push(_sub_items, _subby.sprite);
+                        array_push(_sub_items, _subby);
                     }
                 } else {
-                    array_push(_sub_items, _subby);
-                }
+                    array_push(_sub_items, {sprite:_subby});
+                } 
             }
             if (array_length(_sub_items)) {
                 array_push(_accepted_subs, _sub_items);
             }
         }
-        array_push(subcomponents[$ area], [_overide_start, _overide_start + sprite_length, _accepted_subs]);
+        if (array_length(_accepted_subs)){
+            array_push(subcomponents[$ area], [_overide_start, _overide_start + sprite_length, _accepted_subs]);
+        }
     };
 
     /// @param {String} area
@@ -1917,7 +1944,7 @@ function ComplexSet(_unit) constructor {
     /// @param {Asset.GMSprite} shadow
     static replace_area = function(area, add_sprite, overide_data = "none", sub_components = "none", shadow = "none") {
         remove_area(area);
-        add_to_area(area, add_sprite, overide_data, sub_components);
+        add_to_area(area, add_sprite, overide_data, sub_components, shadow);
     };
 
     /// @param {String} area
@@ -1929,6 +1956,9 @@ function ComplexSet(_unit) constructor {
             }
             if (struct_exists(subcomponents, area)) {
                 struct_remove(subcomponents, area);
+            }
+            if (struct_exists(shadow_set, area)) {
+                struct_remove(shadow_set, area);
             }
         }
     };
@@ -1989,19 +2019,13 @@ function ComplexSet(_unit) constructor {
             x_surface_offset = 0;
             y_surface_offset = 0;
             set_complex_shader_area(["left_head", "right_head", "left_muzzle", "right_muzzle"], data.helm_primary);
-            if (instance_exists(obj_controller)) {
-                var _blend = [
-                    obj_controller.col_r[data.helm_secondary] / 255,
-                    obj_controller.col_g[data.helm_secondary] / 255,
-                    obj_controller.col_b[data.helm_secondary] / 255,
-                ];
-            } else {
-                var _blend = [
-                    obj_creation.col_r[data.helm_secondary] / 255,
-                    obj_creation.col_g[data.helm_secondary] / 255,
-                    obj_creation.col_b[data.helm_secondary] / 255,
-                ];
-            }
+
+            var _obj = instance_exists(obj_controller) ? obj_controller : obj_creation;
+            var _blend = [
+                _obj.col_r[data.helm_secondary] / 255,
+                _obj.col_g[data.helm_secondary] / 255,
+                _obj.col_b[data.helm_secondary] / 255,
+            ];
 
             draw_head({"head_stripe": {texture: spr_helm_stripe, areas: [[0, 0, 128 / 255], [0, 0, 255 / 255], [128 / 255, 64 / 255, 255 / 255], [64 / 255, 128 / 255, 255 / 255]], blend: _blend}});
             x_surface_offset = _temp[0];

--- a/scripts/scr_ComplexSet/scr_ComplexSet.gml
+++ b/scripts/scr_ComplexSet/scr_ComplexSet.gml
@@ -546,8 +546,6 @@ function ComplexSet(_unit) constructor {
         }
 
         var _is_weapon = _mod.position == "weapon";
-
-        var _is_weapon = false;
         if (!_is_weapon && struct_exists(_mod, "min_quality")) {
             var _viable = false;
             var _quality_check_areas = struct_get_names(_mod.min_quality);

--- a/scripts/scr_add_item/scr_add_item.gml
+++ b/scripts/scr_add_item/scr_add_item.gml
@@ -8,11 +8,7 @@ function scr_add_item(_item_name, _quantity = 1, _quality = "any") {
         return "no_item";
     }
 
-    static qualities = [
-        "standard",
-        "master_crafted",
-        "artifact",
-    ];
+    static qualities = EQUIPMENT_QUALITITES;
 
     static selections = [
         "any",
@@ -20,7 +16,7 @@ function scr_add_item(_item_name, _quantity = 1, _quality = "any") {
         "best",
     ];
 
-    static allowed_qualities = new Set(qualities);
+    static allowed_qualities = new Set(EQUIPMENT_QUALITITES);
 
     static allowed_selection = new Set(selections);
 

--- a/scripts/scr_add_item/scr_add_item.gml
+++ b/scripts/scr_add_item/scr_add_item.gml
@@ -8,7 +8,7 @@ function scr_add_item(_item_name, _quantity = 1, _quality = "any") {
         return "no_item";
     }
 
-    static qualities = EQUIPMENT_QUALITITES;
+    static qualities = EQUIPMENT_QUALITIES;
 
     static selections = [
         "any",
@@ -16,7 +16,7 @@ function scr_add_item(_item_name, _quantity = 1, _quality = "any") {
         "best",
     ];
 
-    static allowed_qualities = new Set(EQUIPMENT_QUALITITES);
+    static allowed_qualities = new Set(EQUIPMENT_QUALITIES);
 
     static allowed_selection = new Set(selections);
 
@@ -159,4 +159,31 @@ function EquipmentTracker() constructor {
 
     items = [];
     item_types = {};
+}
+
+
+/// @param {String} quality_a
+/// @param {String} quality_b
+/// @param {String} command
+/// @return {Bool}
+function compare_qualities(quality_a, quality_b, command) {
+    var _index_a = array_get_index(EQUIPMENT_QUALITIES, quality_a);
+    var _index_b = array_get_index(EQUIPMENT_QUALITIES, quality_b);
+    if (_index_a == -1 || _index_b == -1){
+        return false;
+    }
+    switch (command) {
+        case "inmore":
+        case "more":
+            return (_index_a >= _index_b);
+        case "exmore":
+            return (_index_a > _index_b);
+        case "inless":
+        case "less":
+            return (_index_a <= _index_b);
+        case "exless":
+            return (_index_a < _index_b);
+    }
+
+    return false;
 }

--- a/scripts/scr_culture_visuals/scr_culture_visuals.gml
+++ b/scripts/scr_culture_visuals/scr_culture_visuals.gml
@@ -1155,7 +1155,13 @@ global.modular_drawing_items = [
             "mobi": "Jump Pack",
         },
         overides: {
-            "chest_fastening": spr_backpack_fastening,
+            "chest_fastening": {
+                sprite : spr_backpack_fastening,
+                armours_exclude : [
+                    "MK5 Heresy",
+                    "MK6 Corvus",
+                ]
+            }
         },
     },
     {
@@ -1174,7 +1180,13 @@ global.modular_drawing_items = [
             "mobi": "Serpha Jump Pack",
         },
         overides: {
-            "chest_fastening": spr_backpack_fastening,
+            "chest_fastening": {
+                sprite : spr_backpack_fastening,
+                armours_exclude : [
+                    "MK5 Heresy",
+                    "MK6 Corvus",
+                ]
+            }
         },
     },
     {

--- a/scripts/scr_culture_visuals/scr_culture_visuals.gml
+++ b/scripts/scr_culture_visuals/scr_culture_visuals.gml
@@ -341,8 +341,18 @@ function set_up_visual_overides() {
                 var _subs = _mod.subcomponents;
                 for (var s = 0; s < array_length(_subs); s++) {
                     for (var ss = 0; ss < array_length(_subs[s]); ss++) {
-                        if (sprite_exists(_subs[s][ss])) {
-                            _flip_mod.subcomponents[s][ss] = return_sprite_mirrored(_subs[s][ss], false);
+                        var _sub_item = _subs[s][ss];
+                        if (is_struct(_sub_item)) {
+                            var _flipped_item = variable_clone(_sub_item);
+                            if (struct_exists(_flipped_item, "sprite") && sprite_exists(_flipped_item.sprite)) {
+                                _flipped_item.sprite = return_sprite_mirrored(_flipped_item.sprite, false);
+                            }
+                            if (struct_exists(_flipped_item, "shadows") && sprite_exists(_flipped_item.shadows)) {
+                                _flipped_item.shadows = return_sprite_mirrored(_flipped_item.shadows, false);
+                            }
+                            _flip_mod.subcomponents[s][ss] = _flipped_item;
+                        } else if (sprite_exists(_sub_item)) {
+                            _flip_mod.subcomponents[s][ss] = return_sprite_mirrored(_sub_item, false);
                         }
                     }
                 }

--- a/scripts/scr_culture_visuals/scr_culture_visuals.gml
+++ b/scripts/scr_culture_visuals/scr_culture_visuals.gml
@@ -244,10 +244,13 @@ function set_up_visual_overides() {
                     var _found_sprite = false;
                     var _subimg = _sub_group[g];
                     if (!is_string(_subimg)) {
-                        if (!sprite_exists(_subimg)) {
-                            array_delete(_sub_group, g, 1);
+                        if (!is_struct(_subimg)){
+                            if (!sprite_exists(_subimg)) {
+                                array_delete(_sub_group, g, 1);
+                            }
+                            continue;
                         }
-                        continue;
+                        _found_sprite = true;
                     }
                     if (_subimg == "blank") {
                         _item.subcomponents[s][g] = spr_blank;
@@ -256,10 +259,16 @@ function set_up_visual_overides() {
                         for (var m = 0; m < array_length(_mods); m++) {
                             if (struct_exists(_mods[m], "name")) {
                                 if (_mods[m].name == _subimg) {
-                                    _item.subcomponents[s][g] = _mods[m].sprite;
+                                    _item.subcomponents[s][g] = _mods[m];
                                     _found_sprite = true;
                                     break;
                                 }
+                            }
+                        }
+                        if (!_found_sprite){
+                            if (struct_exists(global.reuseable_drawing_items , _subimg)){
+                                _item.subcomponents[s][g] = global.reuseable_drawing_items[$ _subimg];
+                                _found_sprite = true;
                             }
                         }
                     }
@@ -351,6 +360,12 @@ function set_up_visual_overides() {
     }
 }
 
+global.reuseable_drawing_items = {
+    "roman_crest" : {
+        sprite: spr_roman_centurian_crest,
+        shadows: spr_roman_centurian_crest_shadows        
+    }
+}
 global.modular_drawing_items = [
 	// MK7 Aquila Sprites
 	{
@@ -362,6 +377,20 @@ global.modular_drawing_items = [
         body_types: [0],
         sprite: spr_mk7_chest_variants,
         shadows: spr_mk7_chest_variants_shadow,
+        subcomponents: [[]]
+    },
+    {
+        position: "armour",
+        armours: ["MK5 Heresy",
+                  "MK6 Corvus",
+                  "MK7 Aquila",
+                  "MK8 Errant",
+                  "Artificer Armour"
+        ],
+        traits: ["tinkerer"],
+        body_types: [0],
+        sprite: spr_techmarine_complex,
+        role_type: [SPECIALISTS_TECHS]
     },
 	// Other Stuff
     {

--- a/scripts/scr_culture_visuals/scr_culture_visuals.gml
+++ b/scripts/scr_culture_visuals/scr_culture_visuals.gml
@@ -227,6 +227,12 @@ function set_up_visual_overides() {
                             }
                         }
                     }
+                    if (!_found_sprite){
+                        if (struct_exists(global.reuseable_drawing_items , _overide)){
+                            _item.subcomponents[s][g] = global.reuseable_drawing_items[$ _overide];
+                            _found_sprite = true;
+                        }
+                    }
                     if (!_found_sprite) {
                         struct_remove(_item.overides, _overide_areas[o]);
                     }
@@ -374,6 +380,13 @@ global.reuseable_drawing_items = {
     "roman_crest" : {
         sprite: spr_roman_centurian_crest,
         shadows: spr_roman_centurian_crest_shadows        
+    },
+    "default_backpack_fastening" :{
+        sprite : spr_backpack_fastening,
+        armours_exclude : [
+            "MK5 Heresy",
+            "MK6 Corvus",
+        ]
     }
 }
 global.modular_drawing_items = [
@@ -1194,13 +1207,7 @@ global.modular_drawing_items = [
             "mobi": "Jump Pack",
         },
         overides: {
-            "chest_fastening": {
-                sprite : spr_backpack_fastening,
-                armours_exclude : [
-                    "MK5 Heresy",
-                    "MK6 Corvus",
-                ]
-            }
+            "chest_fastening" : "default_backpack_fastening"
         },
     },
     {
@@ -1219,13 +1226,7 @@ global.modular_drawing_items = [
             "mobi": "Serpha Jump Pack",
         },
         overides: {
-            "chest_fastening": {
-                sprite : spr_backpack_fastening,
-                armours_exclude : [
-                    "MK5 Heresy",
-                    "MK6 Corvus",
-                ]
-            }
+            "chest_fastening" : "default_backpack_fastening"
         },
     },
     {

--- a/scripts/scr_culture_visuals/scr_culture_visuals.gml
+++ b/scripts/scr_culture_visuals/scr_culture_visuals.gml
@@ -229,7 +229,7 @@ function set_up_visual_overides() {
                     }
                     if (!_found_sprite){
                         if (struct_exists(global.reuseable_drawing_items , _overide)){
-                            _item.subcomponents[s][g] = global.reuseable_drawing_items[$ _overide];
+                            _item.overides[$ _overide_areas[o]] = global.reuseable_drawing_items[$ _overide];
                             _found_sprite = true;
                         }
                     }

--- a/scripts/scr_draw_unit_image/scr_draw_unit_image.gml
+++ b/scripts/scr_draw_unit_image/scr_draw_unit_image.gml
@@ -547,9 +547,10 @@ function scr_draw_unit_image(_background = false) {
     global.base_component_surface = -1;
 
     var _keep_alive = [
-        "unit",
+        "draw_unit",
         "_texture_draws",
         "texture_draws",
+        "equipment_data"
     ];
 
     for (var i = 0; i < array_length(_keep_alive); i++) {

--- a/scripts/scr_unit_equip_functions/scr_unit_equip_functions.gml
+++ b/scripts/scr_unit_equip_functions/scr_unit_equip_functions.gml
@@ -520,9 +520,9 @@ function unit_has_equipped(check_equippment) {
 	}
 }*/
 
-function UnitEquipment(equipment_set, unit = noone) constructor{
+function UnitEquipment(equipment_set, _unit = noone) constructor{
     self.equipment = equipment_set;
-    self.unit = unit;
+    self.equipping_unit = _unit;
     var _slot_keys = UNIT_EQUIP_SLOTS;
     var _slot, _item;
     for (var i = 0; i < 5; i++){
@@ -597,7 +597,7 @@ function UnitEquipment(equipment_set, unit = noone) constructor{
             max_width: 187,
         };
 
-        var _text = unit != noone ? unit.equipments_qual_string(slot, true) : _item.name;
+        var _text = equipping_unit != noone ? equipping_unit.equipments_qual_string(slot, true) : _item.name;
 
         var _string = new ReactiveString(_text, 0, 0, _data);
 


### PR DESCRIPTION
<!--- YOU CAN DELETE ALL OF THIS AFTER READING. -->

<!--- Make use of markdown lists. They make stuff much easier to read through. -->
<!--- Explain why and what your changes do in simple terms. --->
<!--- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. --->

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->

<!--- "Inspired" by the CDDA PR template -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds quality-gated equipment visuals, named override packets, and shadow-aware subcomponents. Rendering now uses `draw_unit` with cached `equipment_data` for accurate tag/quality checks and correct shadow transforms.

- **New Features**
  - Quality filters: per-slot and per-weapon min_quality/max_quality using `EQUIPMENT_QUALITIES` + `compare_qualities` (adds "shoddy").
  - Overrides: accept full packets (sprite/shadows/subcomponents, filters like `armours_exclude`) and can reference `global.reuseable_drawing_items` (e.g., `roman_crest`, `default_backpack_fastening`).
  - Subcomponents: support structs with `sprite` + `shadows`; mirroring flips both.
  - Roles: Techmarine visuals via `spr_techmarine_complex` for tinkerer tech specialists on MK5–MK8 and Artificer.

- **Refactors**
  - Switched from `unit` to `draw_unit`; cached `equipment_data` and added it to keep-alive in `scr_draw_unit_image`.
  - `assign_modulars` supports `replace_by_default`; `check_component_overides` now routes override packets through modulars for consistent replace behavior.
  - Shadow handling hardened: correct UV transforms, shadows applied per subcomponent choice, and cleared on area replace.
  - Unified qualities via `EQUIPMENT_QUALITIES`; `compare_qualities` added; renamed `UnitEquipment.unit` to `equipping_unit`.

<sup>Written for commit 944cb941bc0a515f342b38b216337637289fc675. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

