### PR TITLE
fix: No chest fastening for MK4,5,6

### DIFF
--- a/ChapterMaster.yyp
+++ b/ChapterMaster.yyp
@@ -594,7 +594,7 @@
   "isEcma":false,
   "LibraryEmitters":[],
   "MetaData":{
-    "IDEVersion":"2026.100.0.1083",
+    "IDEVersion":"2026.0.0.16",
   },
   "name":"ChapterMaster",
   "resources":[

--- a/scripts/scr_culture_visuals/scr_culture_visuals.gml
+++ b/scripts/scr_culture_visuals/scr_culture_visuals.gml
@@ -1196,8 +1196,15 @@ global.modular_drawing_items = [
             "mobi": "Heavy Weapons Pack",
         },
         overides: {
-            "chest_fastening": spr_backpack_fastening,
-        },
+            "chest_fastening": { 
+				sprite: spr_backpack_fastening,
+				armours_exclude: [
+					"MK4 Maximus",
+					"MK5 Heresy",
+					"MK6 Corvus",
+				],
+			},
+		},
     },
     {
         sprite: spr_jump_pack_complex,
@@ -1206,9 +1213,16 @@ global.modular_drawing_items = [
         equipped: {
             "mobi": "Jump Pack",
         },
-        overides: {
-            "chest_fastening" : "default_backpack_fastening"
-        },
+		overides: {
+            "chest_fastening": { 
+				sprite: spr_backpack_fastening,
+				armours_exclude: [
+					"MK4 Maximus",
+					"MK5 Heresy",
+					"MK6 Corvus",
+				],
+			},
+		},
     },
     {
         sprite: spr_cyclone_launcher,
@@ -1226,8 +1240,15 @@ global.modular_drawing_items = [
             "mobi": "Serpha Jump Pack",
         },
         overides: {
-            "chest_fastening" : "default_backpack_fastening"
-        },
+            "chest_fastening": { 
+				sprite: spr_backpack_fastening,
+				armours_exclude: [
+					"MK4 Maximus",
+					"MK5 Heresy",
+					"MK6 Corvus",
+				],
+			},
+		},
     },
     {
         sprite: spr_gear_hood2,


### PR DESCRIPTION
Make use of more flexible Override code so chest fastening sprite no longer appears on these armors when equipping Jump or Heavy Weapon Packs since they have fastenings baked into their default look.

This does mean MK4 will 25% of the time have no fastening, but I think it's fine to have that -sometimes-, perhaps indicating a customized armor with better back support. At the very least an improvement over awkwardly overlapping fastenings 75% of the time.

I may opt to adapt the MK4 fastening into a generic one that sort of phases into itself if the chest already rolled it if it is a significant issue.

Tested visually.

<!--- YOU CAN DELETE ALL OF THIS AFTER READING. -->

<!--- Make use of markdown lists. They make stuff much easier to read through. -->
<!--- Explain why and what your changes do in simple terms. --->
<!--- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. --->

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->

<!--- "Inspired" by the CDDA PR template -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop rendering the chest fastening on MK4 Maximus, MK5 Heresy, and MK6 Corvus when equipping Heavy Weapons, Jump, or Serpha Jump packs to prevent overlapping with built‑in fastenings.

- **Bug Fixes**
  - Made `chest_fastening` accept an object with `sprite` and `armours_exclude`.
  - Applied to Heavy Weapons Pack, Jump Pack, and Serpha Jump Pack using `spr_backpack_fastening` with exclusions for MK4/MK5/MK6.

<sup>Written for commit ed5d1f6e2b4a3fbc5aead1df6a0262bda68f371b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

