### PR TITLE
fix: Crash with creation screen marine viewer

### DIFF
--- a/scripts/scr_culture_visuals/scr_culture_visuals.gml
+++ b/scripts/scr_culture_visuals/scr_culture_visuals.gml
@@ -2081,6 +2081,7 @@ function DummyMarine() constructor {
     static unit_profile_text = scr_unit_detail_text;
     static has_equipped = unit_has_equipped;
     static get_body_data = scr_get_body_data;
+    static unit_equipment_data = scr_get_unit_equipment;
     traits = [];
     company = irandom_range(1, 10);
 

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -713,25 +713,7 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
     static unit_profile_text = scr_unit_detail_text;
     static has_equipped = unit_has_equipped;
 
-    static unit_equipment_data = function(as_UnitEquipment = true) {
-        var armour_data = get_armour_data();
-        var gear_data = get_gear_data();
-        var mobility_data = get_mobility_data();
-        var weapon_one_data = get_weapon_one_data();
-        var weapon_two_data = get_weapon_two_data();
-        var equip_data = {
-            armour: armour_data,
-            gear: gear_data,
-            mobi: mobility_data,
-            wep1: weapon_one_data,
-            wep2: weapon_two_data,
-        };
-        if(as_UnitEquipment){
-            return new UnitEquipment(equip_data, self);
-        } else {
-            return equip_data;
-        }
-    };
+    static unit_equipment_data = scr_get_unit_equipment;
 
     //body parts list can be extended as much as people want
 

--- a/scripts/scr_unit_equip_functions/scr_unit_equip_functions.gml
+++ b/scripts/scr_unit_equip_functions/scr_unit_equip_functions.gml
@@ -520,6 +520,26 @@ function unit_has_equipped(check_equippment) {
 	}
 }*/
 
+function scr_get_unit_equipment(as_UnitEquipment = true){
+        var armour_data = get_armour_data();
+        var gear_data = get_gear_data();
+        var mobility_data = get_mobility_data();
+        var weapon_one_data = get_weapon_one_data();
+        var weapon_two_data = get_weapon_two_data();
+        var equip_data = {
+            armour: armour_data,
+            gear: gear_data,
+            mobi: mobility_data,
+            wep1: weapon_one_data,
+            wep2: weapon_two_data,
+        };
+        if(as_UnitEquipment){
+            return new UnitEquipment(equip_data, self);
+        } else {
+            return equip_data;
+        }
+}
+
 function UnitEquipment(equipment_set, unit = noone) constructor{
     self.equipment = equipment_set;
     self.unit = unit;

--- a/scripts/scr_unit_equip_functions/scr_unit_equip_functions.gml
+++ b/scripts/scr_unit_equip_functions/scr_unit_equip_functions.gml
@@ -540,7 +540,7 @@ function scr_get_unit_equipment(as_UnitEquipment = true){
         }
 }
 
-function UnitEquipment(equipment_set, unit = noone) constructor{
+function UnitEquipment(equipment_set, _unit = noone) constructor{
     self.equipment = equipment_set;
     self.equipping_unit = _unit;
     var _slot_keys = UNIT_EQUIP_SLOTS;


### PR DESCRIPTION
<!--- YOU CAN DELETE ALL OF THIS AFTER READING. -->

<!--- Make use of markdown lists. They make stuff much easier to read through. -->
<!--- Explain why and what your changes do in simple terms. --->
<!--- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. --->

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->

<!--- "Inspired" by the CDDA PR template -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash on the marine creation screen by centralizing how unit equipment is built and exposing it to viewer models. Unifies equipment data creation between `TTRPG_stats` and `DummyMarine`.

- **Bug Fixes**
  - Added shared `scr_get_unit_equipment` and wired it as `unit_equipment_data`.
  - Replaced inline `unit_equipment_data` in `TTRPG_stats` with the shared function.
  - Exposed `unit_equipment_data` on `DummyMarine` so the viewer can access equipment safely.

<sup>Written for commit 0a5046d7ca6ecddc44163284fb38d2514dd962ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

