### PR TITLE
refactor: Optimize has_trait

### DIFF
--- a/scripts/scr_culture_visuals/scr_culture_visuals.gml
+++ b/scripts/scr_culture_visuals/scr_culture_visuals.gml
@@ -2226,23 +2226,16 @@ function DummyMarine() constructor {
         if (is_array(_wanted_trait)) {
             var _len = array_length(_wanted_trait);
 
-            if (_any) {
-                for (var i = 0; i < _len; i++) {
-                    if (array_contains(traits, _wanted_trait[i])) {
-                        return true;
-                    }
+            for (var i = 0; i < _len; i++) {
+                var _has = array_contains(traits, _wanted_trait[i]);
+                if (_any && _has) {
+                    return true;
+                } else if (!_any && !_has) {
+                    return false;
                 }
-
-                return false;
-            } else {
-                for (var i = 0; i < _len; i++) {
-                    if (!array_contains(traits, _wanted_trait[i])) {
-                        return false;
-                    }
-                }
-
-                return true;
             }
+            
+            return _any ? false : true;
         }
 
         return array_contains(traits, _wanted_trait);

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -691,23 +691,16 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
         if (is_array(_wanted_trait)) {
             var _len = array_length(_wanted_trait);
 
-            if (_any) {
-                for (var i = 0; i < _len; i++) {
-                    if (array_contains(traits, _wanted_trait[i])) {
-                        return true;
-                    }
+            for (var i = 0; i < _len; i++) {
+                var _has = array_contains(traits, _wanted_trait[i]);
+                if (_any && _has) {
+                    return true;
+                } else if (!_any && !_has) {
+                    return false;
                 }
-
-                return false;
-            } else {
-                for (var i = 0; i < _len; i++) {
-                    if (!array_contains(traits, _wanted_trait[i])) {
-                        return false;
-                    }
-                }
-
-                return true;
             }
+
+            return _any ? false : true;
         }
 
         return array_contains(traits, _wanted_trait);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refactored the trait check to a single-pass loop with early returns for ANY vs ALL checks. This keeps behavior the same while reducing branching and iterations.

- **Refactors**
  - Replaced separate any/all loops with one loop using `_has` and early returns.
  - Added final `return _any ? false : true` after the loop for clarity.
  - Applied in `scripts/scr_culture_visuals/scr_culture_visuals.gml` and `scripts/scr_marine_struct/scr_marine_struct.gml`.

<sup>Written for commit a62e6d7fac998e9113a81dd2d89cfbe81ca1b24c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

