### PR TITLE
fix: Icon shader

### DIFF
--- a/scripts/scr_ComplexSet/scr_ComplexSet.gml
+++ b/scripts/scr_ComplexSet/scr_ComplexSet.gml
@@ -1197,7 +1197,9 @@ function ComplexSet(_unit) constructor {
         } else {
             draw_sprite(resolved_sprite, resolved_choice ?? 0, component_final_draw_x, component_final_draw_y);
         }
+        shader_reset();
         draw_surface(global.base_component_surface, 0, 0);
+        shader_set(full_livery_shader);
     };
 
     /// @desc Main function


### PR DESCRIPTION
<!--- YOU CAN DELETE ALL OF THIS AFTER READING. -->

<!--- Make use of markdown lists. They make stuff much easier to read through. -->
<!--- Explain why and what your changes do in simple terms. --->
<!--- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. --->

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->

<!--- "Inspired" by the CDDA PR template -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes icons rendering with the livery shader by resetting shader state during component draw. Icons now render with correct colors while livery effects remain where intended.

- **Bug Fixes**
  - Reset shader before drawing `global.base_component_surface` to prevent bleed.
  - Reapply `full_livery_shader` after the draw to restore expected effects.

<sup>Written for commit 89600e2acdf099ad0b6ca50f74865421d39e77dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

