### PR TITLE
fix: No Chest Harness for MK4/5/6

### DIFF
--- a/scripts/scr_culture_visuals/scr_culture_visuals.gml
+++ b/scripts/scr_culture_visuals/scr_culture_visuals.gml
@@ -384,7 +384,8 @@ global.reuseable_drawing_items = {
     "default_backpack_fastening" :{
         sprite : spr_backpack_fastening,
         armours_exclude : [
-            "MK5 Heresy",
+            "MK4 Maximus",
+			"MK5 Heresy",
             "MK6 Corvus",
         ]
     }
@@ -1196,7 +1197,7 @@ global.modular_drawing_items = [
             "mobi": "Heavy Weapons Pack",
         },
         overides: {
-            "chest_fastening": spr_backpack_fastening,
+            "chest_fastening": "default_backpack_fastening"
         },
     },
     {


### PR DESCRIPTION
Unfitting chest harness sprite no longer spawned on certain armours with default chest harnesses already existing.

MK4 will have no harness at all 25% of the time but I think that's fine and better than doubling up 75% of the time, call it tweaked armor with strong back support.

Tested visually.

<!--- YOU CAN DELETE ALL OF THIS AFTER READING. -->

<!--- Make use of markdown lists. They make stuff much easier to read through. -->
<!--- Explain why and what your changes do in simple terms. --->
<!--- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. --->

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->

<!--- "Inspired" by the CDDA PR template -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the generic chest harness from rendering on MK4 Maximus, MK5 Heresy, and MK6 Corvus to avoid duplicate/misaligned harness sprites. Switches to a reusable fastening config so armor-specific exclusions are respected.

- **Bug Fixes**
  - Added "MK4 Maximus" to `armours_exclude` in `default_backpack_fastening`.
  - Replaced `spr_backpack_fastening` override with `default_backpack_fastening` to apply exclusions.

<sup>Written for commit aa6c89d9d3fdbc7d149d8110f9e363269ade42a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

