### PR TITLE
fix(ColourPicker): Surface existence guards

### DIFF
--- a/scripts/ColourPicker/ColourPicker.gml
+++ b/scripts/ColourPicker/ColourPicker.gml
@@ -51,6 +51,10 @@ function ColourPicker(xx, yy, max_width = 400) constructor {
     ];
 
     static create_texture_surface = function(texture_set, sprite_draw_args) {
+        if (!surface_exists(textures_surface)) {
+            textures_surface = surface_create(1, 1);
+        }
+
         var texture_names = struct_get_names(texture_set);
         var total_width = sprite_draw_args.frame_width * array_length(texture_names);
         if (sprite_draw_args.frame_height <= 0 || total_width <= 0) {
@@ -81,6 +85,10 @@ function ColourPicker(xx, yy, max_width = 400) constructor {
     };
 
     static draw_textures_surface = function(selection_method) {
+        if (!surface_exists(textures_surface)) {
+            return;
+        }
+
         draw_set_alpha(1);
         var _tex_height = surface_get_height(textures_surface);
         draw_surface_part(textures_surface, _texture_offset[0], _texture_offset[1], min(max_width, surface_get_width(textures_surface)), _tex_height, x, y);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add surface existence guards in the ColourPicker to prevent crashes when the textures surface is missing or lost. We now create the textures_surface on demand in create_texture_surface and skip drawing in draw_textures_surface if it doesn't exist.

<sup>Written for commit 5f9ef8df887d1e992c31bc0aa7ab403b840cc2bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

