### PR TITLE
refactor(ColourPicker): Harden surface management

### DIFF
--- a/scripts/ColourPicker/ColourPicker.gml
+++ b/scripts/ColourPicker/ColourPicker.gml
@@ -54,28 +54,21 @@ function ColourPicker(xx, yy, max_width = 400) constructor {
     static _last_sprite_args = undefined;
 
     static create_texture_surface = function(texture_set, sprite_draw_args) {
-        if (!surface_exists(textures_surface)) {
-            textures_surface = surface_create(1, 1);
-        }
-
         var texture_names = struct_get_names(texture_set);
         var total_width = sprite_draw_args.frame_width * array_length(texture_names);
         if (sprite_draw_args.frame_height <= 0 || total_width <= 0) {
             exit;
         }
 
-        if (!surface_exists(textures_surface)) {
-            textures_surface = surface_create(1, 1);
-        }
-
-        _last_texture_set = texture_set;
-        _last_sprite_args = sprite_draw_args;
-
         _texture_offset = [
             0,
             0,
         ];
         texture_coords = [];
+
+        if (!surface_exists(textures_surface)) {
+            textures_surface = surface_create(1, 1);
+        }
 
         surface_resize(textures_surface, total_width, sprite_draw_args.frame_height);
         surface_set_target(textures_surface);
@@ -91,7 +84,11 @@ function ColourPicker(xx, yy, max_width = 400) constructor {
             array_push(texture_coords, [[draw_x, draw_y, draw_x + _frame_width, draw_y + _frame_height], texture_names[i]]);
             draw_x += sprite_draw_args.frame_width;
         }
+
         surface_reset_target();
+
+        _last_texture_set = texture_set;
+        _last_sprite_args = sprite_draw_args;
     };
 
     static draw_textures_surface = function(selection_method) {

--- a/scripts/ColourPicker/ColourPicker.gml
+++ b/scripts/ColourPicker/ColourPicker.gml
@@ -50,6 +50,9 @@ function ColourPicker(xx, yy, max_width = 400) constructor {
         0,
     ];
 
+    static _last_texture_set = undefined;
+    static _last_sprite_args = undefined;
+
     static create_texture_surface = function(texture_set, sprite_draw_args) {
         if (!surface_exists(textures_surface)) {
             textures_surface = surface_create(1, 1);
@@ -60,6 +63,13 @@ function ColourPicker(xx, yy, max_width = 400) constructor {
         if (sprite_draw_args.frame_height <= 0 || total_width <= 0) {
             exit;
         }
+
+        if (!surface_exists(textures_surface)) {
+            textures_surface = surface_create(1, 1);
+        }
+
+        _last_texture_set = texture_set;
+        _last_sprite_args = sprite_draw_args;
 
         _texture_offset = [
             0,
@@ -86,7 +96,13 @@ function ColourPicker(xx, yy, max_width = 400) constructor {
 
     static draw_textures_surface = function(selection_method) {
         if (!surface_exists(textures_surface)) {
-            return;
+            if (is_struct(_last_texture_set) && is_struct(_last_sprite_args)) {
+                create_texture_surface(_last_texture_set, _last_sprite_args);
+            }
+
+            if (!surface_exists(textures_surface)) {
+                return;
+            }
         }
 
         draw_set_alpha(1);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Harden ColourPicker surface management to prevent blank renders when the texture surface is missing. The picker now re-creates the surface on demand using the last valid inputs.

- **Bug Fixes**
  - Store last inputs in `_last_texture_set` and `_last_sprite_args` for rebuilds.
  - Create a 1x1 surface only after validating dimensions; ensure it exists before resizing/drawing.
  - In `draw_textures_surface`, try to rebuild using cached inputs if missing; if still missing, exit without drawing.

<sup>Written for commit d95b400d72329def415a5fa9e26847378d25863d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

