### PR TITLE
ci: OpenCode test workflow

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -9,10 +9,8 @@ on:
 jobs:
   opencode:
     if: |
-    if: |
       startsWith(github.event.comment.body, '/oc') ||
       startsWith(github.event.comment.body, '/opencode')
-      contains(github.event.comment.body, '/opencode')
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -24,7 +22,7 @@ jobs:
           persist-credentials: false
 
       - name: Run OpenCode
-        uses: anomalyco/opencode/github@latest
+        uses: anomalyco/opencode/github@v1.18.4
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
         with:

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,0 +1,29 @@
+name: opencode
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  opencode:
+    if: |
+      contains(github.event.comment.body, '/oc') ||
+      contains(github.event.comment.body, '/opencode')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Run OpenCode
+        uses: anomalyco/opencode/github@latest
+        env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+        with:
+          model: opencode/deepseek-v4-flash-free

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -9,7 +9,9 @@ on:
 jobs:
   opencode:
     if: |
-      contains(github.event.comment.body, '/oc') ||
+    if: |
+      startsWith(github.event.comment.body, '/oc') ||
+      startsWith(github.event.comment.body, '/opencode')
       contains(github.event.comment.body, '/opencode')
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an `opencode` GitHub Actions workflow to run OpenCode on demand from issue and PR review comments. Uses `anomalyco/opencode/github@v1.18.4` with model `opencode/deepseek-v4-flash-free` and the `OPENCODE_API_KEY` secret.

- **New Features**
  - Triggers only when the comment starts with `/oc` or `/opencode`.
  - Secure setup with `actions/checkout@v6` (shallow clone, no persisted creds) and `id-token: write`; action pinned to `v1.18.4`.

<sup>Written for commit 3137622d719185bfa562131e862fcacf6a9e1b40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

