### PR TITLE
fix: AudioManager mistakes

### DIFF
--- a/objects/obj_defeat/Step_0.gml
+++ b/objects/obj_defeat/Step_0.gml
@@ -6,7 +6,7 @@ if (goodbye > 0) {
 }
 
 if (fadeout == 1) {
-    global.audio_manager.stop_music(2000)
+    global.audio_manager.stop_music(2000);
 }
 
 if (fadeout == 60) {

--- a/scripts/AudioManager/AudioManager.gml
+++ b/scripts/AudioManager/AudioManager.gml
@@ -3,8 +3,8 @@
 /// crossfading, and volume control.
 ///
 /// Audio loading tiers (user overrides shipped):
-/// 1. Shipped: `working_directory/Audio/`
-/// 2. User: `Audio/` (relative -> AppData/Local/ChapterMaster/Audio/)
+/// 1. Shipped: `ChapterMaster/Audio/`
+/// 2. User: `AppData/Local/ChapterMaster/Custom Files/Audio/`
 ///
 /// Music uses a context/playlist system. Context folders under `Audio/Music/<context>/`
 /// are scanned on discovery. Each context picks a random track from its folder.
@@ -40,13 +40,13 @@
 function AudioManager() constructor {
     // ###### Constants ######
 
-    AUDIO_DIR = working_directory + "/Custom Files/Audio/";
+    AUDIO_DIR = working_directory + "Audio/";
     MUSIC_DIR = AUDIO_DIR + "Music/";
     SFX_DIR = AUDIO_DIR + "SFX/";
 
-    USER_AUDIO_DIR = program_directory + "Audio/";
+    USER_AUDIO_DIR = "Custom Files/Audio/";
     USER_MUSIC_DIR = USER_AUDIO_DIR + "Music/";
-    USER_SFX_DIR = USER_AUDIO_DIR + "SFX//";
+    USER_SFX_DIR = USER_AUDIO_DIR + "SFX/";
 
     DEFAULT_CROSSFADE_MS = 2000;
     DEFAULT_STOP_FADE_MS = 500;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes AudioManager paths and a small syntax mistake so music/SFX load from the correct folders and defeat fadeouts stop music reliably.

- **Bug Fixes**
  - Set shipped audio dir to `working_directory + "Audio/"`; user dir to `"Custom Files/Audio/"`.
  - Fixed `USER_SFX_DIR` from `SFX//` to `SFX/`.
  - Updated comments to reflect `ChapterMaster/Audio/` and `AppData/Local/ChapterMaster/Custom Files/Audio/`.
  - Added missing semicolon on `stop_music(2000);` in `obj_defeat`.

<sup>Written for commit 416365daf3722a84186769343406c0a4c021999c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

