### PR TITLE
ci: OpenCode workflow adjustments

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -38,5 +38,6 @@ jobs:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
         with:
           model: opencode/deepseek-v4-flash-free
+          variant: max
           share: false
           prompt: ${{ inputs.prompt || '' }}

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -5,13 +5,21 @@ on:
     types: [created]
   pull_request_review_comment:
     types: [created]
+  workflow_dispatch:
+    inputs:
+      prompt:
+        description: 'Task'
+        required: true
 
 jobs:
   opencode:
     if: |
-      (startsWith(github.event.comment.body, '/oc')
-        || startsWith(github.event.comment.body, '/opencode'))
-      && contains(fromJson('["OWNER","MEMBER"]'), github.event.comment.author_association)
+      ((github.event_name == 'issue_comment'
+          || github.event_name == 'pull_request_review_comment')
+        && (startsWith(github.event.comment.body, '/oc')
+          || startsWith(github.event.comment.body, '/opencode'))
+        && contains(fromJson('["OWNER","MEMBER"]'), github.event.comment.author_association))
+      || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -31,3 +39,4 @@ jobs:
         with:
           model: opencode/deepseek-v4-flash-free
           share: false
+          prompt: ${{ inputs.prompt || '' }}

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -9,16 +9,19 @@ on:
 jobs:
   opencode:
     if: |
-      startsWith(github.event.comment.body, '/oc') ||
-      startsWith(github.event.comment.body, '/opencode')
+      (startsWith(github.event.comment.body, '/oc')
+        || startsWith(github.event.comment.body, '/opencode'))
+      && contains(fromJson('["OWNER","MEMBER"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+      pull-requests: write
+      issues: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          fetch-depth: 1
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Run OpenCode
@@ -27,3 +30,4 @@ jobs:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
         with:
           model: opencode/deepseek-v4-flash-free
+          share: false

--- a/.github/workflows/opencode_review.yml
+++ b/.github/workflows/opencode_review.yml
@@ -1,0 +1,32 @@
+name: opencode_review
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  opencode:
+    if: |
+      startsWith(github.event.comment.body, '/review')
+      && contains(fromJson('["OWNER","MEMBER"]'), github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Run OpenCode
+        uses: anomalyco/opencode/github@v1.18.4
+        env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+        with:
+          agent: pr_review
+          share: false

--- a/.github/workflows/opencode_review.yml
+++ b/.github/workflows/opencode_review.yml
@@ -29,3 +29,9 @@ jobs:
           variant: max
           agent: pr_review
           share: false
+          prompt: |
+            Review this pull request:
+            - Check for code quality issues
+            - Look for potential bugs and regressions
+            - Suggest improvements
+            Respond terse. All technical substance stays. Only fluff dies.

--- a/.github/workflows/opencode_review.yml
+++ b/.github/workflows/opencode_review.yml
@@ -28,5 +28,7 @@ jobs:
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
         with:
+          model: opencode/deepseek-v4-flash-free
+          variant: max
           agent: pr_review
           share: false

--- a/.github/workflows/opencode_review.yml
+++ b/.github/workflows/opencode_review.yml
@@ -1,8 +1,6 @@
 name: opencode_review
 
 on:
-  issue_comment:
-    types: [created]
   pull_request_review_comment:
     types: [created]
 
@@ -15,7 +13,6 @@ jobs:
     permissions:
       id-token: write
       pull-requests: write
-      issues: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "agent": {
+    "pr_review": {
+      "mode": "primary",
+      "model": "opencode/deepseek-v4-flash-free",
+      "permission": {
+        "doom_loop ": "deny",
+        "external_directory": "deny",
+        "edit": "deny",
+        "lsp": "deny",
+        "question": "deny",
+      },
+    }
+  },
+  "compaction": {
+    "auto": true,
+    "prune": true,
+    "reserved": 120000
+  },
+  "formatter": false,
+  "instructions": [
+    "docs/CODE_STYLE.md",
+    "docs/AGENTS.md"
+  ],
+  "snapshot": false
+}

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -9,8 +9,8 @@
         "external_directory": "deny",
         "edit": "deny",
         "lsp": "deny",
-        "question": "deny",
-      },
+        "question": "deny"
+      }
     }
   },
   "compaction": {
@@ -20,6 +20,7 @@
   },
   "formatter": false,
   "instructions": [
+    "docs/GML_REFERENCE.md",
     "docs/CODE_STYLE.md",
     "docs/AGENTS.md"
   ],

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -5,7 +5,7 @@
       "mode": "primary",
       "model": "opencode/deepseek-v4-flash-free",
       "permission": {
-        "doom_loop ": "deny",
+        "doom_loop": "deny",
         "external_directory": "deny",
         "edit": "deny",
         "lsp": "deny",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add `opencode.jsonc`, tighten OpenCode triggers, add a member-only `/review` workflow, and support manual runs with a task `prompt`. Sets a primary, read-only PR review agent and adds a concise review prompt; both workflows run with `variant: max`.

- **New Features**
  - Adds `pr_review` agent (mode: `primary`) on `opencode/deepseek-v4-flash-free`; denies edit/LSP/question/external-dir/doom-loop; compaction auto+prune (reserved 120000); `formatter`/`snapshot` off; loads `docs/CODE_STYLE.md`, `docs/AGENTS.md`, and `docs/GML_REFERENCE.md`.
  - Updates `.github/workflows/opencode.yml` to allow `/oc` or `/opencode` from `OWNER`/`MEMBER`, or `workflow_dispatch` with `inputs.prompt`; adds `.github/workflows/opencode_review.yml` for `/review` by `OWNER`/`MEMBER` using `agent: pr_review` with a built-in prompt; both checkout full history, set `share: false`, and run with `variant: max`; `opencode.yml` grants `pull-requests` and `issues` write, review grants `pull-requests` write only.

<sup>Written for commit 5ef81656f78731ae3bd265f4885107b081da163b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

