### PR TITLE
docs: Update GML_REFERENCE.md

### DIFF
--- a/docs/GML_REFERENCE.md
+++ b/docs/GML_REFERENCE.md
@@ -23,29 +23,29 @@ This guide covers the language for developers familiar with JavaScript or other 
 
 ## Comparison: GML vs JavaScript
 
-| GML | JavaScript |
+| JavaScript | GML |
 |---|---|
-| `self` | `this` |
-| `struct` | `object` / `{}` |
-| `real` | `number` |
-| `bool` values are `real` (1/0) | distinct `boolean` type |
-| `pointer_null` | `null` |
-| `infinity` | `Infinity` |
-| `typeof(x)` - function | `typeof x` - operator |
-| `instanceof(x, y)` - function | `x instanceof y` - operator |
-| `///` JSDoc | `/** */` JSDoc |
-| `function ... constructor` + `new` | `class` |
-| `var` only | `var`, `let`, `const` |
-| Block scoping: function-level only | Block scoping with `let`/`const` |
-| `#macro` for compile-time constants | No preprocessor |
-| `array_length(a)`, `string_length(s)` | `a.length`, `s.length` |
-| `struct[$ "key"]` | `obj["key"]` |
-| `^^` - logical XOR | `^` - bitwise XOR only |
-| `$` hex prefix | `0x` hex prefix |
+| `this` | `self` |
+| `object` / `{}` | `struct` |
+| `number` | `real` |
+| distinct `boolean` type | `bool` values are `real` (1/0) |
+| `null` | `pointer_null` |
+| `Infinity` | `infinity` |
+| `typeof x` - operator | `typeof(x)` - function |
+| `x instanceof y` - operator | `instanceof(x, y)` - function |
+| `/** */` JSDoc | `///` JSDoc |
+| `class` | `function ... constructor` + `new` |
+| `var`, `let`, `const` | `var` only |
+| Block scoping with `let`/`const` | Block scoping: function-level only |
+| No preprocessor | `#macro` for compile-time constants |
+| `a.length`, `s.length` | `array_length(a)`, `string_length(s)` |
+| `obj["key"]` | `struct[$ "key"]` |
+| `^` - bitwise XOR only | `^^` - logical XOR |
+| `0x` hex prefix | `$` hex prefix |
 | `switch` - fallthrough (uses `break`) | `switch` - fallthrough (uses `break`) |
-| `do...until(condition)` | `do...while(condition)` |
-| `repeat(n) { }` | no equivalent |
-| 0-based array indexing (default) | 0-based array indexing |
+| `do...while(condition)` | `do...until(condition)` |
+| no equivalent | `repeat(n) { }` |
+| 0-based array indexing | 0-based array indexing (default) |
 
 ---
 

--- a/docs/GML_REFERENCE.md
+++ b/docs/GML_REFERENCE.md
@@ -1,6 +1,8 @@
-# GameMaker Language (GML) Guide
+# GameMaker Language (GML) Reference
 
 This guide covers the language for developers familiar with JavaScript or other C-family languages.
+
+GameMaker Language (GML) is syntactically similar to JavaScript ES3 but has significant differences.
 
 ---
 
@@ -54,7 +56,6 @@ GameMaker projects consist of globally referenceable assets. The primary code-ca
 
 ### Scripts
 
-- Named `.gml` files under `scripts/` in the project.
 - Functions and enums defined at the top level are **globally available** - no import/export statements.
 - Loaded early in boot; function definitions are hoisted before any script statements execute.
 
@@ -66,7 +67,7 @@ Objects in GameMaker are **blueprints** (similar to JavaScript classes) from whi
   - `Create` - runs once when an instance is first created (like a constructor).
   - `Step` - runs every frame (like an `update()` loop).
   - `Draw` - runs every frame when the instance is visible (like a `render()` method).
-  - `Alarm` - timed callbacks, set with `alarm[0] = frames;`.
+  - `Alarm` - timed callbacks, set with `alarm[0] = steps;`.
   - Collision events, Input events, etc. - triggered by engine‑detected interactions.
 - **Built‑in Instance Variables** - every Object comes with a rich set of default fields (e.g., `x`, `y`, `speed`, `direction`, `image_index`, `visible`, `solid`). These are analogous to predefined properties on a class that the engine uses for movement, rendering, and collision. You can also define your own custom variables inside events (e.g., `hp = 100` in the `Create` event).
 - **Inheritance** - Objects can have a **Parent** Object. A child inherits all events and instance variables from its parent, and can override them by defining its own events. The child's events can call the parent's version with `event_inherited()`.
@@ -74,8 +75,6 @@ Objects in GameMaker are **blueprints** (similar to JavaScript classes) from whi
 ---
 
 ## Syntax Basics
-
-GameMaker Language (GML) is syntactically similar to JavaScript ES3 but has significant differences.
 
 ### Comments
 
@@ -149,11 +148,9 @@ GML provides several built-in constants. Some act as special data type values, w
 ### String Interpolation
 
 ```gml
-$"Hello {name}"                           // Template string
-string("text {0} and {1}", a, b)          // Deferred placeholder substitution
+$"Hello {name}" // Template string
+string("text {0} and {1}", a, b) // Deferred placeholder substitution
 ```
-
-**Note:** String character positions are **1-indexed** (`string_char_at(s, 1)` gets the first character), while arrays are 0-indexed.
 
 ---
 
@@ -167,9 +164,9 @@ GML has three primary runtime scopes. At runtime, variable names are resolved in
 
 ### Local Scope
 
-Declared with `var`. Exists only during the current function or event execution. 
+Declared with `var`. Scoped to the **function body**, not to individual blocks. Exists only during the current function or event execution.
 
-`var` is scoped to the **function body**, not to individual blocks. Control-flow constructs (`if`, `for`, `switch`, `try`) do **not** create a new local scope.
+Control-flow constructs (`if`, `for`, `switch`, `try`) do **not** create a new local scope.
 
 ```gml
 function example() {

--- a/docs/GML_REFERENCE.md
+++ b/docs/GML_REFERENCE.md
@@ -60,9 +60,16 @@ GameMaker projects consist of globally referenceable assets. The primary code-ca
 
 ### Objects
 
-- Class-like assets from which **Instances** are created at runtime.
-- Have **events** (Create, Step, Draw, Alarm, etc.) where code runs.
-- Objects have built-in instance variables (`x`, `y`, `speed`, `direction`, `image_index`, etc.).
+Objects in GameMaker are **blueprints** (similar to JavaScript classes) from which **Instances** are spawned at runtime. Each Object asset defines:
+
+- **Events** - a set of named code blocks that the engine calls automatically under specific conditions. Think of them as predefined lifecycle methods that GameMaker's runtime invokes for you:
+  - `Create` - runs once when an instance is first created (like a constructor).
+  - `Step` - runs every frame (like an `update()` loop).
+  - `Draw` - runs every frame when the instance is visible (like a `render()` method).
+  - `Alarm` - timed callbacks, set with `alarm[0] = frames;`.
+  - Collision events, Input events, etc. - triggered by engine‑detected interactions.
+- **Built‑in Instance Variables** - every Object comes with a rich set of default fields (e.g., `x`, `y`, `speed`, `direction`, `image_index`, `visible`, `solid`). These are analogous to predefined properties on a class that the engine uses for movement, rendering, and collision. You can also define your own custom variables inside events (e.g., `hp = 100` in the `Create` event).
+- **Inheritance** - Objects can have a **Parent** Object. A child inherits all events and instance variables from its parent, and can override them by defining its own events. The child's events can call the parent's version with `event_inherited()`.
 
 ---
 

--- a/docs/GML_REFERENCE.md
+++ b/docs/GML_REFERENCE.md
@@ -428,7 +428,7 @@ _s[$ "name"];         // Struct accessor (bracket with $)
 ### Legacy DS Structures
 
 | Type | Accessor | Creation |
-|---|---|---|---|
+|---|---|---|
 | `ds_list` | `[\| index]` | `ds_list_create()` |
 | `ds_map` | `[? key]` | `ds_map_create()` |
 | `ds_grid` | `[# x, y]` | `ds_grid_create(w, h)` |

--- a/docs/GML_REFERENCE.md
+++ b/docs/GML_REFERENCE.md
@@ -11,7 +11,7 @@ This guide covers the language for developers familiar with JavaScript or other 
 - [Variable Categories](#variable-categories)
 - [Functions](#functions)
 - [Constructors](#constructors)
-- [Methods](#methods)
+- [Methods and Binding](#methods-and-binding)
 - [Data Structures and Accessors](#data-structures-and-accessors)
 - [Keywords](#keywords)
 - [Constants and Macros](#constants-and-macros)

--- a/docs/GML_REFERENCE.md
+++ b/docs/GML_REFERENCE.md
@@ -421,13 +421,16 @@ _s[$ "name"];         // Struct accessor (bracket with $)
 
 ### Legacy DS Structures
 
-| Type | Accessor | Creation | Notes |
+| Type | Accessor | Creation |
 |---|---|---|---|
-| `ds_list` | `[| index]` | `ds_list_create()` | Manual `ds_destroy()` required |
-| `ds_map` | `[? key]` | `ds_map_create()` | Manual `ds_destroy()` required |
-| `ds_grid` | `[# x, y]` | `ds_grid_create(w, h)` | Manual `ds_destroy()` required |
+| `ds_list` | `[\| index]` | `ds_list_create()` |
+| `ds_map` | `[? key]` | `ds_map_create()` |
+| `ds_grid` | `[# x, y]` | `ds_grid_create(w, h)` |
+| `ds_stack` | Built-in functions | `ds_stack_create()` |
+| `ds_queue` | Built-in functions | `ds_queue_create()` |
+| `ds_priority` | Built-in functions | `ds_priority_create()` |
 
-DS structures must be manually destroyed or they leak memory. GML documentation recommends arrays and structs instead, where possible.
+DS structures must be manually destroyed with `ds_destroy()` or they leak memory. GML documentation recommends arrays and structs instead, where possible.
 
 ---
 

--- a/docs/GML_REFERENCE.md
+++ b/docs/GML_REFERENCE.md
@@ -412,9 +412,9 @@ No `.length` property - use `array_length(_arr)`.
 ```gml
 function modify(_arr) {
     _arr[@ 1] = 200;    // Bypasses CoW, modifies original
+    _arr[1] = 200;    // Creates a copy, reference lost
 }
 ```
-With CoW enabled, use `@` to modify arrays in-place inside functions, or return the modified copy.
 
 ### Structs
 

--- a/docs/GML_REFERENCE.md
+++ b/docs/GML_REFERENCE.md
@@ -36,7 +36,7 @@ This guide covers the language for developers familiar with JavaScript or other 
 | `/** */` JSDoc | `///` JSDoc |
 | `class` | `function ... constructor` + `new` |
 | `var`, `let`, `const` | `var` only |
-| Block scoping with `let`/`const` | Block scoping: function-level only |
+| Block scoping with `let`/`const` | Function-level only |
 | No preprocessor | `#macro` for compile-time constants |
 | `a.length`, `s.length` | `array_length(a)`, `string_length(s)` |
 | `obj["key"]` | `struct[$ "key"]` |
@@ -45,7 +45,6 @@ This guide covers the language for developers familiar with JavaScript or other 
 | `switch` - fallthrough (uses `break`) | `switch` - fallthrough (uses `break`) |
 | `do...while(condition)` | `do...until(condition)` |
 | no equivalent | `repeat(n) { }` |
-| 0-based array indexing | 0-based array indexing (default) |
 
 ---
 

--- a/docs/GML_REFERENCE.md
+++ b/docs/GML_REFERENCE.md
@@ -6,6 +6,8 @@ This guide covers the language for developers familiar with JavaScript or other 
 
 ## Table of Contents
 
+- [Quick Comparison: GML vs JavaScript](#comparison-gml-vs-javascript)
+- [Asset Types](#asset-types)
 - [Syntax Basics](#syntax-basics)
 - [Variable Scope](#variable-scope)
 - [Variable Categories](#variable-categories)
@@ -13,11 +15,55 @@ This guide covers the language for developers familiar with JavaScript or other 
 - [Constructors](#constructors)
 - [Methods and Binding](#methods-and-binding)
 - [Data Structures and Accessors](#data-structures-and-accessors)
-- [Keywords](#keywords)
 - [Constants and Macros](#constants-and-macros)
-- [Built-in Functions](#built-in-functions)
-- [Assets](#assets)
-- [Comparison: GML vs JavaScript](#comparison-gml-vs-javascript)
+- [Built-in Functions List](#built-in-functions-list)
+- [Keywords List](#keywords-list)
+
+---
+
+## Comparison: GML vs JavaScript
+
+| GML | JavaScript |
+|---|---|
+| `self` | `this` |
+| `struct` | `object` / `{}` |
+| `real` | `number` |
+| `bool` values are `real` (1/0) | distinct `boolean` type |
+| `pointer_null` | `null` |
+| `infinity` | `Infinity` |
+| `typeof(x)` - function | `typeof x` - operator |
+| `instanceof(x, y)` - function | `x instanceof y` - operator |
+| `///` JSDoc | `/** */` JSDoc |
+| `function ... constructor` + `new` | `class` |
+| `var` only | `var`, `let`, `const` |
+| Block scoping: function-level only | Block scoping with `let`/`const` |
+| `#macro` for compile-time constants | No preprocessor |
+| `array_length(a)`, `string_length(s)` | `a.length`, `s.length` |
+| `struct[$ "key"]` | `obj["key"]` |
+| `^^` - logical XOR | `^` - bitwise XOR only |
+| `$` hex prefix | `0x` hex prefix |
+| `switch` - fallthrough (uses `break`) | `switch` - fallthrough (uses `break`) |
+| `do...until(condition)` | `do...while(condition)` |
+| `repeat(n) { }` | no equivalent |
+| 0-based array indexing (default) | 0-based array indexing |
+
+---
+
+## Asset Types
+
+GameMaker projects consist of globally referenceable assets. The primary code-carrying assets:
+
+### Scripts
+
+- Named `.gml` files under `scripts/` in the project.
+- Functions and enums defined at the top level are **globally available** - no import/export statements.
+- Loaded early in boot; function definitions are hoisted before any script statements execute.
+
+### Objects
+
+- Class-like assets from which **Instances** are created at runtime.
+- Have **events** (Create, Step, Draw, Alarm, etc.) where code runs.
+- Objects have built-in instance variables (`x`, `y`, `speed`, `direction`, `image_index`, etc.).
 
 ---
 
@@ -341,6 +387,8 @@ When using explicit binding via `method()`, there are specific rules regarding s
 - `static_set(the_method, struct)` has **no effect** - the static struct of the function behind a method cannot be replaced.
 - Variables attached directly to a method via `.` accessor (e.g. `_bound.tag = "x"`) are stored opaquely - not in the static struct.
 
+---
+
 ## Data Structures and Accessors
 
 ### Arrays
@@ -383,36 +431,6 @@ DS structures must be manually destroyed or they leak memory. GML documentation 
 
 ---
 
-## Keywords
-
-Complete GML keyword list:
-
-```
-and             begin           break           case
-catch           constructor     continue        default
-delete          div             do              else
-end             enum            exit            for
-function        global          globalvar       if
-mod             new             not             or
-repeat          return          static          switch
-then            throw           try             until
-var             while           with            xor
-```
-
-- `begin`/`end` are alternative tokens for `{`/`}`.
-- `globalvar` is deprecated; use `global.` instead.
-
-### Preprocessor Directives
-
-```
-#macro      #region     #endregion
-```
-
-- `#region` / `#endregion` create code-folding blocks in the IDE.
-- `#macro NAME value` - compile-time textual replacement. Can span lines with trailing `\`.
-
----
-
 ## Constants and Macros
 
 ### Enums
@@ -439,7 +457,7 @@ Values start at 0 and auto-increment.
 
 ---
 
-## Built-in Functions
+## Built-in Functions List
 
 Primitives have no internal methods; use library functions instead.
 
@@ -457,46 +475,30 @@ Primitives have no internal methods; use library functions instead.
 
 ---
 
-## Assets
+## Keywords List
 
-GameMaker projects consist of globally referenceable assets. The primary code-carrying assets:
+Complete GML keyword list:
 
-### Scripts
+```
+and             begin           break           case
+catch           constructor     continue        default
+delete          div             do              else
+end             enum            exit            for
+function        global          globalvar       if
+mod             new             not             or
+repeat          return          static          switch
+then            throw           try             until
+var             while           with            xor
+```
 
-- Named `.gml` files under `scripts/` in the project.
-- Functions and enums defined at the top level are **globally available** - no import/export statements.
-- Loaded early in boot; function definitions are hoisted before any script statements execute.
+- `begin`/`end` are alternative tokens for `{`/`}`.
+- `globalvar` is deprecated; use `global.` instead.
 
-### Objects
+### Preprocessor Directives
 
-- Class-like assets from which **Instances** are created at runtime.
-- Have **events** (Create, Step, Draw, Alarm, etc.) where code runs.
-- Objects have built-in instance variables (`x`, `y`, `speed`, `direction`, `image_index`, etc.).
+```
+#macro      #region     #endregion
+```
 
----
-
-## Comparison: GML vs JavaScript
-
-| GML | JavaScript |
-|---|---|
-| `self` | `this` |
-| `struct` | `object` / `{}` |
-| `real` | `number` |
-| `bool` values are `real` (1/0) | distinct `boolean` type |
-| `pointer_null` | `null` |
-| `infinity` | `Infinity` |
-| `typeof(x)` - function | `typeof x` - operator |
-| `instanceof(x, y)` - function | `x instanceof y` - operator |
-| `///` JSDoc | `/** */` JSDoc |
-| `function ... constructor` + `new` | `class` |
-| `var` only | `var`, `let`, `const` |
-| Block scoping: function-level only | Block scoping with `let`/`const` |
-| `#macro` for compile-time constants | No preprocessor |
-| `array_length(a)`, `string_length(s)` | `a.length`, `s.length` |
-| `struct[$ "key"]` | `obj["key"]` |
-| `^^` - logical XOR | `^` - bitwise XOR only |
-| `$` hex prefix | `0x` hex prefix |
-| `switch` - fallthrough (uses `break`) | `switch` - fallthrough (uses `break`) |
-| `do...until(condition)` | `do...while(condition)` |
-| `repeat(n) { }` | no equivalent |
-| 0-based array indexing (default) | 0-based array indexing |
+- `#region` / `#endregion` create code-folding blocks in the IDE.
+- `#macro NAME value` - compile-time textual replacement. Can span lines with trailing `\`.

--- a/docs/GML_REFERENCE.md
+++ b/docs/GML_REFERENCE.md
@@ -296,25 +296,50 @@ var _marine = new Marine("Brother Cassius", "Ultramarines");
 
 ---
 
-## Methods
+## Methods and Binding
 
-A **method** binds a function to a specific context so `self` inside the function refers to that context.
+In GML, a **method** is a function that is bound to a specific context (a struct or instance), meaning `self` inside the function refers to that context. 
+
+There are two ways to create a method:
+
+### 1. Implicit Binding (Standard Methods)
+When you define a function inside a struct or constructor, GML automatically binds it to that struct. This is the standard way to create methods, similar to JavaScript.
 
 ```gml
-var _bound = method(_context, function() {
-    return self.some_value;
-});
+// Using a struct literal
+var _my_struct = {
+    hp = 100,
+    get_hp = function() { return self.hp; }
+};
+
+// Using a constructor (best practice for instances)
+function Player() constructor {
+    hp = 100;
+    
+    // Static ensures the method is created once, not copied per instance
+    static get_hp = function() { 
+        return self.hp; 
+    };
+}
 ```
 
-**Behaviour:**
+### 2. Explicit Binding (The `method()` Function)
+You can explicitly bind an existing, unbound function to a specific context using the built-in `method()` function. This behaves like JavaScript's `Function.prototype.bind()` and is useful for callbacks or assigning methods dynamically.
 
+```gml
+var _context = { name: "Cassius" };
+var _unbound_fn = function() { return self.name; };
+
+var _bound = method(_context, _unbound_fn);
+// _bound() will return "Cassius"
+```
+
+**Quirks of `method()` and Static Structs:**
+When using explicit binding via `method()`, there are specific rules regarding static structs:
 - Methods share the **static struct** of the original function they were created from. Chaining `method()` on a method still shares the original function's static struct.
 - `static_get(the_method)` returns the **actual** static struct of the function behind the method (not a copy).
 - `static_set(the_method, struct)` has **no effect** - the static struct of the function behind a method cannot be replaced.
 - Variables attached directly to a method via `.` accessor (e.g. `_bound.tag = "x"`) are stored opaquely - not in the static struct.
-- Use `self` inside a method to reference the bound context.
-
----
 
 ## Data Structures and Accessors
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reorganized and expanded `docs/GML_REFERENCE.md` to clarify core GML concepts, improve the JS comparison, and add a full guide to method binding. This makes the reference easier to scan and more accurate for everyday use.

- **Refactors**
  - Moved “Comparison: GML vs JavaScript” to the top and made it GML-first.
  - Added “Asset Types” (Scripts, Objects, events, inheritance, built-ins).
  - Expanded “Methods and Binding” with implicit methods, `method()` binding, static struct quirks, and examples.
  - Clarified array copy‑on‑write and accessors (`[@]` vs normal indexing) with a practical example.
  - Updated legacy DS structures; added `ds_stack`, `ds_queue`, `ds_priority`; noted required `ds_destroy()`.
  - Split and renamed sections: “Built‑in Functions List” and “Keywords List” (with preprocessor directives).

<sup>Written for commit 156b49b98dc907a870349efa4c38537cafa34c4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

