### PR TITLE
ci: Cron autoformat; OpenCode bump

### DIFF
--- a/.github/workflows/gobo_format.yml
+++ b/.github/workflows/gobo_format.yml
@@ -1,6 +1,8 @@
 name: Gobo Formatter
 
 on:
+  schedule:
+    - cron: "0 3 * * 1"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -33,7 +33,7 @@ jobs:
           persist-credentials: false
 
       - name: Run OpenCode
-        uses: anomalyco/opencode/github@v1.18.4
+        uses: anomalyco/opencode/github@v1.18.7
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
         with:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a weekly Monday 03:00 UTC cron trigger to the Gobo Formatter workflow. Update the OpenCode action to `anomalyco/opencode/github@v1.18.7`.

<sup>Written for commit 5f431576bb9eadad1ff3f9dc37c3afd0dc82d4b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

