### PR TITLE
fix: TTRPG sentinel and sprite prefetch

### DIFF
--- a/scripts/ColourItem/ColourItem.gml
+++ b/scripts/ColourItem/ColourItem.gml
@@ -6,7 +6,14 @@ function fetch_marine_components_to_memory() {
                 if (struct_exists(_element, "overides")) {
                     var _override_areas = struct_get_names(_element.overides);
                     for (var i = 0; i < array_length(_override_areas); i++) {
-                        sprite_prefetch(_element.overides[$ _override_areas[i]]);
+                        var _override_val = _element.overides[$ _override_areas[i]];
+                        if (is_struct(_override_val)) {
+                            if (struct_exists(_override_val, "sprite") && sprite_exists(_override_val.sprite)) {
+                                sprite_prefetch(_override_val.sprite);
+                            }
+                        } else if (sprite_exists(_override_val)) {
+                            sprite_prefetch(_override_val);
+                        }
                     }
                 }
             }

--- a/scripts/scr_UnitGroup/scr_UnitGroup.gml
+++ b/scripts/scr_UnitGroup/scr_UnitGroup.gml
@@ -611,6 +611,9 @@ function collect_role_group(group = SPECIALISTS_STANDARD, location = "", opposit
                 break;
             }
             _unit = fetch_unit([com, i]);
+            if (!is_struct(_unit)) {
+                continue;
+            }
 
             if (_conditions.evaluate(_unit)) {
                 array_push(_units, _unit);
@@ -777,9 +780,11 @@ function SearchConditions(data) constructor {
 
     static evaluate = function(unit) {
         self.unit = unit;
-        if (unit.name() == "") {
-            unit.base_group = "none";
-            // LOGGER.error($"Empty name! Unit:\n{unit}");
+        if (!is_struct(unit) || unit.name() == "") {
+            if (is_struct(unit)) {
+                unit.base_group = "none";
+                // LOGGER.error($"Empty name! Unit:\n{unit}");
+            }
             return false;
         }
 

--- a/scripts/scr_fleet_advisor/scr_fleet_advisor.gml
+++ b/scripts/scr_fleet_advisor/scr_fleet_advisor.gml
@@ -23,7 +23,9 @@ function scr_fleet_advisor() {
         return;
     }
     var cn = id;
-    
+
+    var _blurp = "";
+
     if (menu_adept == 0) {
         if (struct_exists(ini.custom_advisors, "admiral")) {
             scr_image("advisor/splash", ini.custom_advisors.admiral, xx + 16, yy + 43, 310, 828);
@@ -36,7 +38,7 @@ function scr_fleet_advisor() {
         draw_text_transformed(xx + 352, yy + 66, "Flagship Bridge", 1, 1, 0);
         draw_text_transformed(xx + 352, yy + 100, $"Master of the Fleet {ini.lord_admiral_name}", 0.6, 0.6, 0);
         draw_set_font(fnt_40k_14);
-        blurp = "Greetings, Chapter Master.\n\nYou requested a report?  Our fleet contains ";
+        _blurp = "Greetings, Chapter Master.\n\nYou requested a report?  Our fleet contains ";
     }
     if (menu_adept == 1) {
         scr_image("advisor/splash", 1, xx + 16, yy + 43, 310, 828);
@@ -46,38 +48,38 @@ function scr_fleet_advisor() {
         draw_text_transformed(xx + 352, yy + 40, "Flagship Bridge", 1, 1, 0);
         draw_text_transformed(xx + 352, yy + 100, $"Adept {cn.adept_name}", 0.6, 0.6, 0);
         draw_set_font(fnt_40k_14);
-        blurp = "Your fleet contains ";
+        _blurp = "Your fleet contains ";
     }
 
-    blurp += string(temp[37]) + " Capital Ships, ";
-    blurp += string(temp[38]) + " Frigates, and ";
-    blurp += string(temp[39]) + " Escorts";
+    _blurp += string(temp[37]) + " Capital Ships, ";
+    _blurp += string(temp[38]) + " Frigates, and ";
+    _blurp += string(temp[39]) + " Escorts";
 
-    va = real(temp[41]);
+    var _hull_normalized = real(temp[41]);
 
-    if (va >= 1) {
-        blurp += ", none of which are damaged.";
-    }
-    if (va < 1) {
-        blurp += $".  Our most damaged vessel is the {temp[40]} - it has {min(99, round(va * 100))}% Hull Integrity.";
+    if (_hull_normalized >= 1) {
+        _blurp += ", none of which are damaged.";
+    } else if (_hull_normalized < 1) {
+        _blurp += $".  Our most damaged vessel is the {temp[40]} - it has {min(99, round(_hull_normalized * 100))}% Hull Integrity.";
     }
 
-    va = real(temp[42]);
-    if (va == 2) {
-        blurp += "  Two of our ships are highly damaged.  You may wish to purchase a Repair License from the Sector Governerner.";
+    var _crippled_ships = real(temp[42]);
+
+    if (_crippled_ships == 2) {
+        _blurp += "  Two of our ships are highly damaged.  You may wish to purchase a Repair License from the Sector Governerner.";
+    } else if (_crippled_ships > 2) {
+        _blurp += "  Several of our ships are highly damaged.  It is advisable that you purchase a Repair License from the Sector Governer.";
     }
-    if (va > 2) {
-        blurp += "  Several of our ships are highly damaged.  It is advisable that you purchase a Repair License from the Sector Governer.";
-    }
-    blurp += "\n\nHere are the current positions of our ships and their contents:";
+
+    _blurp += "\n\nHere are the current positions of our ships and their contents:";
 
     if (menu_adept == 1) {
-        blurp = string_replace(blurp, "Our", "Your");
-        blurp = string_replace(blurp, " our", " your");
-        blurp = string_replace(blurp, "We", "You");
+        _blurp = string_replace(_blurp, "Our", "Your");
+        _blurp = string_replace(_blurp, " our", " your");
+        _blurp = string_replace(_blurp, "We", "You");
     }
 
-    draw_text_ext(xx + 352, yy + 130, blurp, -1, 536);
+    draw_text_ext(xx + 352, yy + 130, _blurp, -1, 536);
 
     draw_set_font(fnt_40k_30b);
     draw_set_halign(fa_center);

--- a/scripts/scr_role_count/scr_role_count.gml
+++ b/scripts/scr_role_count/scr_role_count.gml
@@ -35,7 +35,7 @@ function scr_role_count(target_role, search_location = "", return_type = "count"
     if (coom >= 0) {
         for (var i = 0; i < array_length(obj_ini.TTRPG[coom]); i++) {
             var unit = obj_ini.TTRPG[coom][i];
-            if (unit.name() == "") {
+            if (!is_struct(unit) || unit.name() == "") {
                 continue;
             }
             if ((unit.role() == target_role) && (obj_ini.god[coom][i] < 10)) {
@@ -52,7 +52,7 @@ function scr_role_count(target_role, search_location = "", return_type = "count"
             for (var i = 0; i < array_length(obj_ini.TTRPG[com]); i++) {
                 var match = false;
                 var unit = fetch_unit([com, i]);
-                if (unit.name() == "") {
+                if (!is_struct(unit) || unit.name() == "") {
                     continue;
                 }
                 if ((unit.role() == target_role) && (search_location == "")) {

--- a/scripts/scr_unit_quick_find_pane/scr_unit_quick_find_pane.gml
+++ b/scripts/scr_unit_quick_find_pane/scr_unit_quick_find_pane.gml
@@ -73,7 +73,7 @@ function UnitQuickFindPanel() constructor {
     };
 
     static evaluate_unit_for_garrison_log = function(unit) {
-        if (unit.name() == "" || !unit.controllable()) {
+        if (!is_struct(unit) || unit.name() == "" || !unit.controllable()) {
             return;
         }
         var unit_location = unit.marine_location();
@@ -135,6 +135,10 @@ function UnitQuickFindPanel() constructor {
                 for (var u = 0; u < array_length(obj_ini.TTRPG[co]); u++) {
                     /// @type {Struct.TTRPG_stats}
                     var _unit = fetch_unit([co, u]);
+                    if (!is_struct(_unit)) {
+                        continue;
+                    }
+
                     evaluate_unit_for_garrison_log(_unit);
                 }
                 try {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes crashes and log spam by guarding against undefined TTRPG units and making sprite override prefetch robust. Also cleans up `scr_fleet_advisor` variable handling with no behavior changes.

- **Bug Fixes**
  - Validate TTRPG units before use in role counting, grouping, and quick-find; skip non-structs or empty `name()`.
  - Prefetch sprite overrides safely for structs with `sprite` or direct ids; only when `sprite_exists`.

- **Refactors**
  - Tidy `scr_fleet_advisor`: use local `_blurp`, clearer var names (`_hull_normalized`, `_crippled_ships`), and consolidated branching; no behavior change.

<sup>Written for commit b28ae086ef072842d75cbea893e955f523f8b755. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

