### PR TITLE
ci: Update opencode permissions and model

### DIFF
--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -24,7 +24,6 @@
       "permission": {
         "doom_loop": "deny",
         "external_directory": "deny",
-        "edit": "deny",
         "lsp": "deny",
         "question": "deny"
       }

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -3,7 +3,6 @@
   "agent": {
     "pr_review": {
       "mode": "primary",
-      "model": "opencode/deepseek-v4-flash-free",
       "permission": {
         "doom_loop": "deny",
         "external_directory": "deny",
@@ -11,7 +10,25 @@
         "lsp": "deny",
         "question": "deny"
       }
-    }
+    },
+    "explore": {
+      "permission": {
+        "doom_loop": "deny",
+        "external_directory": "deny",
+        "edit": "deny",
+        "lsp": "deny",
+        "question": "deny"
+      }
+    },
+    "general": {
+      "permission": {
+        "doom_loop": "deny",
+        "external_directory": "deny",
+        "edit": "deny",
+        "lsp": "deny",
+        "question": "deny"
+      }
+    },
   },
   "compaction": {
     "auto": true,
@@ -21,8 +38,8 @@
   "formatter": false,
   "instructions": [
     "docs/GML_REFERENCE.md",
-    "docs/CODE_STYLE.md",
-    "docs/AGENTS.md"
+    "docs/CODE_STYLE.md"
   ],
-  "snapshot": false
+  "snapshot": false,
+  "model": "opencode/deepseek-v4-flash-free"
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Centralized the model config in `opencode.jsonc`, aligned agent permissions, and simplified docs inputs. `general` now has edit permission enabled.

- **Refactors**
  - Moved model to root: `opencode/deepseek-v4-flash-free` (removed `agent.pr_review` override).
  - Added `agent.explore` (deny all) and `agent.general` (edit allowed; other actions denied).
  - Removed `docs/AGENTS.md` from `instructions`.

<sup>Written for commit c5e8055ab12b9c424e21dce8ded8e4f457f7f1ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

