### PR TITLE
fix: fetch_unit guardrails

### DIFF
--- a/objects/obj_controller/Alarm_5.gml
+++ b/objects/obj_controller/Alarm_5.gml
@@ -292,6 +292,7 @@ try {
         for (var e = 0; e < array_length(obj_ini.god[c]); e++) {
             if (obj_ini.god[c][e] == 10) {
                 var unit = fetch_unit([c, e]);
+                if (!is_struct(unit)) { continue; }
                 p += 1;
                 penit_co[p] = c;
                 penit_id[p] = e;

--- a/objects/obj_dropdown_sel/Step_0.gml
+++ b/objects/obj_dropdown_sel/Step_0.gml
@@ -126,6 +126,7 @@ if ((target == "event_loc") && (determined_planets == 0)) {
     for (var coo = 0; coo <= 10; coo++) {
         for (var ide = 1; ide <= 300; ide++) {
             var _unit = fetch_unit([coo, ide]);
+            if (!is_struct(_unit)) { continue; }
             if ((_unit.role() != obj_ini.role[100][6]) && (_unit.role() != "Venerable " + string(obj_ini.role[100][6])) && (_unit.planet_location > 0)) {
                 var stahp = 0;
                 var first_open = 0;

--- a/objects/obj_en_fleet/Alarm_1.gml
+++ b/objects/obj_en_fleet/Alarm_1.gml
@@ -166,6 +166,7 @@ try {
                             }
                             if ((ca >= 0) && (ca < 11)) {
                                 _unit = fetch_unit([ca, ia]);
+                                if (!is_struct(_unit)) { continue; }
                                 if ((_unit.location_string == cur_star.name) && (_unit.planet_location > 0)) {
                                     if ((_unit.role() == "Ork Sniper") && (obj_ini.race[ca][ia] != 1)) {
                                         tem1_base = 3;

--- a/objects/obj_event/Create_0.gml
+++ b/objects/obj_event/Create_0.gml
@@ -14,31 +14,30 @@ closing = false;
 
 attendants = 0;
 avatars = 0;
-for (var i = 0; i <= 2500; i++) {
-    attend_co[i] = 0;
-    attend_id[i] = 0;
-    attend_mood[i] = "";
-    attend_corrupted[i] = 0;
-    attend_feasted[i] = 0;
-    attend_drunk[i] = 0;
-    attend_high[i] = 0;
-    attend_confused[i] = 0;
-    attend_actioned[i] = 0;
-    attend_corruption[i] = 0;
-    attend_race[i] = 0;
-    attend_displayed[i] = 0; // Set to 1
 
-    if (i <= 10) {
-        avatar_name[i] = "";
-        avatar_rank[i] = "";
-        avatar_image[i] = 0;
-        avatar_co[i] = 0;
-        avatar_id[i] = 0;
-    }
-    if (i <= 20) {
-        line[i] = "";
-    }
-}
+var _array_size = 2501;
+
+attend_co = array_create(_array_size, 0);
+attend_id = array_create(_array_size, 0);
+attend_mood = array_create(_array_size, "");
+attend_corrupted = array_create(_array_size, 0);
+attend_feasted = array_create(_array_size, 0);
+attend_drunk = array_create(_array_size, 0);
+attend_high = array_create(_array_size, 0);
+attend_confused = array_create(_array_size, 0);
+attend_actioned = array_create(_array_size, 0);
+attend_corruption = array_create(_array_size, 0);
+attend_race = array_create(_array_size, 0);
+attend_displayed = array_create(_array_size, 0);
+
+avatar_name = array_create(_array_size, "");
+avatar_rank = array_create(_array_size, "");
+avatar_image = array_create(_array_size, 0);
+avatar_co = array_create(_array_size, 0);
+avatar_id = array_create(_array_size, 0);
+
+line = array_create(_array_size, "");
+
 lines = 0;
 
 main_color = obj_ini.main_color;

--- a/objects/obj_event/Step_0.gml
+++ b/objects/obj_event/Step_0.gml
@@ -26,7 +26,7 @@ if ((closing == true) && (fading == -1) && (fade_alpha <= 0)) {
     }
 
     for (var ide = 1; ide <= 700; ide++) {
-        var unit = obj_ini.TTRPG[attend_co[ide]][attend_id[ide]];
+        var unit = fetch_unit([attend_co[ide], attend_id[ide]]); if (!is_struct(unit)) { continue; }
         if ((attend_corrupted[ide] == 0) && (attend_id[ide] > 0)) {
             if (array_contains(obj_ini.artifact_tags[obj_controller.fest_display], "chaos")) {
                 unit.corruption += choose(1, 2, 3, 4);
@@ -110,7 +110,7 @@ if (ticked == 1) {
     }
 
     var ide = floor(random(attendants)) + 1;
-    var unit = obj_ini.TTRPG[attend_co[ide]][attend_id[ide]];
+    var unit = fetch_unit([attend_co[ide], attend_id[ide]]); if (!is_struct(unit)) { ticked = 0; exit; }
     var textt = "";
     var doso = false;
     var activity = "";

--- a/objects/obj_event/Step_0.gml
+++ b/objects/obj_event/Step_0.gml
@@ -26,16 +26,21 @@ if ((closing == true) && (fading == -1) && (fade_alpha <= 0)) {
     }
 
     for (var ide = 1; ide <= 700; ide++) {
-        var unit = fetch_unit([attend_co[ide], attend_id[ide]]); if (!is_struct(unit)) { continue; }
-        if ((attend_corrupted[ide] == 0) && (attend_id[ide] > 0)) {
-            if (array_contains(obj_ini.artifact_tags[obj_controller.fest_display], "chaos")) {
-                unit.corruption += choose(1, 2, 3, 4);
-            }
-            if (array_contains(obj_ini.artifact_tags[obj_controller.fest_display], "daemonic")) {
-                unit.corruption += choose(6, 7, 8, 9);
-            }
-            attend_corrupted[ide] = 1;
+        var unit = fetch_unit([attend_co[ide], attend_id[ide]]);
+    
+        if (!is_struct(unit) || attend_corrupted[ide] != 0 || attend_id[ide] <= 0) {
+            continue;
         }
+
+        if (array_contains(obj_ini.artifact_tags[obj_controller.fest_display], "chaos")) {
+            unit.corruption += choose(1, 2, 3, 4);
+        }
+
+        if (array_contains(obj_ini.artifact_tags[obj_controller.fest_display], "daemonic")) {
+            unit.corruption += choose(6, 7, 8, 9);
+        }
+    
+        attend_corrupted[ide] = 1;
     }
 
     obj_controller.fest_repeats -= 1;

--- a/objects/obj_mass_equip/Step_0.gml
+++ b/objects/obj_mass_equip/Step_0.gml
@@ -12,6 +12,7 @@ try {
                 for (var i = 0; i < array_length(obj_ini.role[co]); i++) {
                     if (obj_ini.role[co][i] == obj_ini.role[100][role]) {
                         var _unit = fetch_unit([co, i]);
+                        if (!is_struct(_unit)) { continue; }
                         if (_unit.squad != "none") {
                             var _squad = fetch_squad(_unit.squad);
                             if (!_squad.allow_bulk_swap) {

--- a/objects/obj_ncombat/Alarm_7.gml
+++ b/objects/obj_ncombat/Alarm_7.gml
@@ -55,13 +55,18 @@ try {
                 var master_present = 0;
 
                 var master_index = array_get_index(obj_ini.role[0], obj_ini.role[100][eROLE.CHAPTERMASTER]);
-                var chaos_meeting = fetch_unit([0, master_index]).planet_location;
+                var _fetched_chaos = fetch_unit([0, master_index]);
+                if (!is_struct(_fetched_chaos)) {
+                    LOGGER.error($"fetch_unit guardrail triggered for chapter master [0, {master_index}] in cs_meeting post-battle");
+                    exit;
+                }
+                var chaos_meeting = _fetched_chaos.planet_location;
 
                 for (var co = 0; co <= 10; co++) {
                     for (var i = 0; i < array_length(obj_ini.TTRPG[co]); i++) {
                         var good = 0;
-                        _unit = fetch_unit([co, i]);
-                        if (_unit.role() == "" || _unit.location_string != name) {
+                        var _unit = fetch_unit([co, i]);
+                        if (!is_struct(_unit) || _unit.role() == "" || _unit.location_string != name) {
                             continue;
                         }
                         if (_unit.planet_location == floor(chaos_meeting)) {

--- a/objects/obj_p_assra/Alarm_0.gml
+++ b/objects/obj_p_assra/Alarm_0.gml
@@ -4,6 +4,7 @@ for (o = 0; o < array_length(origin.board_co); o++) {
     co = origin.board_co[o];
     i = origin.board_id[o];
     unit = fetch_unit([co, i]);
+    if (!is_struct(unit)) { continue; }
     if ((unit.hp() <= -15) && (obj_ini.race[co][i] == 1) && (unit.name() != "")) {
         var seed_lost = 0;
         if (apothecary <= 0) {

--- a/objects/obj_p_assra/Step_0.gml
+++ b/objects/obj_p_assra/Step_0.gml
@@ -120,6 +120,7 @@ if ((boarding == true) && (board_cooldown >= 0) && instance_exists(target) && in
             ac = 0;
             dr = 1;
             unit = fetch_unit([co, i]);
+            if (!is_struct(unit)) { continue; }
             gear_bonus = 0;
             marine_bonus = 0;
             boarding_odds = 50;
@@ -571,7 +572,7 @@ if ((boarding == true) && (board_cooldown >= 0) && instance_exists(target) && in
             for (var o = 0; o < array_length(origin.board_co); o++) {
                 co = origin.board_co[o];
                 i = origin.board_id[o];
-                unit = obj_ini.TTRPG[co][i];
+                unit = fetch_unit([co, i]); if (!is_struct(unit)) { continue; }
                 unit_exp = unit.experience;
                 exp_roll = irandom(150 + unit_exp) + 1;
                 if (exp_roll >= unit_exp) {

--- a/objects/obj_p_ship/Alarm_0.gml
+++ b/objects/obj_p_ship/Alarm_0.gml
@@ -190,6 +190,7 @@ for (var co = 0; co <= obj_ini.companies; co++) {
             continue;
         }
         var unit = fetch_unit([co, i]);
+        if (!is_struct(unit)) { continue; }
         if (unit.ship_location == ship_id) {
             if (unit.is_boarder && unit.hp() > (unit.max_health() / 10)) {
                 array_push(board_co, co);

--- a/objects/obj_popup/Destroy_0.gml
+++ b/objects/obj_popup/Destroy_0.gml
@@ -59,7 +59,7 @@ if (instance_exists(obj_controller)) {
             with (obj_star) {
                 if (string_count(name, scr_master_loc()) > 0) {
                     meeting_star = self.id;
-                    meeting_planet = obj_ini.TTRPG[0][1].planet_location;
+                    var _fetched = fetch_unit([0, 1]); meeting_planet = is_struct(_fetched) ? _fetched.planet_location : 0;
                 }
             }
         }

--- a/objects/obj_popup/Step_0.gml
+++ b/objects/obj_popup/Step_0.gml
@@ -156,10 +156,10 @@ try {
                         ide += 1;
                         if ((attend_corrupted[ide] == 0) && (attend_id[ide] > 0)) {
                             if (string_count("chaos", obj_ini.artifact_tags[obj_controller.fest_display]) > 0) {
-                                obj_ini.TTRPG[attend_co[ide]][attend_id[ide]].corruption += choose(1, 2, 3, 4);
+                                var _unit = fetch_unit([attend_co[ide], attend_id[ide]]); if (is_struct(_unit)) { _unit.corruption += choose(1, 2, 3, 4); }
                             }
                             if (string_count("daemonic", obj_ini.artifact_tags[obj_controller.fest_display]) > 0) {
-                                obj_ini.TTRPG[attend_co[ide]][attend_id[ide]].corruption += choose(6, 7, 8, 9);
+                                var _unit = fetch_unit([attend_co[ide], attend_id[ide]]); if (is_struct(_unit)) { _unit.corruption += choose(6, 7, 8, 9); }
                             }
                             attend_corrupted[ide] = 1;
                         }

--- a/scripts/scr_UnitGroup/scr_UnitGroup.gml
+++ b/scripts/scr_UnitGroup/scr_UnitGroup.gml
@@ -862,7 +862,7 @@ function collect_by_religeon(religion, sub_cult = "", location = "") {
     for (var com = 0; com <= obj_ini.companies; com++) {
         for (var i = 1; i < array_length(obj_ini.TTRPG[com]); i++) {
             _add = false;
-            _unit = obj_ini.TTRPG[com][i];
+            _unit = fetch_unit([com, i]); if (!is_struct(_unit)) { continue; }
             if (_unit.name() == "") {
                 LOGGER.error($"Empty name! Unit:\n{_unit}");
                 continue;

--- a/scripts/scr_add_artifact/scr_add_artifact.gml
+++ b/scripts/scr_add_artifact/scr_add_artifact.gml
@@ -516,6 +516,7 @@ function ArtifactStruct(Index) constructor {
             if (equipped() && is_array(bearer)) {
                 var _b_type = determine_base_type();
                 var unit = fetch_unit(bearer);
+                if (!is_struct(unit)) { return; }
                 if (_b_type == "weapon") {
                     if (unit.weapon_one(true) == index) {
                         unit.update_weapon_one("", false, true);
@@ -539,6 +540,7 @@ function ArtifactStruct(Index) constructor {
                     for (var co = 0; co < obj_ini.companies; co++) {
                         for (var i = 0; i < array_length(obj_ini.role[co]); i++) {
                             var _unit = fetch_unit([co, i]);
+                            if (!is_struct(_unit)) { continue; }
                             if (_unit.weapon_one(true) == index) {
                                 _unit.update_weapon_one("", false, true);
                                 _bearer_found = true;
@@ -571,6 +573,7 @@ function ArtifactStruct(Index) constructor {
                         for (var co = 0; co < obj_ini.companies; co++) {
                             for (var i = 0; i < array_length(obj_ini.role[co]); i++) {
                                 var _unit = fetch_unit([co, i]);
+                                if (!is_struct(_unit)) { continue; }
                                 if (_unit[$ _find_function](true) == index) {
                                     _unit[$ _update_function]("", false, true);
                                     _bearer_found = true;

--- a/scripts/scr_add_artifact/scr_add_artifact.gml
+++ b/scripts/scr_add_artifact/scr_add_artifact.gml
@@ -275,6 +275,11 @@ function artifact_has_tag(index, wanted_tag) {
 //TODO make a proper artifact struct
 function ArtifactStruct(Index) constructor {
     index = Index;
+    custom_data = {};
+    name = "";
+    custom_description = "";
+    bearer = false;
+
 
     static type = function() {
         return obj_ini.artifact[index];
@@ -294,12 +299,13 @@ function ArtifactStruct(Index) constructor {
     };
 
     static can_equip = function() {
-        _can_equip = true;
+        var _can_equip = true;
         var none_equips = [
             "Statue",
             "Casket",
             "Chalice",
             "Robot",
+            "Tome"
         ];
         if (array_contains(none_equips, type())) {
             _can_equip = false;
@@ -512,88 +518,94 @@ function ArtifactStruct(Index) constructor {
     };
 
     static unequip_from_unit = function() {
+        if (!equipped()) {
+            bearer = false;
+            return;
+        }
+    
         try {
-            if (equipped() && is_array(bearer)) {
-                var _b_type = determine_base_type();
-                var unit = fetch_unit(bearer);
-                if (!is_struct(unit)) { return; }
-                if (_b_type == "weapon") {
-                    if (unit.weapon_one(true) == index) {
-                        unit.update_weapon_one("", false, true);
-                    } else if (unit.weapon_two(true) == index) {
-                        unit.update_weapon_two("", false, true);
-                    }
-                } else if (_b_type == "gear") {
-                    unit.update_gear("", false, true);
-                } else if (_b_type == "armour") {
-                    unit.update_armour("", false, true);
-                } else if (_b_type == "mobility") {
-                    unit.update_mobility_item("", false, true);
+            var _type = determine_base_type();
+    
+            if (is_array(bearer)) {
+                var _unit = fetch_unit(bearer);
+                if (is_struct(_unit)) {
+                    unequip_from_single_unit(_unit, _type);
                 }
-                bearer = false;
-                obj_ini.artifact_equipped[index] = false;
-            } else if (equipped()) {
-                var _b_type = determine_base_type();
-                var _bearer = false;
-                var _bearer_found = false;
-                if (_b_type == "weapon") {
-                    for (var co = 0; co < obj_ini.companies; co++) {
-                        for (var i = 0; i < array_length(obj_ini.role[co]); i++) {
-                            var _unit = fetch_unit([co, i]);
-                            if (!is_struct(_unit)) { continue; }
-                            if (_unit.weapon_one(true) == index) {
-                                _unit.update_weapon_one("", false, true);
-                                _bearer_found = true;
-                            } else if (_unit.weapon_two(true) == index) {
-                                _unit.update_weapon_two("", false, true);
-                                _bearer_found = true;
-                            }
-                            if (_bearer_found) {
-                                break;
-                            }
-                        }
-                        if (_bearer_found) {
-                            break;
-                        }
-                    }
-                } else {
-                    var _find_function = "";
-                    var _update_function = "";
-                    if (_b_type == "gear") {
-                        _update_function = "update_gear";
-                        _find_function = "gear";
-                    } else if (_b_type == "armour") {
-                        _update_function = "update_armour";
-                        _find_function = "armour";
-                    } else if (_b_type == "mobility") {
-                        _update_function = "update_mobility_item";
-                        _find_function = "mobility_item";
-                    }
-                    if (_find_function != "") {
-                        for (var co = 0; co < obj_ini.companies; co++) {
-                            for (var i = 0; i < array_length(obj_ini.role[co]); i++) {
-                                var _unit = fetch_unit([co, i]);
-                                if (!is_struct(_unit)) { continue; }
-                                if (_unit[$ _find_function](true) == index) {
-                                    _unit[$ _update_function]("", false, true);
-                                    _bearer_found = true;
-                                }
-                                if (_bearer_found) {
-                                    break;
-                                }
-                            }
-                            if (_bearer_found) {
-                                break;
-                            }
-                        }
-                    }
-                }
+            } else {
+                search_and_unequip_from_all_units(_type);
             }
         } catch (_exception) {
             ERROR_HANDLER.handle_exception(_exception);
         }
+    
         bearer = false;
         obj_ini.artifact_equipped[index] = false;
+    };
+    
+    /// @desc Unequip from a single unit. Returns true if something was unequipped.
+    /// @param {Struct.TTRPG_stats} _unit
+    /// @param {String} _type
+    /// @return {Bool} Returns true if something was unequipped.
+    static unequip_from_single_unit = function(_unit, _type, _check_equipped = true) {
+        switch (_type) {
+            case "weapon":
+                if (_unit.weapon_one() == type()) {
+                    _unit.update_weapon_one("", false, true);
+                    return true;
+                } else if (_unit.weapon_two() == type()) {
+                    _unit.update_weapon_two("", false, true);
+                    return true;
+                }
+    
+                return false;
+                break;
+            case "gear":
+                if (_check_equipped && _unit.gear() != type()) {
+                    return false;
+                }
+    
+                _unit.update_gear("", false, true);
+                return true;
+                break;
+            case "armour":
+                if (_check_equipped && _unit.armour() != type()) {
+                    return false;
+                }
+    
+                _unit.update_armour("", false, true);
+                return true;
+                break;
+            case "mobility":
+                if (_check_equipped && _unit.mobility_item() != type()) {
+                    return false;
+                }
+    
+                _unit.update_mobility_item("", false, true);
+                return true;
+                break;
+        }
+    
+        return false;
+    };
+    
+    /// @desc Search all units across companies and unequip the first match
+    /// @param {String} _type
+    /// @return {Bool} Returns true if something was unequipped.
+    static search_and_unequip_from_all_units = function(_type) {
+        for (var co = 0; co < obj_ini.companies; co++) {
+            for (var i = 0; i < array_length(obj_ini.role[co]); i++) {
+                var _unit = fetch_unit([co, i]);
+                if (!is_struct(_unit)) {
+                    continue;
+                }
+    
+                if (unequip_from_single_unit(_unit, _type)) {
+                    return true;
+                }
+            }
+        }
+    
+        return false;
     };
 
     static equip_on_unit = function(unit, slot = -1) {
@@ -628,11 +640,6 @@ function ArtifactStruct(Index) constructor {
             obj_controller.cooldown = 8;
         }
     };
-
-    custom_data = {};
-    name = "";
-    custom_description = "";
-    bearer = false;
 
     static assign_text_from_tag_match = function(text_set) {
         var _return_text = "";

--- a/scripts/scr_add_corruption/scr_add_corruption.gml
+++ b/scripts/scr_add_corruption/scr_add_corruption.gml
@@ -27,6 +27,7 @@ function scr_add_corruption(is_fleet, modifier_type) {
                     continue;
                 }
                 var unit = fetch_unit([co, i]);
+                if (!is_struct(unit)) { continue; }
                 if (array_contains(ships, unit.ship_location)) {
                     if (modifier_type == "1d3") {
                         unit.edit_corruption(choose(1, 2, 3));

--- a/scripts/scr_bionics_count/scr_bionics_count.gml
+++ b/scripts/scr_bionics_count/scr_bionics_count.gml
@@ -15,6 +15,7 @@ function scr_bionics_count(argument0, argument1, argument2, argument3) {
         repeat (300) {
             i += 1;
             var _unit = fetch_unit([com, i]);
+            if (!is_struct(_unit)) { continue; }
             if (argument0 == "star") {
                 if ((obj_ini.race[com][i] == 1) && (_unit.location_string == argument1) && (_unit.planet_location == argument2)) {
                     if (argument3 == "total") {

--- a/scripts/scr_boarding_actions/scr_boarding_actions.gml
+++ b/scripts/scr_boarding_actions/scr_boarding_actions.gml
@@ -20,6 +20,7 @@ function create_boarding_craft(target_ship) {
             boarders -= 1;
             bear.boarders += 1;
             unit = fetch_unit([board_co[o], board_id[o]]);
+            if (!is_struct(unit)) { continue; }
             if (unit.IsSpecialist(SPECIALISTS_APOTHECARIES)) {
                 if ((unit.gear() == "Narthecium") && (unit.hp() >= 10)) {
                     bear.apothecary += 1;

--- a/scripts/scr_check_equip/scr_check_equip.gml
+++ b/scripts/scr_check_equip/scr_check_equip.gml
@@ -16,6 +16,7 @@ function scr_check_equip(search_item, system, planet_or_ship_id, remove_item) {
             marine_present = false;
             if (!instance_exists(obj_ncombat)) {
                 unit = fetch_unit([c, i]);
+                if (!is_struct(unit)) { continue; }
                 if ((system != "") && (planet_or_ship_id > 0)) {
                     if (unit.is_at_location(system, planet_or_ship_id, -1)) {
                         marine_present = true;

--- a/scripts/scr_civil_roster/scr_civil_roster.gml
+++ b/scripts/scr_civil_roster/scr_civil_roster.gml
@@ -105,7 +105,7 @@ function scr_civil_roster(_unit_location, _target_location, _is_planet) {
                         va = obj_temp_meeting.ide[v];
                     }
                 }
-                unit = obj_ini.TTRPG[cooh][va];
+                unit = fetch_unit([cooh, va]); if (!is_struct(unit)) { continue; }
 
                 // Chaos corruption check here
                 if (new_combat.battle_special == "cs_meeting_battle1") {

--- a/scripts/scr_company_struct/scr_company_struct.gml
+++ b/scripts/scr_company_struct/scr_company_struct.gml
@@ -379,7 +379,10 @@ function CompanyStruct(comp) constructor {
             current_squad = (current_squad - 1 < 0) ? array_length(company_squads) - 1 : current_squad - 1;
         }
         var _member = grab_current_squad().members[0];
-        obj_controller.unit_focus = fetch_unit(_member);
+        var _fetched = fetch_unit(_member);
+        if (is_struct(_fetched)) {
+            obj_controller.unit_focus = _fetched;
+        }
     };
     squad_search();
 
@@ -454,7 +457,10 @@ function CompanyStruct(comp) constructor {
 
     static default_member = function() {
         var _member = company_squads[0].members[0];
-        obj_controller.unit_focus = fetch_unit(_member);
+        var _fetched = fetch_unit(_member);
+        if (is_struct(_fetched)) {
+            obj_controller.unit_focus = _fetched;
+        }
         selected_unit = obj_controller.unit_focus;
     };
 
@@ -545,7 +551,8 @@ function CompanyStruct(comp) constructor {
         //should be moved elsewhere for efficiency
         squad_leader = _cur_squad.determine_leader();
         if (squad_leader != "none") {
-            var leader_text = $"Squad Leader : {fetch_unit(squad_leader).name_role()}";
+            var _fetched = fetch_unit(squad_leader);
+            var leader_text = is_struct(_fetched) ? $"Squad Leader : {_fetched.name_role()}" : "Squad Leader : Unknown";
             draw_text_transformed(xx + bound_width[0] + 5, yy + bound_height[0] + 50, leader_text, 1, 1, 0);
         }
         squad_loc = _cur_squad.squad_loci();

--- a/scripts/scr_company_view/scr_company_view.gml
+++ b/scripts/scr_company_view/scr_company_view.gml
@@ -153,7 +153,7 @@ function scr_company_view(company) {
     for (var v = 0; v < company_length; v++) {
         unit = fetch_unit([company, v]);
 
-        if (unit.name() != "") {
+        if (is_struct(unit) && unit.name() != "") {
             unit_loc = unit.marine_location();
 
             // Check if unit is on a lost ship

--- a/scripts/scr_count_forces/scr_count_forces.gml
+++ b/scripts/scr_count_forces/scr_count_forces.gml
@@ -1,38 +1,47 @@
-function scr_count_forces(_unit_location, _target_location, _is_planet, instance = false) {
-    if (_is_planet) {
-        var info_mahreens = 0;
-        var info_vehicles = 0;
-        //For each of the companies (HQ + 10)
-        for (var company = 0; company < 11; company++) {
-            var i = 0;
-            var _unit = fetch_unit([company, i]);
-            //For each unit in that company, while unit exists
-            //Marines and vehicles get checked AT THE SAME TIME
-            //This is possible since array for saving vehicles and marines are separated
-            while ((is_struct(_unit) && _unit.name() != "" || i < array_length(obj_ini.veh_race[company])) && i < 500) {
-                if ((_unit.race() == 1) && (_unit.location_string == _unit_location) && (_unit.planet_location == _target_location)) {
-                    info_mahreens++;
-                }
+function scr_count_forces(_unit_location, _target_location, _is_planet, _return_as_array = false) {
+    if (!_is_planet) {
+        return;
+    }
 
-                if (i < array_length(obj_ini.veh_race[company])) {
-                    if ((obj_ini.veh_race[company][i] == 1) && (obj_ini.veh_loc[company][i] == _unit_location) && (obj_ini.veh_wid[company][i] == _target_location)) {
-                        info_vehicles++;
-                    }
-                }
+    var _marine_count = 0;
+    var _vehicle_count = 0;
+    var _max_companies = 11;
+    var _safety_limit = 500;
 
-                i++;
+    for (var _company = 0; _company < _max_companies; _company++) {
+        var _veh_race = obj_ini.veh_race[_company];
+        var _veh_loc = obj_ini.veh_loc[_company];
+        var _veh_wid = obj_ini.veh_wid[_company];
+        var _veh_len = array_length(_veh_race);
+
+        for (var i = 0; i < _safety_limit; i++) {
+            var _unit = fetch_unit([_company, i]);
+            var _marine_exists = is_struct(_unit) && _unit.name() != "";
+            var _vehicle_exists = i < _veh_len;
+
+            if (!_marine_exists && !_vehicle_exists) {
+                break;
+            }
+
+            if (_marine_exists && _unit.race() == 1 && _unit.location_string == _unit_location && _unit.planet_location == _target_location) {
+                _marine_count++;
+            }
+
+            if (_vehicle_exists && _veh_race[i] == 1 && _veh_loc[i] == _unit_location && _veh_wid[i] == _target_location) {
+                _vehicle_count++;
             }
         }
-        if (instance) {
-            return [
-                info_mahreens,
-                info_vehicles,
-            ];
-        } else {
-            if (instance_exists(obj_turn_end)) {
-                obj_turn_end.info_mahreens = info_mahreens;
-                obj_turn_end.info_vehicles = info_vehicles;
-            }
+    }
+
+    if (_return_as_array) {
+        return [
+            _marine_count,
+            _vehicle_count,
+        ];
+    } else {
+        if (instance_exists(obj_turn_end)) {
+            obj_turn_end.info_mahreens = _marine_count;
+            obj_turn_end.info_vehicles = _vehicle_count;
         }
     }
 }

--- a/scripts/scr_count_forces/scr_count_forces.gml
+++ b/scripts/scr_count_forces/scr_count_forces.gml
@@ -9,7 +9,7 @@ function scr_count_forces(_unit_location, _target_location, _is_planet, instance
             //For each unit in that company, while unit exists
             //Marines and vehicles get checked AT THE SAME TIME
             //This is possible since array for saving vehicles and marines are separated
-            while ((_unit.name() != "" || i < array_length(obj_ini.veh_race[company])) && i < 500) {
+            while ((is_struct(_unit) && _unit.name() != "" || i < array_length(obj_ini.veh_race[company])) && i < 500) {
                 if ((_unit.race() == 1) && (_unit.location_string == _unit_location) && (_unit.planet_location == _target_location)) {
                     info_mahreens++;
                 }

--- a/scripts/scr_count_marines_on_ship/scr_count_marines_on_ship.gml
+++ b/scripts/scr_count_marines_on_ship/scr_count_marines_on_ship.gml
@@ -4,7 +4,8 @@ function scr_count_marines_on_ship(ship_number) {
         var _company_size = array_length(obj_ini.TTRPG[company]);
         for (var marine = 1; marine < _company_size; marine++) {
             if (obj_ini.name[company][marine] != "") {
-                if (obj_ini.TTRPG[company][marine].ship_location == ship_number) {
+                var _unit = fetch_unit([company, marine]);
+                if (is_struct(_unit) && _unit.ship_location == ship_number) {
                     count++;
                 }
             }

--- a/scripts/scr_crusade/scr_crusade.gml
+++ b/scripts/scr_crusade/scr_crusade.gml
@@ -71,11 +71,11 @@ function scr_crusade() {
                 continue;
             }
             unit = fetch_unit([co, i]);
+            if (!is_struct(unit)) { continue; }
             if (unit.ship_location == -1) {
                 continue;
             }
             if (array_contains(total_ship_id, unit.ship_location)) {
-                unit = obj_ini.TTRPG[co][i];
                 death_determination = floor(random(100)) + 1;
                 //specialist trait greatly reduces death risk
                 //TODO figure out how to quantify and present these risks so the player knows to protect dudes with trait

--- a/scripts/scr_destroy_planet/scr_destroy_planet.gml
+++ b/scripts/scr_destroy_planet/scr_destroy_planet.gml
@@ -43,6 +43,7 @@ function scr_destroy_planet(destruction_method) {
     for (var cah = 0; cah <= obj_ini.companies; cah++) {
         for (var ed = 0; ed < array_length(obj_ini.role[cah]); ed++) {
             var unit = fetch_unit([cah, ed]);
+            if (!is_struct(unit)) { continue; }
             if ((unit.location_string == you.name) && (unit.planet_location == baid)) {
                 if (unit.role() == obj_ini.role[100][eROLE.CHAPTERMASTER]) {
                     obj_controller.alarm[7] = 15;

--- a/scripts/scr_dialogue/scr_dialogue.gml
+++ b/scripts/scr_dialogue/scr_dialogue.gml
@@ -184,7 +184,7 @@ function scr_dialogue(diplo_keyphrase, data = {}) {
                 }
             }
 
-            if ((obj_ini.TTRPG[0][3].corruption >= 50) && (born == true)) {
+            var _ms = fetch_unit([0, 3]); if (is_struct(_ms) && _ms.corruption >= 50 && born) {
                 add_diplomacy_option({option_text: "Right now I need my Master of Sanctity at my side, trusting that his Chapter Master is doing what is best, what is necessary for the Chapter, during this dangerous moment. All will be made clear in time, I promise you brother. This is the right path.", goto: "cs_meeting_m3"});
             }
         }
@@ -216,12 +216,16 @@ function scr_dialogue(diplo_keyphrase, data = {}) {
 
             diplo_text = $"[[{obj_controller.faction_leader[eFACTION.CHAOS]} turns to you, his voice even and calm]]\n\nHere is the first step you must take, to prove you’ve truly left the Imperium behind. Kill him. Kill your loyal brothers.\n[[His Chaos Terminators raise their weapons as one and point them at you. Somewhere behind them a daemon cackles.]]\nChoose now or be obliterated.";
 
+            var _name = "";
             var _master_of_sanct = fetch_unit([0, 3]);
+            if (is_struct(_master_of_sanct)) {
+                _name = _master_of_sanct.name();
+            }
 
-            var _string = $"Stand with me my brothers! Fight for the future of your Chapter, and slay {_master_of_sanct.name()}!  [Battle loyalist  {global.chapter_name}";
+            var _string = $"Stand with me my brothers! Fight for the future of your Chapter, and slay {_name}!  [Battle loyalist  {global.chapter_name}";
             add_diplomacy_option({option_text: _string, goto: "cs_meeting_battle1", goto: "cs_meeting_battle1"});
 
-            _string = $"{global.chapter_name}, I order you to hold your fire! {_master_of_sanct.name()}, if you doubt my leadership then let it be decided by single combat! [Duel your Master of Sanctity]";
+            _string = $"{global.chapter_name}, I order you to hold your fire! {_name}, if you doubt my leadership then let it be decided by single combat! [Duel your Master of Sanctity]";
             add_diplomacy_option({option_text: _string, goto: "cs_meeting_battle2"});
 
             _string = $"I deny you {obj_controller.faction_leader[eFACTION.CHAOS]}.  And now I shall destroy you.  For the Emperor! [Attack Chaos forces]";
@@ -342,7 +346,7 @@ function scr_dialogue(diplo_keyphrase, data = {}) {
             var born = false;
             for (var ii = 1; ii < 200; ii++) {
                 if (obj_ini.role[0][ii] == obj_ini.role[100][eROLE.CHAPTERMASTER]) {
-                    fetch_unit([0, ii]).corruption += floor(random_range(30, 50));
+                    var _unit = fetch_unit([0, ii]); if (is_struct(_unit)) { _unit.corruption += floor(random_range(30, 50)); }
                 }
             }
             obj_controller.chaos_rating += 1;
@@ -379,6 +383,7 @@ function scr_dialogue(diplo_keyphrase, data = {}) {
             }
             if (!_found) {
                 var _master = fetch_unit([0, 0]);
+                if (!is_struct(_master)) { exit; }
                 if (_master.planet_location > 0) {
                     var _master_star = find_star_by_name(_master.location_string);
                     if (_master_star != noone) {

--- a/scripts/scr_diplomacy_helpers/scr_diplomacy_helpers.gml
+++ b/scripts/scr_diplomacy_helpers/scr_diplomacy_helpers.gml
@@ -202,7 +202,6 @@ function draw_character_diplomacy() {
     _cm_slate.YY = 520;
     _cm_slate.inside_method = function() {
         var _master = fetch_unit([0, 0]);
-
         if (!variable_instance_exists(obj_controller, "master_image")) {
             obj_controller.master_image = _master.draw_unit_image();
         }
@@ -266,14 +265,13 @@ function scr_emmisary_diplomacy_routes() {
     } else if (diplomacy_pathway == "Khorne_path") {
         scr_diplomacy_hit(0,, function() {
             //TODO central get cm choice_func
-            var chapter_master = obj_ini.TTRPG[0][0];
             cooldown = 8000;
             diplomacy_pathway = "sacrifice_lib";
             //grab a random librarian
             var lib = scr_random_marine(SPECIALISTS_LIBRARIANS, 0);
             if (lib != "none") {
-                chapter_master = obj_ini.TTRPG[0][1];
-                var dead_lib = obj_ini.TTRPG[lib[0]][lib[1]];
+                var chapter_master = fetch_unit([0, 1]);
+                var dead_lib = fetch_unit([lib[0], lib[1]]);
                 pop_up = instance_create(0, 0, obj_popup);
                 pop_up.title = "Skull for the Skull Throne";
                 pop_up.text = $"You summon {dead_lib.name_role()} to your personal chambers. Darting from the shadows you deftly strike his head from his shoulders. With the flesh removed from his skull you place the skull upon a hastily erected shrine.";
@@ -293,10 +291,10 @@ function scr_emmisary_diplomacy_routes() {
             diplomacy_pathway = "sacrifice_champ";
             var champ = scr_random_marine(obj_ini.role[100][7], 0);
             if (champ != "none") {
-                var chapter_master = obj_ini.TTRPG[0][1];
+                var chapter_master = fetch_unit([0, 1]);
                 chapter_master.add_trait("blood_for_blood");
                 chapter_master.edit_corruption(20);
-                var dead_champ = obj_ini.TTRPG[champ[0]][champ[1]];
+                var dead_champ = fetch_unit([champ[0], champ[1]]);
                 //TODO make this into a real dual with consequences
                 pop_up = instance_create(0, 0, obj_popup);
                 pop_up.title = "Skull for the Skull Throne";

--- a/scripts/scr_enemy_ai_e/scr_enemy_ai_e.gml
+++ b/scripts/scr_enemy_ai_e/scr_enemy_ai_e.gml
@@ -745,6 +745,7 @@ function scr_enemy_ai_e() {
         for (var co = 0; co <= 10; co++) {
             for (var i = 1; i <= 200; i++) {
                 var _unit = fetch_unit([co, i]);
+                if (!is_struct(_unit)) { continue; }
                 var _is_unit_real_and_here = _unit.role() != "" && _unit.location_string == name;
                 var _is_this_a_chaos_meeting = _unit.planet_location == floor(chaos_meeting);
                 var _unit_does_not_have_dreadnought_role = _unit.role() != obj_ini.role[100][6];

--- a/scripts/scr_event_code/scr_event_code.gml
+++ b/scripts/scr_event_code/scr_event_code.gml
@@ -158,6 +158,10 @@ function event_end_turn_action() {
                 var comp = _event.company;
                 var marine_num = _event.marine;
                 var _unit = fetch_unit([comp, marine_num]);
+                if (!is_struct(_unit)) {
+                    LOGGER.error($"fetch_unit returned non-struct for company {comp}, marine {marine_num}");
+                    continue;
+                }
                 var item = _event.crafted;
                 var _pop_data = {};
 
@@ -309,6 +313,7 @@ function strange_build_event() {
         var marine = marine_and_company[1];
         var text = "";
         var _unit = fetch_unit(marine_and_company);
+        if (!is_struct(_unit)) { exit; }
         var role = _unit.role();
         text = _unit.name_role();
         text += " is taken by a strange mood and starts building!";

--- a/scripts/scr_event_dudes/scr_event_dudes.gml
+++ b/scripts/scr_event_dudes/scr_event_dudes.gml
@@ -53,7 +53,7 @@ function scr_event_dudes(do_action, is_planet, system_name, location_id) {
             if (obj_ini.name[coh][ide] == "") {
                 continue;
             }
-            unit = obj_ini.TTRPG[coh][ide];
+            unit = fetch_unit([coh, ide]); if (!is_struct(unit)) { continue; }
 
             if ((is_planet == 0) && (unit.ship_location == location_id)) {
                 if ((obj_ini.race[coh][ide] == 1) || (obj_ini.race[coh][ide] == 5)) {

--- a/scripts/scr_event_gossip/scr_event_gossip.gml
+++ b/scripts/scr_event_gossip/scr_event_gossip.gml
@@ -6,7 +6,7 @@ function scr_event_gossip(argument0) {
     that = 0;
     that_type = "";
     words = "";
-    him_chaos = obj_ini.TTRPG[attend_co[argument0]][attend_id[argument0]].corruption;
+    var _unit = fetch_unit([attend_co[argument0], attend_id[argument0]]); him_chaos = is_struct(_unit) ? _unit.corruption : 0;
 
     p = -1;
     repeat (101) {

--- a/scripts/scr_garrison/scr_garrison.gml
+++ b/scripts/scr_garrison/scr_garrison.gml
@@ -145,6 +145,7 @@ function GarrisonForce(system, planet, type = "garrison") constructor {
         for (var _squad = 0; _squad < array_length(garrison_squads); _squad++) {
             var _leader = garrison_squads[_squad].determine_leader();
             _unit = fetch_unit(_leader);
+            if (!is_struct(_unit)) { continue; }
             if (garrison_leader == false) {
                 garrison_leader = _unit;
                 for (var r = 0; r < array_length(hierarchy); r++) {
@@ -291,6 +292,7 @@ function GarrisonForce(system, planet, type = "garrison") constructor {
                         //loop squads in the garrison
                         _squad = garrison_squads[s];
                         _leader = fetch_unit(_squad.squad_leader);
+                        if (!is_struct(_leader)) { continue; }
                         /*here we decide if a _squad had favourable positioning for the coming battle
 						   take a random of their wisdom plus their luck minus how bad the combat loss was
 						*/

--- a/scripts/scr_ini_ship_cleanup/scr_ini_ship_cleanup.gml
+++ b/scripts/scr_ini_ship_cleanup/scr_ini_ship_cleanup.gml
@@ -6,6 +6,7 @@ function scr_kill_ship(index) {
             for (var co = 0; co <= companies; co++) {
                 for (var i = 0; i < array_length(name[co]); i++) {
                     _unit = fetch_unit([co, i]);
+                    if (!is_struct(_unit)) { continue; }
                     if (_unit.ship_location > -1) {
                         if (_unit.ship_location == index) {
                             if (!(irandom(_unit.luck) - 3)) {

--- a/scripts/scr_kill_unit/scr_kill_unit.gml
+++ b/scripts/scr_kill_unit/scr_kill_unit.gml
@@ -10,11 +10,16 @@ function scr_kill_unit(company, unit_slot) {
             alarm[7] = 5;
             global.defeat = 1;
         }
+
         var _unit = fetch_unit([company, unit_slot]);
-        if (_unit.weapon_one() == "Company Standard" || _unit.weapon_two() == "Company Standard") {
-            scr_loyalty("Lost Standard", "+");
+
+        if (is_struct(_unit)) {
+            if (_unit.weapon_one() == "Company Standard" || _unit.weapon_two() == "Company Standard") {
+                scr_loyalty("Lost Standard", "+");
+            }
+            _unit.remove_from_squad();
         }
-        _unit.remove_from_squad();
+
         scr_wipe_unit(company, unit_slot);
     } catch (ex) {
         LOGGER.error($"company: {company}, unit_slot: {unit_slot}");

--- a/scripts/scr_marine_count/scr_marine_count.gml
+++ b/scripts/scr_marine_count/scr_marine_count.gml
@@ -20,7 +20,11 @@ function scr_marine_count(argument0, argument1, argument2) {
                 if (obj_ini.name[com][ide] == "") {
                     continue;
                 }
-                unit = obj_ini.TTRPG[com][ide];
+                unit = fetch_unit([com, ide]);
+                if (!is_struct(unit)) {
+                    ide += 1;
+                    continue;
+                }
                 if (check < sca) {
                     ide += 1;
                     if ((unit.role() != "") && (obj_ini.race[com][ide] <= 5) && (unit.location_string == argument0.name) && (unit.planet_location == argument1)) {

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -2375,6 +2375,7 @@ function fetch_unit_uid(uuid) {
         var _comp_length = array_length(obj_ini.TTRPG[i]);
         for (var s = 0; s < _comp_length; s++) {
             var _unit = fetch_unit([i, s]);
+            if (!is_struct(_unit)) { continue; }
             if (_unit.uid == uuid) {
                 return _unit;
             }

--- a/scripts/scr_master_loc/scr_master_loc.gml
+++ b/scripts/scr_master_loc/scr_master_loc.gml
@@ -21,6 +21,7 @@ function scr_master_loc() {
                         continue;
                     }
                     unit = fetch_unit([co, v]);
+                    if (!is_struct(unit)) { continue; }
                     if (unit.role() == obj_ini.role[100][eROLE.CHAPTERMASTER]) {
                         if ((unit.planet_location > 0) && (unit.ship_location < 0)) {
                             lick = $"{unit.location_string}." + string(unit.planet_location);

--- a/scripts/scr_max_marine/scr_max_marine.gml
+++ b/scripts/scr_max_marine/scr_max_marine.gml
@@ -19,7 +19,7 @@ function scr_max_marine(max_type) {
             i += 1; // man_c[i]=0;man_i[i]=0;
 
             if (obj_ini.name[c][i] != "") {
-                unit = obj_ini.TTRPG[c][i];
+                unit = fetch_unit([c, i]); if (!is_struct(unit)) { continue; }
                 if (max_type == "chaos") {
                     if (unit.corruption > value) {
                         value = unit.corruption;

--- a/scripts/scr_mechanicus_missions/scr_mechanicus_missions.gml
+++ b/scripts/scr_mechanicus_missions/scr_mechanicus_missions.gml
@@ -380,7 +380,7 @@ function mechanicus_mars_mission_target_time_elapsed(planet) {
     for (com = 0; com <= 10; com++) {
         for (ide = 0; ide < array_length(obj_ini.TTRPG[com]); ide++) {
             _unit = fetch_unit([com, ide]);
-            if (_unit.name() == "") {
+            if (!is_struct(_unit) || _unit.name() == "") {
                 continue;
             }
             if (_unit.role() == obj_ini.role[100][eROLE.TECHMARINE]) {

--- a/scripts/scr_mission_functions/scr_mission_functions.gml
+++ b/scripts/scr_mission_functions/scr_mission_functions.gml
@@ -227,6 +227,7 @@ function problem_end_turn_checks() {
                     for (me = 0; me < array_length(obj_ini.role[co]); me++) {
                         if ((obj_ini.race[co][me] == 1) && (obj_ini.role[co][me] != "")) {
                             _unit = fetch_unit([co, me]);
+                            if (!is_struct(_unit)) { continue; }
                             _unit.edit_corruption(irandom_range(3, 6));
                             _unit.alter_loyalty(-10);
                         }
@@ -328,6 +329,7 @@ function init_marine_acting_strange() {
     }
 
     var unit = fetch_unit(marine_and_company);
+    if (!is_struct(unit)) { exit; }
     var role = unit.role();
     var text = unit.name_role();
     var company_text = scr_convert_company_to_string(unit.company);
@@ -397,7 +399,7 @@ function init_protect_raider_mission(squad) {
     }
 
     var _leader = fetch_unit(squad.determine_leader());
-
+    if (!is_struct(_leader)) { return; }
     var _wis_test = _tester.standard_test(_leader, "wisdom", _mod, ["ambush"]);
 
     if (!_wis_test[0]) {

--- a/scripts/scr_move_unit_info/scr_move_unit_info.gml
+++ b/scripts/scr_move_unit_info/scr_move_unit_info.gml
@@ -2,7 +2,11 @@ function scr_move_unit_info(start_company, end_company, start_slot, end_slot, ev
     //eval_squad : determine whether movement of units between companies should decide to check their squad coherency or not, defaults to true
 
     //this makes sure coherency of the unit's squad and the squads logging of the unit location are kept up to date
-    var unit = obj_ini.TTRPG[start_company][start_slot];
+    var unit = fetch_unit([start_company, start_slot]);
+    if (!is_struct(unit)) {
+        exit;
+    }
+
     if (eval_squad) {
         unit.movement_after_math(end_company, end_slot);
     }
@@ -18,13 +22,15 @@ function scr_move_unit_info(start_company, end_company, start_slot, end_slot, ev
     obj_ini.age[end_company][end_slot] = obj_ini.age[start_company][start_slot];
     obj_ini.mobi[end_company][end_slot] = obj_ini.mobi[start_company][start_slot];
 
-    var _temp_struct = obj_ini.TTRPG[end_company][end_slot];
+    var _temp_struct = fetch_unit([end_company, end_slot]);
 
     obj_ini.TTRPG[end_company][end_slot] = obj_ini.TTRPG[start_company][start_slot];
 
     obj_ini.TTRPG[start_company][start_slot] = _temp_struct;
-    _temp_struct.company = start_company;
-    _temp_struct.marine_number = start_slot;
+    if (is_struct(_temp_struct)) {
+        _temp_struct.company = start_company;
+        _temp_struct.marine_number = start_slot;
+    }
 
     _temp_struct = fetch_unit([end_company, end_slot]);
     if (is_struct(_temp_struct)) {

--- a/scripts/scr_player_fleet_combat_functions/scr_player_fleet_combat_functions.gml
+++ b/scripts/scr_player_fleet_combat_functions/scr_player_fleet_combat_functions.gml
@@ -351,6 +351,7 @@ function setup_player_combat_ship() {
                 continue;
             }
             var unit = fetch_unit([co, i]);
+            if (!is_struct(unit)) { continue; }
             if (unit.ship_location == ship_id) {
                 if (unit.is_boarder && unit.hp() > (unit.max_health() / 10)) {
                     array_push(board_co, co);

--- a/scripts/scr_player_fleet_functions/scr_player_fleet_functions.gml
+++ b/scripts/scr_player_fleet_functions/scr_player_fleet_functions.gml
@@ -3,6 +3,7 @@ function fleet_has_roles(fleet, roles = []) {
     for (var i = 0; i <= 10; i++) {
         for (var s = 0; s < array_length(obj_ini.TTRPG[i]); s++) {
             var unit = fetch_unit([i, s]);
+            if (!is_struct(unit)) { continue; }
             if (unit.planet_location < 1) {
                 if (array_contains(all_ships, unit.ship_location)) {
                     if (array_contains(roles, unit.role())) {
@@ -492,6 +493,7 @@ function set_fleet_location(location) {
     for (var co = 0; co <= obj_ini.companies; co++) {
         for (var i = 0; i < array_length(obj_ini.name[co]); i++) {
             var unit = fetch_unit([co, i]);
+            if (!is_struct(unit)) { continue; }
             if (array_contains(fleet_ships, unit.ship_location)) {
                 unit.location_string = location;
             }

--- a/scripts/scr_player_ship_functions/scr_player_ship_functions.gml
+++ b/scripts/scr_player_ship_functions/scr_player_ship_functions.gml
@@ -214,6 +214,7 @@ function loose_ship_to_warp_event() {
                 continue;
             }
             unit = fetch_unit([company, marine]);
+            if (!is_struct(unit)) { continue; }
             if (unit.ship_location == _ship_index) {
                 unit.location_string = "Lost";
             }

--- a/scripts/scr_promote/scr_promote.gml
+++ b/scripts/scr_promote/scr_promote.gml
@@ -88,12 +88,13 @@ function setup_promotion_popup() {
                                 var mem;
                                 for (mem = 0; mem < array_length(move_members); mem++) {
                                     var mem_unit = fetch_unit(move_members[mem]);
+                                    if (!is_struct(mem_unit)) { continue; }
                                     if (mem_unit.company != target_comp) {
                                         scr_move_unit_info(mem_unit.company, target_comp, mem_unit.marine_number, mahreens, false);
                                         squad.members[mem][0] = target_comp;
                                         squad.members[mem][1] = mahreens;
                                     }
-                                    mem_unit = obj_ini.TTRPG[target_comp][mahreens];
+                                    mem_unit = fetch_unit([target_comp, mahreens]); if (!is_struct(mem_unit)) { continue; }
                                     mem_unit.squad = move_squad;
                                     if (!mem_unit.IsSpecialist(SPECIALISTS_SQUAD_LEADERS)) {
                                         mem_unit.update_role(role_name[target_role]);
@@ -116,7 +117,7 @@ function setup_promotion_popup() {
                         if (!moveable) {
                             if (unit.company != target_comp) {
                                 scr_move_unit_info(unit.company, target_comp, unit.marine_number, mahreens);
-                                unit = obj_ini.TTRPG[target_comp][mahreens];
+                                unit = fetch_unit([target_comp, mahreens]); if (!is_struct(unit)) { continue; }
                             }
                             unit.update_role(role_name[target_role]);
                             unit.alter_equipment({"wep1": req_wep1, "wep2": req_wep2, "mobi": req_mobi, "armour": req_armour, "gear": req_gear});

--- a/scripts/scr_random_event/scr_random_event.gml
+++ b/scripts/scr_random_event/scr_random_event.gml
@@ -272,7 +272,11 @@ function scr_random_event(execute_now) {
         }
         var marine = marine_and_company[1];
         var company = marine_and_company[0];
-        var _unit = obj_ini.TTRPG[company][marine];
+        var _unit = fetch_unit([company, marine]);
+        if (!is_struct(_unit)) {
+            LOGGER.error("RE: Promotion, couldn't pick a space marine");
+            exit;
+        }
         var role = _unit.role();
         var text = _unit.name_role();
         var company_text = scr_convert_company_to_string(company);

--- a/scripts/scr_random_marine/scr_random_marine.gml
+++ b/scripts/scr_random_marine/scr_random_marine.gml
@@ -41,7 +41,12 @@ function scr_random_marine(role, exp_req, search_params = {}) {
                 var list_place = irandom(comp_size - 1);
                 var _dude_index = marine_list[list_place];
                 var match = true;
-                var unit = obj_ini.TTRPG[company][_dude_index];
+                var unit = fetch_unit([company, _dude_index]);
+                if (!is_struct(unit)) {
+                    array_delete(marine_list, list_place, 1);
+                    comp_size--;
+                    continue;
+                }
 
                 //exit if not real name
                 if ((unit.name() == "") || (unit.name() == 0)) {

--- a/scripts/scr_role_count/scr_role_count.gml
+++ b/scripts/scr_role_count/scr_role_count.gml
@@ -34,14 +34,14 @@ function scr_role_count(target_role, search_location = "", return_type = "count"
 
     if (coom >= 0) {
         for (var i = 0; i < array_length(obj_ini.TTRPG[coom]); i++) {
-            var unit = obj_ini.TTRPG[coom][i];
+            var unit = fetch_unit([coom, i]);
             if (!is_struct(unit) || unit.name() == "") {
                 continue;
             }
             if ((unit.role() == target_role) && (obj_ini.god[coom][i] < 10)) {
                 count += 1;
                 if (return_type == "units") {
-                    array_push(units, obj_ini.TTRPG[coom][i]);
+                    var _u = fetch_unit([coom, i]); if (is_struct(_u)) { array_push(units, _u); }
                 }
             }
         }

--- a/scripts/scr_roster/scr_roster.gml
+++ b/scripts/scr_roster/scr_roster.gml
@@ -276,7 +276,7 @@ function Roster() constructor {
             for (var i = 0; i < array_length(obj_ini.role[co]); i++) {
                 var _allow = false;
                 var _unit = fetch_unit([co, i]);
-                if (_unit.name() == "" || _unit.role() == "") {
+                if (!is_struct(_unit) || _unit.name() == "" || _unit.role() == "") {
                     continue;
                 }
                 if (_unit.hp() <= 0 || _unit.in_jail()) {

--- a/scripts/scr_ship_battle/scr_ship_battle.gml
+++ b/scripts/scr_ship_battle/scr_ship_battle.gml
@@ -30,7 +30,7 @@ function scr_ship_battle(target_ship_id, cooridor_width) {
                 if (obj_ini.name[co][v] == "") {
                     continue;
                 }
-                unit = obj_ini.TTRPG[co][v];
+                unit = fetch_unit([co, v]); if (!is_struct(unit)) { continue; }
                 if ((unit.ship_location == target_ship_id) && unit.hp()) {
                     okay = 1;
                 }

--- a/scripts/scr_ship_occupants/scr_ship_occupants.gml
+++ b/scripts/scr_ship_occupants/scr_ship_occupants.gml
@@ -20,6 +20,7 @@ function scr_ship_occupants(target_ship_id) {
             i += 1;
             if (obj_ini.role[co][i] != "") {
                 unit = fetch_unit([co, i]);
+                if (!is_struct(unit)) { continue; }
                 if (unit.ship_location != target_ship_id) {
                     good = 0;
                 }

--- a/scripts/scr_special_view/scr_special_view.gml
+++ b/scripts/scr_special_view/scr_special_view.gml
@@ -80,6 +80,7 @@ function scr_special_view(command_group) {
                 continue;
             }
             var _unit = fetch_unit([0, v]);
+            if (!is_struct(_unit)) { continue; }
             if (_unit.ship_location > -1) {
                 var ham = _unit.ship_location;
                 if (obj_ini.ship_location[ham] == "Lost") {

--- a/scripts/scr_specialist_training/scr_specialist_training.gml
+++ b/scripts/scr_specialist_training/scr_specialist_training.gml
@@ -134,9 +134,13 @@ function apothecary_training() {
             if (recruit_count > 0) {
                 var random_marine = scr_random_marine(novice_type, 0);
                 if (random_marine != "none") {
-                    apothecary_recruit_points -= 48;
                     /// @type {Struct.TTRPG_stats}
                     var unit = fetch_unit(random_marine);
+                    if (!is_struct(unit) || unit.name() == "") {
+                        return;
+                    }
+
+                    apothecary_recruit_points -= 48;
                     scr_alert("green", "recruitment", unit.name_role() + " has finished training.", 0, 0);
                     unit.update_role(obj_ini.role[100][15]);
                     unit.role_tag = [
@@ -180,6 +184,7 @@ function apothecary_training() {
                 if (open_slot != -1) {
                     scr_move_unit_info(marine_company, 0, marine_position, open_slot);
                     var unit = fetch_unit([0, open_slot]);
+                    if (!is_struct(unit) || unit.name() == "") { return; }
                     unit.update_role(novice_type);
                     unit.update_gear("");
                     unit.update_mobility_item("");
@@ -214,6 +219,7 @@ function chaplain_training() {
                     var random_marine = scr_random_marine(novice_type, 0);
                     if (random_marine != "none") {
                         var unit = fetch_unit(random_marine);
+                        if (!is_struct(unit) || unit.name() == "") { return; }
                         scr_alert("green", "recruitment", unit.name_role() + " has finished training.", 0, 0);
                         chaplain_points -= 48;
                         unit.update_role(obj_ini.role[100][14]);
@@ -254,9 +260,12 @@ function chaplain_training() {
                     var marine_company = random_marine[0];
                     var open_slot = find_company_open_slot(0);
                     if (open_slot != -1) {
-                        chaplain_aspirant = 1;
                         scr_move_unit_info(marine_company, 0, marine_position, open_slot);
                         var unit = fetch_unit([0, open_slot]);
+                        if (!is_struct(unit) || unit.name() == "") {
+                            return;
+                        }
+                        chaplain_aspirant = 1;
                         unit.update_role(novice_type);
                         unit.update_gear("");
                         unit.update_mobility_item("");
@@ -292,6 +301,7 @@ function librarian_training() {
                 var random_marine = scr_random_marine(novice_type, 0, {"stat": [["psionic", 2, "more"]]});
                 if (random_marine != "none") {
                     var unit = fetch_unit(random_marine);
+                    if (!is_struct(unit) || unit.name() == "") { return; }
                     psyker_points -= goal;
                     psyker_aspirant = 0;
 
@@ -323,6 +333,7 @@ function librarian_training() {
                 if (open_slot != -1) {
                     scr_move_unit_info(marine_company, 0, marine_position, open_slot);
                     var unit = fetch_unit([0, open_slot]);
+                    if (!is_struct(unit) || unit.name() == "") { return; }
                     unit.update_role(novice_type);
                     unit.update_powers();
                     psyker_aspirant = 1;
@@ -368,6 +379,7 @@ function techmarine_training() {
                 var random_marine = scr_random_marine(novice_type, 0);
                 if (random_marine != "none") {
                     var unit = fetch_unit(random_marine);
+                    if (!is_struct(unit) || unit.name() == "") { return; }
                     tech_points -= _threshold;
 
                     unit.update_role(obj_ini.role[100][16]);
@@ -437,6 +449,7 @@ function techmarine_training() {
                 if (open_slot != -1) {
                     scr_move_unit_info(marine_company, 0, marine_position, open_slot);
                     var unit = fetch_unit([0, open_slot]);
+                    if (!is_struct(unit) || unit.name() == "") { return; }
                     unit.update_role(novice_type);
 
                     // Remove from ship

--- a/scripts/scr_squads/scr_squads.gml
+++ b/scripts/scr_squads/scr_squads.gml
@@ -300,7 +300,7 @@ function UnitSquad(squad_type = undefined, company = 0) constructor {
         var _struct_array = [];
         for (var i = array_length(members) - 1; i >= 0; i--) {
             _unit = fetch_unit(members[i]);
-            if (_unit.name() == "") {
+            if (!is_struct(_unit) || _unit.name() == "") {
                 array_delete(members, i, 1);
                 continue;
             } else {
@@ -318,7 +318,7 @@ function UnitSquad(squad_type = undefined, company = 0) constructor {
         var member_length = array_length(members);
         for (var i = 0; i < member_length; i++) {
             _unit = fetch_unit(members[i]);
-            if (_unit.name() == "") {
+            if (!is_struct(_unit) || _unit.name() == "") {
                 array_delete(members, i, 1);
                 member_length--;
                 i--;
@@ -516,7 +516,7 @@ function UnitSquad(squad_type = undefined, company = 0) constructor {
         var exact_loc = false;
         for (var i = 0; i < member_length; i++) {
             _unit = fetch_unit(members[i]);
-            if (_unit.name() == "") {
+            if (!is_struct(_unit) || _unit.name() == "") {
                 array_delete(members, i, 1);
                 member_length--;
                 i--;
@@ -591,7 +591,7 @@ function UnitSquad(squad_type = undefined, company = 0) constructor {
         var highest_exp = 0;
         for (var i = 0; i < member_length; i++) {
             var _unit = fetch_unit(members[i]);
-            if (_unit.name() == "") {
+            if (!is_struct(_unit) || _unit.name() == "") {
                 array_delete(members, i, 1);
                 member_length--;
                 i--;
@@ -610,7 +610,7 @@ function UnitSquad(squad_type = undefined, company = 0) constructor {
                     }
                 } else if (leader_hier_pos < array_length(hierarchy) && hierarchy[leader_hier_pos] == _unit.role()) {
                     var _leader = fetch_unit(leader);
-                    if (_leader.experience < _unit.experience) {
+                    if (is_struct(_leader) && _leader.experience < _unit.experience) {
                         leader = [
                             _unit.company,
                             _unit.marine_number,
@@ -639,13 +639,15 @@ function UnitSquad(squad_type = undefined, company = 0) constructor {
         var remove_sgt;
         if (sgt != "none") {
             remove_sgt = fetch_unit(sgt);
-            if (remove_sgt.IsSpecialist(SPECIALISTS_SQUAD_LEADERS)) {
-                var replace_role = remove_sgt.role();
-                remove_sgt.update_role(new_sgt.role());
-                //TODO centralise loyalty changes for role changes in the update_role method
-                remove_sgt.alter_loyalty(-10);
-                new_sgt.update_role(replace_role);
-                new_sgt.alter_loyalty(10);
+            if (is_struct(remove_sgt)) {
+                if (remove_sgt.IsSpecialist(SPECIALISTS_SQUAD_LEADERS)) {
+                    var replace_role = remove_sgt.role();
+                    remove_sgt.update_role(new_sgt.role());
+                    //TODO centralise loyalty changes for role changes in the update_role method
+                    remove_sgt.alter_loyalty(-10);
+                    new_sgt.update_role(replace_role);
+                    new_sgt.alter_loyalty(10);
+                }
             }
         }
     };
@@ -670,7 +672,7 @@ function UnitSquad(squad_type = undefined, company = 0) constructor {
         member_length = array_length(members);
         for (var i = 0; i < member_length; i++) {
             var _unit = fetch_unit(members[i]);
-            if (_unit.name() == "") {
+            if (!is_struct(_unit) || _unit.name() == "") {
                 array_delete(members, i, 1);
                 member_length--;
                 i--;

--- a/scripts/scr_start_load/scr_start_load.gml
+++ b/scripts/scr_start_load/scr_start_load.gml
@@ -96,7 +96,7 @@ function scr_start_load(fleet, load_from_star, load_options) {
         for (var _unit = 0; _unit < (array_length(obj_ini.role[_comp]) - 1); _unit++) {
             var _marine = fetch_unit([_comp, _unit]);
             // check if marine exists
-            if (_marine.name() != "") {
+            if (is_struct(_marine) && _marine.name() != "") {
                 //calculate marine space
                 var marine_size = _marine.get_unit_size();
                 _company_size += marine_size;
@@ -112,6 +112,7 @@ function scr_start_load(fleet, load_from_star, load_options) {
                 for (var squad_member = 0; squad_member < array_length(_members); squad_member++) {
                     squaddy = _members[squad_member];
                     var _marine = fetch_unit(squaddy);
+                    if (!is_struct(_marine)) { continue; }
                     var marine_size = _marine.get_unit_size();
                     _company_size += marine_size;
                     array_push(company_loader, _marine);

--- a/scripts/scr_system_spawn_functions/scr_system_spawn_functions.gml
+++ b/scripts/scr_system_spawn_functions/scr_system_spawn_functions.gml
@@ -113,6 +113,7 @@ function player_home_planet(home_planet) {
     for (var co = 0; co <= obj_ini.companies; co++) {
         for (var i = 0; i < array_length(obj_ini.name[co]); i++) {
             var unit = fetch_unit([co, i]);
+            if (!is_struct(unit)) { continue; }
             if (unit.location_string == name) {
                 unit.planet_location = home_planet;
             }

--- a/scripts/scr_transfer_marines/scr_transfer_marines.gml
+++ b/scripts/scr_transfer_marines/scr_transfer_marines.gml
@@ -63,8 +63,10 @@ function transfer_marines() {
                         for (var mem = 0; mem < array_length(move_members); mem++) {
                             obj_controller.man_sel[w + mem] = 0;
                             var member_unit = fetch_unit(move_members[mem]);
+                            if (!is_struct(member_unit)) { continue; }
                             scr_move_unit_info(member_unit.company, target_comp, member_unit.marine_number, mahreens, false);
                             var _unit = fetch_unit([target_comp, mahreens]);
+                            if (!is_struct(_unit)) { continue; }
                             _unit.squad = move_squad;
                             squad.members[mem][0] = target_comp;
                             squad.members[mem][1] = mahreens;

--- a/scripts/scr_ui_advisors/scr_ui_advisors.gml
+++ b/scripts/scr_ui_advisors/scr_ui_advisors.gml
@@ -109,7 +109,7 @@ function scr_ui_advisors() {
                 draw_set_halign(fa_left);
 
                 for (var qp = 1; qp <= min(36, penitorium); qp++) {
-                    var unit = obj_ini.TTRPG[penit_co[qp]][penit_id[qp]];
+                    var unit = fetch_unit([penit_co[qp], penit_id[qp]]); if (!is_struct(unit)) { continue; }
                     var r_eta = "";
                     if (unit.corruption > 0) {
                         r_eta = string(round((unit.corruption * unit.corruption) / 50));
@@ -722,7 +722,7 @@ function scr_ui_advisors() {
     // ** Chapter Master **
     if (menu == eMENU.CHAPTER_MASTER) {
         draw_set_color(0);
-        draw_sprite(spr_solid_bg, 0, xx, yy);
+        draw_sprite(spr_rock_bg, 0, xx, yy);
         draw_sprite(spr_master_splash, 0, xx, yy);
 
         draw_rectangle(xx + 213, yy + 25, xx + 622, yy + 78, 0);
@@ -762,14 +762,16 @@ function scr_ui_advisors() {
         draw_text(xx + 222, yy + 200, "Kills:");
         draw_text(xx + 222.5, yy + 200.5, "Kills:");
 
-        draw_text_ext(xx + 222, yy + 216, string_hash_to_newline(string(tot_ki)), -1, 396);
+        // draw_text_ext(xx + 222, yy + 216, string_hash_to_newline(string(tot_ki)), -1, 396);
         var unit = fetch_unit([0, 1]);
-        if (unit.ship_location == -1) {
-            draw_text(xx + 222, yy + 380, string_hash_to_newline($"Current Location: {unit.location_string} {unit.planet_location}#Health: {unit.hp()}%"));
+        if (is_struct(unit)) {
+            if (unit.ship_location == -1) {
+                draw_text(xx + 222, yy + 380, string_hash_to_newline($"Current Location: {unit.location_string} {unit.planet_location}#Health: {unit.hp()}%"));
+            } else if (unit.ship_location > -1) {
+                draw_text(xx + 222, yy + 380, string_hash_to_newline($"Current Location: Onboard {obj_ini.ship[unit.ship_location]}#Health: {unit.hp()}%"));
+            }
         }
-        if (unit.ship_location > -1) {
-            draw_text(xx + 222, yy + 380, string_hash_to_newline($"Current Location: Onboard {obj_ini.ship[unit.ship_location]}#Health: {unit.hp()}%"));
-        }
+
         draw_text(xx + 222.5, yy + 380.5, string_hash_to_newline("Current Location:#Health:"));
 
         draw_sprite(spr_arrow, 0, xx + 217, yy + 32);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds guardrails around `fetch_unit()` calls to prevent crashes after `scr_kill_unit` started unsetting `TTRPG` entries. Also refactors artifact unequip and force counting, and replaces manual event array setup with `array_create()`.

- **Bug Fixes**
  - Replaced direct `obj_ini.TTRPG[...]` reads with `fetch_unit()` + `is_struct()` checks across events/popups (including fest corruption and end-turn craft), dialogue/diplomacy routes (cs_meeting), gossip, ship boarding/combat/fleet functions, ship/planet helpers (destroy, occupants, ship cleanup), rosters/squads/garrisons, training/promotions/transfers/missions/random selections, company view/focus, role counts, and master lookups.
  - Tightened edge paths: skip invalid units and log instead of crashing; safer swaps/early exits in `scr_move_unit_info`, `scr_random_event` promotion pick, and “strange mood”/crafting flows; `scr_kill_unit` only removes from squad if valid.
  - Advisor UI: guard leader focus and location text; switch Chapter Master screen background to `spr_rock_bg`.

- **Refactors**
  - `scr_count_forces()`: single-pass marine/vehicle count with guarded fetches; supports optional array return.
  - Artifact unequip: added `unequip_from_single_unit()` and `search_and_unequip_from_all_units()`, stricter struct checks, consistent `bearer` reset, and added "Tome" to non-equip list.
  - Event setup: replaced manual array initialization in `obj_event.Create` with `array_create()` for clarity and speed.

<sup>Written for commit 2765869582249b0431b5732f027f17224d04d827. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

