### PR TITLE
ci: Run formatter every day

### DIFF
--- a/.github/workflows/gobo_format.yml
+++ b/.github/workflows/gobo_format.yml
@@ -2,7 +2,7 @@ name: Gobo Formatter
 
 on:
   schedule:
-    - cron: "0 3 * * 1"
+    - cron: "0 3 * * *"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Run the Gobo Formatter workflow every day at 03:00 UTC instead of weekly to keep formatting consistent and reduce drift. Updates the cron in `.github/workflows/gobo_format.yml` from `0 3 * * 1` to `0 3 * * *`.

<sup>Written for commit e286d12b3e0c67f368e00a09b428f01d6c4cfb87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

