### PR TITLE
refactor: Remove static company sizes and KILL parallel arrays

### DIFF
--- a/objects/obj_controller/Alarm_5.gml
+++ b/objects/obj_controller/Alarm_5.gml
@@ -290,9 +290,8 @@ try {
     var p = 0;
     for (var c = 0; c < 11; c++) {
         for (var e = 0; e < array_length(obj_ini.TTRPG[c]); e++) {
-            var _unit = fetch_unt([c,e]);
+            var _unit = fetch_unit([c,e]);
             if (_unit.god_status == 10) {
-                var _unit = fetch_unit([c, e]);
                 if (!is_struct(_unit)) {
                     continue;
                 }

--- a/objects/obj_controller/Alarm_5.gml
+++ b/objects/obj_controller/Alarm_5.gml
@@ -289,22 +289,23 @@ try {
     }
     var p = 0;
     for (var c = 0; c < 11; c++) {
-        for (var e = 0; e < array_length(obj_ini.god[c]); e++) {
-            if (obj_ini.god[c][e] == 10) {
-                var unit = fetch_unit([c, e]);
-                if (!is_struct(unit)) {
+        for (var e = 0; e < array_length(obj_ini.TTRPG[c]); e++) {
+            var _unit = fetch_unt([c,e]);
+            if (_unit.god_status == 10) {
+                var _unit = fetch_unit([c, e]);
+                if (!is_struct(_unit)) {
                     continue;
                 }
                 p += 1;
                 penit_co[p] = c;
                 penit_id[p] = e;
                 penitorium += 1;
-                unit.alter_loyalty(-1);
-                if ((unit.corruption < 90) && (unit.corruption > 0)) {
+                _unit.alter_loyalty(-1);
+                if ((_unit.corruption < 90) && (_unit.corruption > 0)) {
                     var heresy_old = 0, heresy_new = 0;
-                    heresy_old = round((unit.corruption * unit.corruption) / 50) - 0.5;
-                    heresy_new = (heresy_old * 50) / unit.corruption;
-                    unit.corruption = max(0, heresy_new);
+                    heresy_old = round((_unit.corruption * _unit.corruption) / 50) - 0.5;
+                    heresy_new = (heresy_old * 50) / _unit.corruption;
+                    _unit.corruption = max(0, heresy_new);
                 }
             }
         }

--- a/objects/obj_controller/Alarm_5.gml
+++ b/objects/obj_controller/Alarm_5.gml
@@ -291,21 +291,23 @@ try {
     for (var c = 0; c < 11; c++) {
         for (var e = 0; e < array_length(obj_ini.TTRPG[c]); e++) {
             var _unit = fetch_unit([c,e]);
-            if (_unit.god_status == 10) {
-                if (!is_struct(_unit)) {
-                    continue;
-                }
-                p += 1;
-                penit_co[p] = c;
-                penit_id[p] = e;
-                penitorium += 1;
-                _unit.alter_loyalty(-1);
-                if ((_unit.corruption < 90) && (_unit.corruption > 0)) {
-                    var heresy_old = 0, heresy_new = 0;
-                    heresy_old = round((_unit.corruption * _unit.corruption) / 50) - 0.5;
-                    heresy_new = (heresy_old * 50) / _unit.corruption;
-                    _unit.corruption = max(0, heresy_new);
-                }
+            if (!is_struct(_unit)) {
+                continue;
+            }
+            if (_unit.god_status != 10) {
+                continue;
+            }
+
+            p += 1;
+            penit_co[p] = c;
+            penit_id[p] = e;
+            penitorium += 1;
+            _unit.alter_loyalty(-1);
+            if ((_unit.corruption < 90) && (_unit.corruption > 0)) {
+                var heresy_old = 0, heresy_new = 0;
+                heresy_old = round((_unit.corruption * _unit.corruption) / 50) - 0.5;
+                heresy_new = (heresy_old * 50) / _unit.corruption;
+                _unit.corruption = max(0, heresy_new);
             }
         }
     }

--- a/objects/obj_controller/Create_0.gml
+++ b/objects/obj_controller/Create_0.gml
@@ -591,7 +591,7 @@ if (instance_exists(obj_ini)) {
         penitent_end = millenium + year + obj_ini.penitent_end;
     }
 
-    if (string_count(obj_ini.spe[0][1], "$") > 0) {
+    if (string_count(obj_ini.TTRPG[0][0].specials, "$") > 0) {
         born_leader = 1;
     }
 }

--- a/objects/obj_controller/Mouse_50.gml
+++ b/objects/obj_controller/Mouse_50.gml
@@ -31,7 +31,7 @@ if ((menu == eMENU.RECLUSIAM) && (cooldown <= 0) && (penitorium > 0)) {
             if ((mouse_x >= xx + 1508) && (mouse_x < xx + 1567)) {
                 cooldown = 20;
                 var c = penit_co[qp], e = penit_id[qp];
-                obj_ini.god[c][e] -= 10;
+                obj_ini.TTRPG[c][e].god_status -= 10;
                 re = 1;
             }
         }
@@ -44,8 +44,8 @@ if ((menu == eMENU.RECLUSIAM) && (cooldown <= 0) && (penitorium > 0)) {
         penitorium = 0;
         var p = 0;
         for (var c = 0; c < 11; c++) {
-            for (var e = 0; e < array_length(obj_ini.god[c]); e++) {
-                if (obj_ini.god[c][e] == 10) {
+            for (var e = 0; e < array_length(obj_ini.TTRPG[c]); e++) {
+                if (obj_ini.TTRPG[c][e].god_status == 10) {
                     p += 1;
                     penit_co[p] = c;
                     penit_id[p] = e;

--- a/objects/obj_ini/Create_0.gml
+++ b/objects/obj_ini/Create_0.gml
@@ -118,29 +118,29 @@ veh_acc = array_create_2d(_max_companies, _max_vehicles, "");
 defaults_slot = 100;
 
 /// @type {Array<Array<Real>>}
-race = array_create_2d(11, 501, 0);
+race = array_create(11, 501);
 /// @type {Array<Array<String>>}
-name = array_create_2d(11, 501, "");
+name = array_create(11, []);
 /// @type {Array<Array<String>>}
-role = array_create_2d(11, 501, "");
+role = array_create(11, []);
 /// @type {Array<Array<String>>}
-wep1 = array_create_2d(11, 501, "");
+wep1 = array_create(11, []);
 /// @type {Array<Array<String>>}
-spe = array_create_2d(11, 501, "");
+spe = array_create(11, []);
 /// @type {Array<Array<String>>}
-wep2 = array_create_2d(11, 501, "");
+wep2 = array_create(11, []);
 /// @type {Array<Array<String>>}
-armour = array_create_2d(11, 501, "");
+armour = array_create(11, []);
 /// @type {Array<Array<String>>}
-gear = array_create_2d(11, 501, "");
+gear = array_create(11, []);
 /// @type {Array<Array<String>>}
-mobi = array_create_2d(11, 501, "");
+mobi = array_create(11, []);
 /// @type {Array<Array<Real>>}
-age = array_create_2d(11, 501, 0);
-/// @type {Array<Array<Real>>}
-god = array_create_2d(11, 501, 0);
+age = array_create_2d(11, []);
+/// @type {Array<Ar<Real>>}
+god = array_create(11, []);
 /// @type {Array<Array<Struct.TTRPG_stats>>}
-TTRPG = array_create_2d(11, 501, undefined);
+TTRPG = array_create(11, []);
 
 load_default_gear = function(_role_id, _role_name, _wep1, _wep2, _armour, _mobi, _gear) {
     role[defaults_slot][_role_id] = _role_name;

--- a/objects/obj_ini/Create_0.gml
+++ b/objects/obj_ini/Create_0.gml
@@ -118,7 +118,7 @@ veh_acc = array_create_2d(_max_companies, _max_vehicles, "");
 defaults_slot = 100;
 
 /// @type {Array<Array<Real>>}
-race = array_create(11, 501);
+race = array_create(11, []);
 /// @type {Array<Array<String>>}
 name = array_create(11, []);
 /// @type {Array<Array<String>>}

--- a/objects/obj_ini/Create_0.gml
+++ b/objects/obj_ini/Create_0.gml
@@ -126,8 +126,6 @@ role = array_create(11, []);
 /// @type {Array<Array<String>>}
 wep1 = array_create(11, []);
 /// @type {Array<Array<String>>}
-spe = array_create(11, []);
-/// @type {Array<Array<String>>}
 wep2 = array_create(11, []);
 /// @type {Array<Array<String>>}
 armour = array_create(11, []);
@@ -135,10 +133,6 @@ armour = array_create(11, []);
 gear = array_create(11, []);
 /// @type {Array<Array<String>>}
 mobi = array_create(11, []);
-/// @type {Array<Array<Real>>}
-age = array_create_2d(11, []);
-/// @type {Array<Ar<Real>>}
-god = array_create(11, []);
 /// @type {Array<Array<Struct.TTRPG_stats>>}
 TTRPG = array_create(11, []);
 

--- a/objects/obj_ini/Create_0.gml
+++ b/objects/obj_ini/Create_0.gml
@@ -176,14 +176,12 @@ if (global.load == -1) {
 /// Called from save function to take all object variables and convert them to a json savable format and return it
 serialize = function() {
     var _marines = array_create(0);
-    for (var _coy = 0; _coy <= 10; _coy++) {
-        for (var _mar = 0; _mar <= 500; _mar++) {
+    for (var _coy = 0; _coy <= obj_ini.companies; _coy++) {
+        for (var _mar = 0; _mar < array_length(obj_ini.TTRPG[_coy]); _mar++) {
             if (name[_coy][_mar] != "") {
                 var _marine_json = jsonify_marine_struct(_coy, _mar, false);
                 array_push(_marines, _marine_json);
-            } else if (_mar > 0 && _mar <= 499 && name[_coy][_mar + 1] == "") {
-                break;
-            }
+            } 
         }
     }
 

--- a/objects/obj_p_assra/Alarm_0.gml
+++ b/objects/obj_p_assra/Alarm_0.gml
@@ -18,7 +18,7 @@ for (o = 0; o < array_length(origin.board_co); o++) {
 
             if (apothecary_had > 0) {
                 if (unit.base_group == "astartes") {
-                    var age = obj_ini.age[co][i];
+                    var age = unit.age;
                     if ((age <= ((obj_controller.millenium * 1000) + obj_controller.year) - 10) && (obj_ini.zygote == 0)) {
                         seed_lost += 1;
                     }

--- a/scripts/scr_UnitGroup/scr_UnitGroup.gml
+++ b/scripts/scr_UnitGroup/scr_UnitGroup.gml
@@ -860,7 +860,7 @@ function stat_valuator(search_params, _unit) {
 function collect_by_religeon(religion, sub_cult = "", location = "") {
     var _units = [], _unit, count = 0, _add = false;
     for (var com = 0; com <= obj_ini.companies; com++) {
-        for (var i = 1; i < array_length(obj_ini.TTRPG[com]); i++) {
+        for (var i = 0; i < array_length(obj_ini.TTRPG[com]); i++) {
             _add = false;
             _unit = fetch_unit([com, i]);
             if (!is_struct(_unit)) {

--- a/scripts/scr_add_man/scr_add_man.gml
+++ b/scripts/scr_add_man/scr_add_man.gml
@@ -76,7 +76,7 @@ function scr_add_man(man_role, target_company, spawn_exp, spawn_name, corruption
             }
         }
 
-        obj_ini.age[target_company][_company_slot] = (obj_controller.millenium * 1000) + obj_controller.year;
+        _unit.age = (obj_controller.millenium * 1000) + obj_controller.year;
 
         switch (spawn_name) {
             case "":

--- a/scripts/scr_add_man/scr_add_man.gml
+++ b/scripts/scr_add_man/scr_add_man.gml
@@ -73,9 +73,6 @@ function scr_add_man(man_role, target_company, spawn_exp, spawn_name, corruption
             // TODO: Implement Chaos Spawn (Race 12, Possessed Claws)
         }
     }
-
-    _unit.age = (obj_controller.millenium * 1000) + obj_controller.year;
-
     switch (spawn_name) {
         case "":
         case "imperial":
@@ -123,6 +120,8 @@ function scr_add_man(man_role, target_company, spawn_exp, spawn_name, corruption
     _unit.add_exp(spawn_exp);
     _unit.allocate_unit_to_fresh_spawn(home_spot);
     _unit.update_role(man_role);
+    _unit.age = (obj_controller.millenium * 1000) + obj_controller.year;
+
     with (obj_ini) {
         scr_company_order(target_company);
     }

--- a/scripts/scr_add_man/scr_add_man.gml
+++ b/scripts/scr_add_man/scr_add_man.gml
@@ -13,9 +13,8 @@ function scr_add_man(man_role, target_company, spawn_exp, spawn_name, corruption
         "Flash Git",
     ];
     var _gear = {};
-    var _company_slot = 0;
 
-    _company_slot = find_company_open_slot(target_company);
+    var _company_slot = find_company_open_slot(target_company);
 
     scr_wipe_unit(target_company, _company_slot);
     var _unit = fetch_unit([target_company, _company_slot]);

--- a/scripts/scr_add_man/scr_add_man.gml
+++ b/scripts/scr_add_man/scr_add_man.gml
@@ -17,118 +17,116 @@ function scr_add_man(man_role, target_company, spawn_exp, spawn_name, corruption
 
     _company_slot = find_company_open_slot(target_company);
 
-    if (_company_slot != -1) {
-        scr_wipe_unit(target_company, _company_slot);
-        var _unit = fetch_unit([target_company, _company_slot]);
-        if (other_gear == true) {
-            // TODO: Implement logic for Chapter Servitor, Neophyte, and Serf (Race 1, Scout/Astartes stats)
-            // TODO: Implement logic for Mercenary (Race 2, Human stats, Hellgun)
-            // TODO: Implement logic for Auxiliary Soldier (Race 2.5, Renegade stats)
+    scr_wipe_unit(target_company, _company_slot);
+    var _unit = fetch_unit([target_company, _company_slot]);
+    if (other_gear == true) {
+        // TODO: Implement logic for Chapter Servitor, Neophyte, and Serf (Race 1, Scout/Astartes stats)
+        // TODO: Implement logic for Mercenary (Race 2, Human stats, Hellgun)
+        // TODO: Implement logic for Auxiliary Soldier (Race 2.5, Renegade stats)
 
-            switch (man_role) {
-                case "Skitarii":
-                    spawn_exp = 10;
-                    obj_ini.race[target_company][_company_slot] = 3;
-                    _unit = new TTRPG_stats("mechanicus", target_company, _company_slot, "skitarii");
-                    break;
-                case "Techpriest":
-                    spawn_exp = 100;
-                    obj_ini.race[target_company][_company_slot] = 3;
-                    _unit = new TTRPG_stats("mechanicus", target_company, _company_slot, "tech_priest");
-                    break;
-                case "Crusader":
-                    spawn_exp = 10;
-                    obj_ini.race[target_company][_company_slot] = 4;
-                    _unit = new TTRPG_stats("inquisition", target_company, _company_slot, "inquisition_crusader");
-                    break;
-                // TODO: Implement Sanctioned Psyker (Race 4, Psychic powers, Force Staff)
-                case "Sister of Battle":
-                    spawn_exp = 20;
-                    obj_ini.race[target_company][_company_slot] = 5;
-                    _unit = new TTRPG_stats("adeptus_sororitas", target_company, _company_slot, "sister_of_battle");
-                    break;
-                case "Sister Hospitaler":
-                    spawn_exp = 50;
-                    obj_ini.race[target_company][_company_slot] = 5;
-                    _unit = new TTRPG_stats("adeptus_sororitas", target_company, _company_slot, "sister_hospitaler");
-                    break;
-                // TODO: Implement Prioress (Race 5, Sororitas leader gear/stats)
-                case "Ranger":
-                    spawn_exp = 180;
-                    obj_ini.race[target_company][_company_slot] = 6;
-                    _unit = new TTRPG_stats("Eldari", target_company, _company_slot, "eldar_ranger");
-                    break;
-                case "Ork Sniper":
-                    spawn_exp = 20;
-                    obj_ini.race[target_company][_company_slot] = eFACTION.ORK;
-                    _unit = new TTRPG_stats("ork", target_company, _company_slot, "ork_sniper");
-                    break;
-                case "Flash Git":
-                    spawn_exp = 40;
-                    obj_ini.race[target_company][_company_slot] = eFACTION.ORK;
-                    _unit = new TTRPG_stats("ork", target_company, _company_slot, "flash_git");
-                    break;
-                // TODO: Implement Warboss (Race 7)
-                // TODO: Implement Fire Warrior (Race 8, T'au gear/stats)
-                // TODO: Implement Chaos Cultist (Race 10, Autogun)
-                // TODO: Implement Chaos Champion (Race 11, CSM stats)
-                // TODO: Implement Chaos Spawn (Race 12, Possessed Claws)
-            }
-        }
-
-        _unit.age = (obj_controller.millenium * 1000) + obj_controller.year;
-
-        switch (spawn_name) {
-            case "":
-            case "imperial":
-                obj_ini.name[target_company][_company_slot] = global.name_generator.ChapterMemberNameGeneration();
-                break;
-            default:
-                obj_ini.name[target_company][_company_slot] = spawn_name;
-                break;
-        }
         switch (man_role) {
-            case "Ranger":
-                obj_ini.name[target_company][_company_slot] = global.name_generator.GenerateMultiSyllable("eldar", 2);
+            case "Skitarii":
+                spawn_exp = 10;
+                obj_ini.race[target_company][_company_slot] = 3;
+                _unit = new TTRPG_stats("mechanicus", target_company, _company_slot, "skitarii");
                 break;
-
-            case "Ork Sniper":
-            case "Flash Git":
-                obj_ini.name[target_company][_company_slot] = global.name_generator.GenerateComposite("ork", false);
+            case "Techpriest":
+                spawn_exp = 100;
+                obj_ini.race[target_company][_company_slot] = 3;
+                _unit = new TTRPG_stats("mechanicus", target_company, _company_slot, "tech_priest");
                 break;
-
+            case "Crusader":
+                spawn_exp = 10;
+                obj_ini.race[target_company][_company_slot] = 4;
+                _unit = new TTRPG_stats("inquisition", target_company, _company_slot, "inquisition_crusader");
+                break;
+            // TODO: Implement Sanctioned Psyker (Race 4, Psychic powers, Force Staff)
             case "Sister of Battle":
-            case "Sister Hospitaler":
-                obj_ini.name[target_company][_company_slot] = global.name_generator.GenerateFromSet("imperial_female");
+                spawn_exp = 20;
+                obj_ini.race[target_company][_company_slot] = 5;
+                _unit = new TTRPG_stats("adeptus_sororitas", target_company, _company_slot, "sister_of_battle");
                 break;
+            case "Sister Hospitaler":
+                spawn_exp = 50;
+                obj_ini.race[target_company][_company_slot] = 5;
+                _unit = new TTRPG_stats("adeptus_sororitas", target_company, _company_slot, "sister_hospitaler");
+                break;
+            // TODO: Implement Prioress (Race 5, Sororitas leader gear/stats)
+            case "Ranger":
+                spawn_exp = 180;
+                obj_ini.race[target_company][_company_slot] = 6;
+                _unit = new TTRPG_stats("Eldari", target_company, _company_slot, "eldar_ranger");
+                break;
+            case "Ork Sniper":
+                spawn_exp = 20;
+                obj_ini.race[target_company][_company_slot] = eFACTION.ORK;
+                _unit = new TTRPG_stats("ork", target_company, _company_slot, "ork_sniper");
+                break;
+            case "Flash Git":
+                spawn_exp = 40;
+                obj_ini.race[target_company][_company_slot] = eFACTION.ORK;
+                _unit = new TTRPG_stats("ork", target_company, _company_slot, "flash_git");
+                break;
+            // TODO: Implement Warboss (Race 7)
+            // TODO: Implement Fire Warrior (Race 8, T'au gear/stats)
+            // TODO: Implement Chaos Cultist (Race 10, Autogun)
+            // TODO: Implement Chaos Champion (Race 11, CSM stats)
+            // TODO: Implement Chaos Spawn (Race 12, Possessed Claws)
         }
-
-        if (!array_contains(non_marine_roles, man_role)) {
-            obj_ini.race[target_company][_company_slot] = eFACTION.PLAYER;
-            if (man_role == obj_ini.role[100][12]) {
-                _gear = {
-                    wep2: obj_ini.wep2[100][12],
-                    wep1: obj_ini.wep1[100][12],
-                    armour: obj_ini.armour[100][12],
-                    gear: obj_ini.gear[100][12],
-                    mobi: obj_ini.mobi[100][12],
-                };
-            }
-
-            _unit = new TTRPG_stats("chapter", target_company, _company_slot, "scout", other_data);
-            _unit.corruption = corruption;
-            _unit.roll_age();
-            _unit.alter_equipment(_gear);
-            marines += 1;
-        }
-        obj_ini.TTRPG[target_company][_company_slot] = _unit;
-        _unit.add_exp(spawn_exp);
-        _unit.allocate_unit_to_fresh_spawn(home_spot);
-        _unit.update_role(man_role);
-        with (obj_ini) {
-            scr_company_order(target_company);
-        }
-        _unit.update_health(_unit.max_health());
-        return _unit;
     }
+
+    _unit.age = (obj_controller.millenium * 1000) + obj_controller.year;
+
+    switch (spawn_name) {
+        case "":
+        case "imperial":
+            obj_ini.name[target_company][_company_slot] = global.name_generator.ChapterMemberNameGeneration();
+            break;
+        default:
+            obj_ini.name[target_company][_company_slot] = spawn_name;
+            break;
+    }
+    switch (man_role) {
+        case "Ranger":
+            obj_ini.name[target_company][_company_slot] = global.name_generator.GenerateMultiSyllable("eldar", 2);
+            break;
+
+        case "Ork Sniper":
+        case "Flash Git":
+            obj_ini.name[target_company][_company_slot] = global.name_generator.GenerateComposite("ork", false);
+            break;
+
+        case "Sister of Battle":
+        case "Sister Hospitaler":
+            obj_ini.name[target_company][_company_slot] = global.name_generator.GenerateFromSet("imperial_female");
+            break;
+    }
+
+    if (!array_contains(non_marine_roles, man_role)) {
+        obj_ini.race[target_company][_company_slot] = eFACTION.PLAYER;
+        if (man_role == obj_ini.role[100][12]) {
+            _gear = {
+                wep2: obj_ini.wep2[100][12],
+                wep1: obj_ini.wep1[100][12],
+                armour: obj_ini.armour[100][12],
+                gear: obj_ini.gear[100][12],
+                mobi: obj_ini.mobi[100][12],
+            };
+        }
+
+        _unit = new TTRPG_stats("chapter", target_company, _company_slot, "scout", other_data);
+        _unit.corruption = corruption;
+        _unit.roll_age();
+        _unit.alter_equipment(_gear);
+        marines += 1;
+    }
+    obj_ini.TTRPG[target_company][_company_slot] = _unit;
+    _unit.add_exp(spawn_exp);
+    _unit.allocate_unit_to_fresh_spawn(home_spot);
+    _unit.update_role(man_role);
+    with (obj_ini) {
+        scr_company_order(target_company);
+    }
+    _unit.update_health(_unit.max_health());
+    return _unit;
 }

--- a/scripts/scr_add_man/scr_add_man.gml
+++ b/scripts/scr_add_man/scr_add_man.gml
@@ -120,7 +120,9 @@ function scr_add_man(man_role, target_company, spawn_exp, spawn_name, corruption
     _unit.add_exp(spawn_exp);
     _unit.allocate_unit_to_fresh_spawn(home_spot);
     _unit.update_role(man_role);
-    _unit.age = (obj_controller.millenium * 1000) + obj_controller.year;
+    if (array_contains(non_marine_roles, man_role)) {
+        _unit.age = (obj_controller.millenium * 1000) + obj_controller.year;
+    }
 
     with (obj_ini) {
         scr_company_order(target_company);

--- a/scripts/scr_after_combat/scr_after_combat.gml
+++ b/scripts/scr_after_combat/scr_after_combat.gml
@@ -301,7 +301,7 @@ function after_combat_recover_marine_gene_seed(unit) {
     }
 
     if (unit.base_group == "astartes") {
-        var _birthday = unit.age();
+        var _birthday = unit.age;
         var _current_year = (obj_controller.millenium * 1000) + obj_controller.year;
         var _seed_harvestable = 0;
         var _seed_lost = 0;

--- a/scripts/scr_chapter_managent_events/scr_chapter_managent_events.gml
+++ b/scripts/scr_chapter_managent_events/scr_chapter_managent_events.gml
@@ -273,10 +273,8 @@ function new_forge_master_chosen(pick) {
         reset_popup_options();
         if (pick.company > 0) {
             for (var i = 0; i < array_length(obj_ini.TTRPG[0]); i++) {
-                if (obj_ini.TTRPG[0][i].name() == "") {
-                    scr_move_unit_info(pick.company, 0, pick.marine_number, i);
-                    break;
-                }
+                scr_move_unit_info(pick.company, 0, pick.marine_number, i);
+                break;
             }
         }
     }

--- a/scripts/scr_chapter_managent_events/scr_chapter_managent_events.gml
+++ b/scripts/scr_chapter_managent_events/scr_chapter_managent_events.gml
@@ -272,10 +272,8 @@ function new_forge_master_chosen(pick) {
         }
         reset_popup_options();
         if (pick.company > 0) {
-            for (var i = 0; i < array_length(obj_ini.TTRPG[0]); i++) {
-                scr_move_unit_info(pick.company, 0, pick.marine_number, i);
-                break;
-            }
+            var _company_slot = find_company_open_slot(0);
+            scr_move_unit_info(pick.company, 0, pick.marine_number, _company_slot);
         }
     }
 }

--- a/scripts/scr_chapter_managent_events/scr_chapter_managent_events.gml
+++ b/scripts/scr_chapter_managent_events/scr_chapter_managent_events.gml
@@ -272,8 +272,8 @@ function new_forge_master_chosen(pick) {
         }
         reset_popup_options();
         if (pick.company > 0) {
-            for (var i = 1; i < 500; i++) {
-                if (obj_ini.name[0][i] == "") {
+            for (var i = 0; i < array_length(obj_ini.TTRPG[0]); i++) {
+                if (obj_ini.TTRPG[0][i].name() == "") {
                     scr_move_unit_info(pick.company, 0, pick.marine_number, i);
                     break;
                 }

--- a/scripts/scr_check_equip/scr_check_equip.gml
+++ b/scripts/scr_check_equip/scr_check_equip.gml
@@ -9,10 +9,8 @@ function scr_check_equip(search_item, system, planet_or_ship_id, remove_item) {
     var man_c = 0, man_i = 0, have = 0, unit, marine_present;
 
     for (var c = 0; c <= 10; c++) {
-        for (var i = 1; i <= 500; i++) {
-            if (obj_ini.name[c][i] == "") {
-                continue;
-            }
+        for (var i = 0; i <= array_length(obj_ini.TTRPG[c]); i++) {
+
             marine_present = false;
             if (!instance_exists(obj_ncombat)) {
                 unit = fetch_unit([c, i]);

--- a/scripts/scr_check_equip/scr_check_equip.gml
+++ b/scripts/scr_check_equip/scr_check_equip.gml
@@ -8,8 +8,8 @@ function scr_check_equip(search_item, system, planet_or_ship_id, remove_item) {
 
     var man_c = 0, man_i = 0, have = 0, unit, marine_present;
 
-    for (var c = 0; c <= 10; c++) {
-        for (var i = 0; i <= array_length(obj_ini.TTRPG[c]); i++) {
+    for (var c = 0; c <= obj_ini.companies; c++) {
+        for (var i = 0; i < array_length(obj_ini.TTRPG[c]); i++) {
 
             marine_present = false;
             if (!instance_exists(obj_ncombat)) {

--- a/scripts/scr_civil_roster/scr_civil_roster.gml
+++ b/scripts/scr_civil_roster/scr_civil_roster.gml
@@ -366,7 +366,7 @@ function scr_civil_roster(_unit_location, _target_location, _is_planet) {
                     targ.dudes_num[targ.men] = 1;
                     targ.dudes_hp[targ.men] = unit.hp();
                     targ.dudes_exp[targ.men] = unit.experience;
-                    targ.dudes_powers[targ.men] = deploying_unit.spe[cooh][va];
+                    targ.dudes_powers[targ.men] = unit.specials;
                     targ.dudes_wep1[targ.men] = deploying_unit.wep1[cooh][va];
                     targ.dudes_wep2[targ.men] = deploying_unit.wep2[cooh][va];
                     targ.dudes_gear[targ.men] = deploying_unit.gear[cooh][va];
@@ -700,7 +700,7 @@ function scr_civil_roster(_unit_location, _target_location, _is_planet) {
                         col = obj_controller.bat_command_column;
                         new_combat.important_dudes += 1;
                         new_combat.big_mofo = 1;
-                        if (string_count("0", deploying_unit.spe[cooh][va]) > 0) {
+                        if (string_count("0", deploying_unit.specials) > 0) {
                             new_combat.chapter_master_psyker = 1;
                         } else {
                             new_combat.chapter_master_psyker = 0;
@@ -747,7 +747,7 @@ function scr_civil_roster(_unit_location, _target_location, _is_planet) {
                     targ.marine_mobi[targ.men] = unit.mobility_item();
                     targ.marine_hp[targ.men] = unit.hp();
                     targ.marine_exp[targ.men] = unit.experience;
-                    targ.marine_powers[targ.men] = deploying_unit.spe[cooh][va];
+                    targ.marine_powers[targ.men] = deploying_unit.specials;
                     targ.marine_ranged[targ.men] = unit.ranged_attack();
                     targ.marine_ac[targ.men] = unit.armour_calc();
                     targ.marine_attack[targ.men] = unit.melee_attack();

--- a/scripts/scr_civil_roster/scr_civil_roster.gml
+++ b/scripts/scr_civil_roster/scr_civil_roster.gml
@@ -700,7 +700,7 @@ function scr_civil_roster(_unit_location, _target_location, _is_planet) {
                         col = obj_controller.bat_command_column;
                         new_combat.important_dudes += 1;
                         new_combat.big_mofo = 1;
-                        if (string_count("0", deploying_unit.specials) > 0) {
+                        if (string_count("0", unit.specials) > 0) {
                             new_combat.chapter_master_psyker = 1;
                         } else {
                             new_combat.chapter_master_psyker = 0;
@@ -740,14 +740,14 @@ function scr_civil_roster(_unit_location, _target_location, _is_planet) {
                     targ.marine_co[targ.men] = unit.company;
                     targ.marine_id[targ.men] = v;
                     targ.marine_type[targ.men] = unit.role();
-                    targ.marine_wep1[targ.men] = deploying_unit.wep1[cooh][va];
-                    targ.marine_wep2[targ.men] = deploying_unit.wep2[cooh][va];
-                    targ.marine_armour[targ.men] = deploying_unit.armour[cooh][va];
-                    targ.marine_gear[targ.men] = deploying_unit.gear[cooh][va];
+                    targ.marine_wep1[targ.men] = unit.weapon_one();
+                    targ.marine_wep2[targ.men] = unit.weapon_two();
+                    targ.marine_armour[targ.men] = unit.armour();
+                    targ.marine_gear[targ.men] = unit.gear());
                     targ.marine_mobi[targ.men] = unit.mobility_item();
                     targ.marine_hp[targ.men] = unit.hp();
                     targ.marine_exp[targ.men] = unit.experience;
-                    targ.marine_powers[targ.men] = deploying_unit.specials;
+                    targ.marine_powers[targ.men] = unit.specials;
                     targ.marine_ranged[targ.men] = unit.ranged_attack();
                     targ.marine_ac[targ.men] = unit.armour_calc();
                     targ.marine_attack[targ.men] = unit.melee_attack();

--- a/scripts/scr_civil_roster/scr_civil_roster.gml
+++ b/scripts/scr_civil_roster/scr_civil_roster.gml
@@ -743,7 +743,7 @@ function scr_civil_roster(_unit_location, _target_location, _is_planet) {
                     targ.marine_wep1[targ.men] = unit.weapon_one();
                     targ.marine_wep2[targ.men] = unit.weapon_two();
                     targ.marine_armour[targ.men] = unit.armour();
-                    targ.marine_gear[targ.men] = unit.gear());
+                    targ.marine_gear[targ.men] = unit.gear();
                     targ.marine_mobi[targ.men] = unit.mobility_item();
                     targ.marine_hp[targ.men] = unit.hp();
                     targ.marine_exp[targ.men] = unit.experience;

--- a/scripts/scr_company_order/scr_company_order.gml
+++ b/scripts/scr_company_order/scr_company_order.gml
@@ -112,7 +112,7 @@ function scr_company_order(company) {
         var _temps = [];
         for (var i = 0; i < array_length(_company_marines.units); i++) {
             var _unit = _company_marines.units[i];
-            array_push(_temps, {unit: _unit, race: _unit.race(), name: _unit.name(), role: _unit.role(), wep1: _unit.weapon_one(true), wep2: _unit.weapon_two(true), armour: _unit.armour(true), gear: _unit.gear(true), mobi: _unit.mobility_item(true), age: _unit.age(), spe: _unit.specials(), god: _unit.god_status});
+            array_push(_temps, {unit: _unit, race: _unit.race(), name: _unit.name(), role: _unit.role(), wep1: _unit.weapon_one(true), wep2: _unit.weapon_two(true), armour: _unit.armour(true), gear: _unit.gear(true), mobi: _unit.mobility_item(true), age: _unit.age, spe: _unit.specials(), god: _unit.god_status});
         }
 
         TTRPG[co] = array_create(_temps, 0);
@@ -124,7 +124,6 @@ function scr_company_order(company) {
         armour[co] = array_create(_temps, 0);
         gear[co] = array_create(_temps, 0);
         mobi[co] = array_create(_temps, 0);
-        age[co] = array_create(_temps, 0);
         spe[co] = array_create(_temps, 0);
         for (var i = 0; i < array_length(_temps); i++) {
             var _unit = _temps[i];
@@ -138,7 +137,6 @@ function scr_company_order(company) {
             armour[co][i] = _unit.armour;
             gear[co][i] = _unit.gear;
             mobi[co][i] = _unit.mobi;
-            age[co][i] = _unit.age;
             spe[co][i] = _unit.spe;
             if (_struc.marine_number != i) {
                 if (TTRPG[_struc.company][_struc.marine_number].uid == _struc.uid) {

--- a/scripts/scr_company_order/scr_company_order.gml
+++ b/scripts/scr_company_order/scr_company_order.gml
@@ -112,9 +112,20 @@ function scr_company_order(company) {
         var _temps = [];
         for (var i = 0; i < array_length(_company_marines.units); i++) {
             var _unit = _company_marines.units[i];
-            array_push(_temps, {unit: _unit, race: _unit.race(), name: _unit.name(), role: _unit.role(), wep1: _unit.weapon_one(true), wep2: _unit.weapon_two(true), armour: _unit.armour(true), gear: _unit.gear(true), mobi: _unit.mobility_item(true), age: _unit.age(), spe: _unit.specials(), god: _unit.god_status()});
+            array_push(_temps, {unit: _unit, race: _unit.race(), name: _unit.name(), role: _unit.role(), wep1: _unit.weapon_one(true), wep2: _unit.weapon_two(true), armour: _unit.armour(true), gear: _unit.gear(true), mobi: _unit.mobility_item(true), age: _unit.age(), spe: _unit.specials(), god: _unit.god_status});
         }
 
+        TTRPG[co] = array_create(_temps, 0);
+        race[co] = array_create(_temps, 0);
+        name[co] = array_create(_temps, 0);
+        role[co] = array_create(_temps, 0);
+        wep1[co] = array_create(_temps, 0);
+        wep2[co] = array_create(_temps, 0);
+        armour[co] = array_create(_temps, 0);
+        gear[co] = array_create(_temps, 0);
+        mobi[co] = array_create(_temps, 0);
+        age[co] = array_create(_temps, 0);
+        spe[co] = array_create(_temps, 0);
         for (var i = 0; i < array_length(_temps); i++) {
             var _unit = _temps[i];
             var _struc = _unit.unit;
@@ -129,7 +140,6 @@ function scr_company_order(company) {
             mobi[co][i] = _unit.mobi;
             age[co][i] = _unit.age;
             spe[co][i] = _unit.spe;
-            god[co][i] = _unit.god;
             if (_struc.marine_number != i) {
                 if (TTRPG[_struc.company][_struc.marine_number].uid == _struc.uid) {
                     TTRPG[_struc.company][_struc.marine_number] = new TTRPG_stats("chapter", _struc.company, _struc.marine_number, "blank");

--- a/scripts/scr_company_order/scr_company_order.gml
+++ b/scripts/scr_company_order/scr_company_order.gml
@@ -112,7 +112,7 @@ function scr_company_order(company) {
         var _temps = [];
         for (var i = 0; i < array_length(_company_marines.units); i++) {
             var _unit = _company_marines.units[i];
-            array_push(_temps, {unit: _unit, race: _unit.race(), name: _unit.name(), role: _unit.role(), wep1: _unit.weapon_one(true), wep2: _unit.weapon_two(true), armour: _unit.armour(true), gear: _unit.gear(true), mobi: _unit.mobility_item(true), age: _unit.age, spe: _unit.specials(), god: _unit.god_status});
+            array_push(_temps, {unit: _unit, race: _unit.race(), name: _unit.name(), role: _unit.role(), wep1: _unit.weapon_one(true), wep2: _unit.weapon_two(true), armour: _unit.armour(true), gear: _unit.gear(true), mobi: _unit.mobility_item(true)});
         }
 
         TTRPG[co] = array_create(_temps, 0);
@@ -124,7 +124,6 @@ function scr_company_order(company) {
         armour[co] = array_create(_temps, 0);
         gear[co] = array_create(_temps, 0);
         mobi[co] = array_create(_temps, 0);
-        spe[co] = array_create(_temps, 0);
         for (var i = 0; i < array_length(_temps); i++) {
             var _unit = _temps[i];
             var _struc = _unit.unit;
@@ -137,7 +136,6 @@ function scr_company_order(company) {
             armour[co][i] = _unit.armour;
             gear[co][i] = _unit.gear;
             mobi[co][i] = _unit.mobi;
-            spe[co][i] = _unit.spe;
             if (_struc.marine_number != i) {
                 if (TTRPG[_struc.company][_struc.marine_number].uid == _struc.uid) {
                     TTRPG[_struc.company][_struc.marine_number] = new TTRPG_stats("chapter", _struc.company, _struc.marine_number, "blank");

--- a/scripts/scr_company_order/scr_company_order.gml
+++ b/scripts/scr_company_order/scr_company_order.gml
@@ -17,7 +17,7 @@ function sort_all_companies_to_map(map) {
 }
 
 function company_length(company){
-    return obj_ini.TTRPG[company];
+    return array_length(obj_ini.TTRPG[company]);
 }
 
 function scr_company_order(company) {

--- a/scripts/scr_company_order/scr_company_order.gml
+++ b/scripts/scr_company_order/scr_company_order.gml
@@ -17,7 +17,7 @@ function sort_all_companies_to_map(map) {
 }
 
 function company_length(company){
-    return obj_ini.TTRPG(company)
+    return obj_ini.TTRPG[company];
 }
 
 function scr_company_order(company) {

--- a/scripts/scr_company_order/scr_company_order.gml
+++ b/scripts/scr_company_order/scr_company_order.gml
@@ -115,15 +115,16 @@ function scr_company_order(company) {
             array_push(_temps, {unit: _unit, race: _unit.race(), name: _unit.name(), role: _unit.role(), wep1: _unit.weapon_one(true), wep2: _unit.weapon_two(true), armour: _unit.armour(true), gear: _unit.gear(true), mobi: _unit.mobility_item(true)});
         }
 
-        TTRPG[co] = array_create(_temps, 0);
-        race[co] = array_create(_temps, 0);
-        name[co] = array_create(_temps, 0);
-        role[co] = array_create(_temps, 0);
-        wep1[co] = array_create(_temps, 0);
-        wep2[co] = array_create(_temps, 0);
-        armour[co] = array_create(_temps, 0);
-        gear[co] = array_create(_temps, 0);
-        mobi[co] = array_create(_temps, 0);
+        var _new_length = array_length(_temps);
+        TTRPG[co] = array_create(_new_length, 0);
+        race[co] = array_create(_new_length, 0);
+        name[co] = array_create(_new_length, 0);
+        role[co] = array_create(_new_length, 0);
+        wep1[co] = array_create(_new_length, 0);
+        wep2[co] = array_create(_new_length, 0);
+        armour[co] = array_create(_new_length, 0);
+        gear[co] = array_create(_new_length, 0);
+        mobi[co] = array_create(_new_length, 0);
         for (var i = 0; i < array_length(_temps); i++) {
             var _unit = _temps[i];
             var _struc = _unit.unit;
@@ -136,12 +137,6 @@ function scr_company_order(company) {
             armour[co][i] = _unit.armour;
             gear[co][i] = _unit.gear;
             mobi[co][i] = _unit.mobi;
-            if (_struc.marine_number != i) {
-                if (TTRPG[_struc.company][_struc.marine_number].uid == _struc.uid) {
-                    TTRPG[_struc.company][_struc.marine_number] = new TTRPG_stats("chapter", _struc.company, _struc.marine_number, "blank");
-                    scr_wipe_unit(_struc.company, _struc.marine_number);
-                }
-            }
             _struc.company = co;
             _struc.marine_number = i;
             if (_struc.squad != "none") {

--- a/scripts/scr_company_order/scr_company_order.gml
+++ b/scripts/scr_company_order/scr_company_order.gml
@@ -16,6 +16,10 @@ function sort_all_companies_to_map(map) {
     }
 }
 
+function company_length(company){
+    return obj_ini.TTRPG(company)
+}
+
 function scr_company_order(company) {
     try {
         // company : company number

--- a/scripts/scr_company_view/scr_company_view.gml
+++ b/scripts/scr_company_view/scr_company_view.gml
@@ -60,7 +60,7 @@ function find_company_open_slot(target_company) {
         array_push(obj_ini.gear[target_company], "");
         array_push(obj_ini.mobi[target_company], "");
         array_push(obj_ini.TTRPG[target_company], undefined);
-        good = array_length(obj_ini.TTRPG) - 1;
+        good = array_length(obj_ini.TTRPG[target_company]) - 1;
     }
     return good;
 }

--- a/scripts/scr_company_view/scr_company_view.gml
+++ b/scripts/scr_company_view/scr_company_view.gml
@@ -49,6 +49,17 @@ function find_company_open_slot(target_company) {
             break;
         }
     }
+    if (good == -1){
+        array_push(race[target_company], "");
+        array_push(name[target_company],"");
+        array_push(role[target_company],"");
+        array_push(wep1[target_company], "");
+        array_push(wep2[target_company] , "");
+        array_push(armour[target_company] , "");
+        array_push(gear[target_company] , "");
+        array_push(mobi[target_company] , "");
+        array_push(TTRPG[target_company],undefined);        
+    }
     return good;
 }
 

--- a/scripts/scr_company_view/scr_company_view.gml
+++ b/scripts/scr_company_view/scr_company_view.gml
@@ -49,16 +49,18 @@ function find_company_open_slot(target_company) {
             break;
         }
     }
-    if (good == -1){
-        array_push(race[target_company], "");
-        array_push(name[target_company],"");
-        array_push(role[target_company],"");
-        array_push(wep1[target_company], "");
-        array_push(wep2[target_company] , "");
-        array_push(armour[target_company] , "");
-        array_push(gear[target_company] , "");
-        array_push(mobi[target_company] , "");
-        array_push(TTRPG[target_company],undefined);        
+    if (good == -1) {
+        good = array_length(obj_ini.name[target_company]);
+        array_push(obj_ini.race[target_company], 0);
+        array_push(obj_ini.name[target_company], "");
+        array_push(obj_ini.role[target_company], "");
+        array_push(obj_ini.wep1[target_company], "");
+        array_push(obj_ini.wep2[target_company], "");
+        array_push(obj_ini.armour[target_company], "");
+        array_push(obj_ini.gear[target_company], "");
+        array_push(obj_ini.mobi[target_company], "");
+        array_push(obj_ini.TTRPG[target_company], undefined);
+    }
     }
     return good;
 }

--- a/scripts/scr_company_view/scr_company_view.gml
+++ b/scripts/scr_company_view/scr_company_view.gml
@@ -60,7 +60,7 @@ function find_company_open_slot(target_company) {
         array_push(obj_ini.gear[target_company], "");
         array_push(obj_ini.mobi[target_company], "");
         array_push(obj_ini.TTRPG[target_company], undefined);
-    }
+        good = array_length(obj_ini.TTRPG) - 1;
     }
     return good;
 }

--- a/scripts/scr_controller_helpers/scr_controller_helpers.gml
+++ b/scripts/scr_controller_helpers/scr_controller_helpers.gml
@@ -236,8 +236,8 @@ function scr_toggle_reclu() {
                 // Get list of jailed marines
                 var p = 0;
                 for (var c = 0; c < 11; c++) {
-                    for (var e = 0; e < array_length(obj_ini.god[c]); e++) {
-                        if (obj_ini.god[c][e] == 10) {
+                    for (var e = 0; e < array_length(obj_ini.TTRPG[c]); e++) {
+                        if (obj_ini.TTRPG[c][e].god_status == 10) {
                             p += 1;
                             penit_co[p] = c;
                             penit_id[p] = e;

--- a/scripts/scr_count_forces/scr_count_forces.gml
+++ b/scripts/scr_count_forces/scr_count_forces.gml
@@ -6,7 +6,6 @@ function scr_count_forces(_unit_location, _target_location, _is_planet, _return_
     var _marine_count = 0;
     var _vehicle_count = 0;
     var _max_companies = 11;
-    var _safety_limit = 500;
 
     for (var _company = 0; _company < _max_companies; _company++) {
         var _veh_race = obj_ini.veh_race[_company];
@@ -14,7 +13,7 @@ function scr_count_forces(_unit_location, _target_location, _is_planet, _return_
         var _veh_wid = obj_ini.veh_wid[_company];
         var _veh_len = array_length(_veh_race);
 
-        for (var i = 0; i < _safety_limit; i++) {
+        for (var i = 0; i < array_length(obj_ini.TTRPG[_company]); i++) {
             var _unit = fetch_unit([_company, i]);
             var _marine_exists = is_struct(_unit) && _unit.name() != "";
             var _vehicle_exists = i < _veh_len;

--- a/scripts/scr_crusade/scr_crusade.gml
+++ b/scripts/scr_crusade/scr_crusade.gml
@@ -5,7 +5,6 @@ function scr_crusade() {
 
     var unit;
     var co = 0, i = 0, apoth = 0, death_determination = 0, death_determination_2 = 0, roll3 = 0, type = "", artifacts = 0, clean = 0;
-    good = 0;
     seed = 0;
     marines_lost = 0;
     var heroics_strings = [];
@@ -58,18 +57,14 @@ function scr_crusade() {
 
     var death_data = death_sets[$ type];
 
-    for (co = 0; co <= 10; co++) {
+    for (co = 0; co <= company_length(co); co++) {
         clean[co] = 0;
     }
     var total_ship_id = array_concat(capital_num, frigate_num, escort_num);
 
-    for (co = 0; co <= 10; co++) {
-        for (i = 0; i <= 500; i++) {
-            good = 0;
+    for (co = 0; co <= obj_ini.company_length(); co++) {
+        for (i = 0; i <= company_length(co)); i++) {
             dead = false;
-            if (obj_ini.name[co][i] == "") {
-                continue;
-            }
             unit = fetch_unit([co, i]);
             if (!is_struct(unit)) {
                 continue;

--- a/scripts/scr_crusade/scr_crusade.gml
+++ b/scripts/scr_crusade/scr_crusade.gml
@@ -57,13 +57,13 @@ function scr_crusade() {
 
     var death_data = death_sets[$ type];
 
-    for (co = 0; co <= company_length(co); co++) {
+    for (co = 0; co <= companies; co++) {
         clean[co] = 0;
     }
     var total_ship_id = array_concat(capital_num, frigate_num, escort_num);
 
-    for (co = 0; co <= obj_ini.company_length(); co++) {
-        for (i = 0; i <= company_length(co)); i++) {
+    for (co = 0; co <= obj_ini.companies; co++) {
+        for (i = 0; i < company_length(co); i++) {
             dead = false;
             unit = fetch_unit([co, i]);
             if (!is_struct(unit)) {

--- a/scripts/scr_dialogue/scr_dialogue.gml
+++ b/scripts/scr_dialogue/scr_dialogue.gml
@@ -2922,21 +2922,13 @@ function scr_dialogue(diplo_keyphrase, data = {}) {
                 if (rando == 5) {
                     obj_controller.useful_info += "CM|";
 
-                    var him_c = 0, him_i = 0, him_num = 0, him_cor = 0, split = "";
+                    var _unit = scr_max_marine("chaos");
 
-                    split = scr_max_marine("chaos");
-
-                    explode_script(split, "|");
-                    him_c = real(explode[0]);
-                    him_i = real(explode[1]);
-                    him_num = string(explode[2]);
-                    him_cor = real(explode[3]);
-
-                    if (him_cor == 0) {
+                    if (_unit.company == 0) {
                         diplo_text = "I have looked into the strands of fate, with your chapter, and found that the future is not suspect for any of your men.  None of them have their minds poisoned by the taint of chaos.";
                     }
-                    if (him_cor > 0) {
-                        diplo_text = "I have looked into the strands of fate, with your chapter.  Your 'battle brother' " + string(him_num) + " has a clouded, dark future- it is advised you watch him carefully.";
+                    else if (_unit.company > 0) {
+                        diplo_text = $"I have looked into the strands of fate, with your chapter.  Your 'battle brother' {_unit.name_role()} has a clouded, dark future- it is advised you watch him carefully.";
                     }
                 }
                 // * Next random event *

--- a/scripts/scr_dialogue/scr_dialogue.gml
+++ b/scripts/scr_dialogue/scr_dialogue.gml
@@ -178,8 +178,9 @@ function scr_dialogue(diplo_keyphrase, data = {}) {
 
             // Option4 here if all the right conditions are met
             var born = false;
-            for (var i = 1; i <= 200; i++) {
-                if ((obj_ini.role[0][i] == obj_ini.role[100][eROLE.CHAPTERMASTER]) && (string_count("$", obj_ini.spe[0][i]) > 0)) {
+            for (var i = 0; i < array_length(obj_ini.TTRPG[0]); i++) {
+                var _unit = fetch_unit([o, i]);
+                if ((_unit.role() == obj_ini.role[100][eROLE.CHAPTERMASTER]) && (string_count("$", _unit.specials) > 0)) {
                     born = true;
                 }
             }

--- a/scripts/scr_dialogue/scr_dialogue.gml
+++ b/scripts/scr_dialogue/scr_dialogue.gml
@@ -179,7 +179,7 @@ function scr_dialogue(diplo_keyphrase, data = {}) {
             // Option4 here if all the right conditions are met
             var born = false;
             for (var i = 0; i < array_length(obj_ini.TTRPG[0]); i++) {
-                var _unit = fetch_unit([o, i]);
+                var _unit = fetch_unit([0, i]);
                 if ((_unit.role() == obj_ini.role[100][eROLE.CHAPTERMASTER]) && (string_count("$", _unit.specials) > 0)) {
                     born = true;
                 }

--- a/scripts/scr_enemy_ai_d/scr_enemy_ai_d.gml
+++ b/scripts/scr_enemy_ai_d/scr_enemy_ai_d.gml
@@ -164,9 +164,10 @@ function scr_enemy_ai_d() {
                 scr_event_log("red", $"Chief {obj_ini.role[100][17]} reports a disturbance in the warp.  He claims it is like a shadow.");
             }
             if ((obj_controller.known[eFACTION.TYRANIDS] == 0) && (woop == 0) && yep) {
-                for (var q = 1; q <= 90; q++) {
-                    if (obj_ini.role[0][q] == obj_ini.role[100][eROLE.CHAPTERMASTER]) {
-                        if (string_count("0", obj_ini.spe[0][q]) > 0) {
+                for (var q = 0; q < array_length(obj_ini.TTRPG[0]); q++) {
+                    var _unit = fetch_unit([0, q]);
+                    if (_unit.role() == obj_ini.role[100][eROLE.CHAPTERMASTER]) {
+                        if (string_count("0", _unit.special) > 0) {
                             scr_popup("Shadow in the Warp", "You are distracted and bothered by a nagging sensation in the warp.  It feels as though a shadow descends upon your sector.", "shadow", "");
                             scr_event_log("red", "You sense a disturbance in the warp.  It feels something like a massive shadow.");
                         }

--- a/scripts/scr_enemy_ai_d/scr_enemy_ai_d.gml
+++ b/scripts/scr_enemy_ai_d/scr_enemy_ai_d.gml
@@ -167,7 +167,7 @@ function scr_enemy_ai_d() {
                 for (var q = 0; q < array_length(obj_ini.TTRPG[0]); q++) {
                     var _unit = fetch_unit([0, q]);
                     if (_unit.role() == obj_ini.role[100][eROLE.CHAPTERMASTER]) {
-                        if (string_count("0", _unit.special) > 0) {
+                        if (string_count("0", _unit.specials) > 0) {
                             scr_popup("Shadow in the Warp", "You are distracted and bothered by a nagging sensation in the warp.  It feels as though a shadow descends upon your sector.", "shadow", "");
                             scr_event_log("red", "You sense a disturbance in the warp.  It feels something like a massive shadow.");
                         }

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -1478,8 +1478,6 @@ function scr_initialize_custom() {
         armour[_idx] = array_create(_len, "");
         gear[_idx] = array_create(_len, "");
         mobi[_idx] = array_create(_len, "");
-        age[_idx] = array_create(_len, _age_val);
-        god[_idx] = array_create(_len, 0);
     };
 
     _init_marine_row(0, 500, _current_age);
@@ -2013,9 +2011,8 @@ function scr_initialize_custom() {
             chaos[c][i] = 0;
             gear[c][i] = "";
             mobi[c][i] = "";
-            age[c][i] = ((millenium * 1000) + year) - 10;
-            god[c][i] = 0;
             TTRPG[c][i] = new TTRPG_stats("chapter", c, i, "blank");
+            TTRPG[c][i].age = ((millenium * 1000) + year) - 10;
         }
     }
 

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -2997,7 +2997,9 @@ function scr_initialize_custom() {
     //   ** sets up the starting squads**
     LOGGER.info("set up the starting squads");
     obj_ini.squads = {};
+    sort_all_companies();
     game_start_squads();
+    sort_all_companies();
 }
 
 /// @description helper function to streamline code inside of scr_initialize_custom, should only be used as part of game setup and not during normal gameplay

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -2006,7 +2006,6 @@ function scr_initialize_custom() {
             wep1[c][i] = "";
             wep2[c][i] = "";
             armour[c][i] = "";
-            chaos[c][i] = 0;
             gear[c][i] = "";
             mobi[c][i] = "";
             TTRPG[c][i] = new TTRPG_stats("chapter", c, i, "blank");
@@ -2997,9 +2996,7 @@ function scr_initialize_custom() {
     //   ** sets up the starting squads**
     LOGGER.info("set up the starting squads");
     obj_ini.squads = {};
-    sort_all_companies();
     game_start_squads();
-    sort_all_companies();
 }
 
 /// @description helper function to streamline code inside of scr_initialize_custom, should only be used as part of game setup and not during normal gameplay

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -1473,7 +1473,6 @@ function scr_initialize_custom() {
         name[_idx] = array_create(_len, "");
         role[_idx] = array_create(_len, "");
         wep1[_idx] = array_create(_len, "");
-        spe[_idx] = array_create(_len, "");
         wep2[_idx] = array_create(_len, "");
         armour[_idx] = array_create(_len, "");
         gear[_idx] = array_create(_len, "");
@@ -2005,7 +2004,6 @@ function scr_initialize_custom() {
             name[c][i] = "";
             role[c][i] = "";
             wep1[c][i] = "";
-            spe[c][i] = "";
             wep2[c][i] = "";
             armour[c][i] = "";
             chaos[c][i] = 0;
@@ -2026,7 +2024,7 @@ function scr_initialize_custom() {
         chapter_master.add_bionics("none", "standard", false);
     }
 
-    spe[_company_i][_marine_i] = "";
+    chapter_master.specials = "";
     chapter_master.add_trait("lead_example");
 
     //builds in which of the three chapter master types your CM is
@@ -2034,12 +2032,12 @@ function scr_initialize_custom() {
     switch (obj_creation.chapter_master_specialty) {
         case 1:
             chapter_master.add_exp(550);
-            spe[_company_i][_marine_i] += "$";
+            chapter_master.specials += "$";
             chapter_master.add_trait("charismatic");
             break;
         case 2:
             chapter_master.add_exp(650);
-            spe[_company_i][_marine_i] += "@";
+            chapter_master.specials += "@";
             chapter_master.add_trait("paragon");
             break;
         case 3:

--- a/scripts/scr_kill_unit/scr_kill_unit.gml
+++ b/scripts/scr_kill_unit/scr_kill_unit.gml
@@ -52,10 +52,11 @@ function kill_and_recover(company, unit_slot, equipment = true, gene_seed_collec
         unit.alter_equipment(strip, false, true);
     }
     if (gene_seed_collect && unit.base_group == "astartes") {
-        if (unit.age > 30 && !obj_ini.zygote && !obj_ini.doomed) {
+
+        if (unit.marine_ascension > 30 && !obj_ini.zygote && !obj_ini.doomed) {
             obj_controller.gene_seed += 1;
         }
-        if (unit.age > 50 && !obj_ini.doomed) {
+        if (unit.marine_ascension > 100 && !obj_ini.doomed) {
             obj_controller.gene_seed += 1;
         }
     }

--- a/scripts/scr_kill_unit/scr_kill_unit.gml
+++ b/scripts/scr_kill_unit/scr_kill_unit.gml
@@ -36,7 +36,6 @@ function scr_wipe_unit(company, unit_slot) {
     array_set(obj_ini.role[company], unit_slot, "");
     array_set(obj_ini.armour[company], unit_slot, "");
     array_set(obj_ini.gear[company], unit_slot, "");
-    array_set(obj_ini.age[company], unit_slot, 0);
     array_set(obj_ini.mobi[company], unit_slot, "");
     array_set(obj_ini.TTRPG[company], unit_slot, undefined);
 }
@@ -54,10 +53,10 @@ function kill_and_recover(company, unit_slot, equipment = true, gene_seed_collec
         unit.alter_equipment(strip, false, true);
     }
     if (gene_seed_collect && unit.base_group == "astartes") {
-        if (unit.age() > 30 && !obj_ini.zygote && !obj_ini.doomed) {
+        if (unit.age > 30 && !obj_ini.zygote && !obj_ini.doomed) {
             obj_controller.gene_seed += 1;
         }
-        if (unit.age() > 50 && !obj_ini.doomed) {
+        if (unit.age > 50 && !obj_ini.doomed) {
             obj_controller.gene_seed += 1;
         }
     }

--- a/scripts/scr_kill_unit/scr_kill_unit.gml
+++ b/scripts/scr_kill_unit/scr_kill_unit.gml
@@ -28,7 +28,6 @@ function scr_kill_unit(company, unit_slot) {
 }
 
 function scr_wipe_unit(company, unit_slot) {
-    array_set(obj_ini.spe[company], unit_slot, "");
     array_set(obj_ini.race[company], unit_slot, 0);
     array_set(obj_ini.name[company], unit_slot, "");
     array_set(obj_ini.wep1[company], unit_slot, "");

--- a/scripts/scr_kill_unit/scr_kill_unit.gml
+++ b/scripts/scr_kill_unit/scr_kill_unit.gml
@@ -36,7 +36,6 @@ function scr_wipe_unit(company, unit_slot) {
     array_set(obj_ini.role[company], unit_slot, "");
     array_set(obj_ini.armour[company], unit_slot, "");
     array_set(obj_ini.gear[company], unit_slot, "");
-    array_set(obj_ini.god[company], unit_slot, 0);
     array_set(obj_ini.age[company], unit_slot, 0);
     array_set(obj_ini.mobi[company], unit_slot, "");
     array_set(obj_ini.TTRPG[company], unit_slot, undefined);

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -938,7 +938,6 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
         }
         array_push(epithets, epithet);
     };
-
     static name = function() {
         return obj_ini.name[company][marine_number];
     }; // get marine name
@@ -1045,12 +1044,10 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
         return obj_ini.artifact[wep];
     };
 
-    static specials = function() {
-        return obj_ini.spe[company][marine_number];
-    };
+    specials = "";
 
     static specials_array = function() {
-        var _specials_array = string_split(obj_ini.spe[company][marine_number], "|", true);
+        var _specials_array = string_split(specials, "|", true);
         return _specials_array;
     };
 
@@ -1067,7 +1064,7 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
         var _powers_known_count = 0;
         var _discipline_powers_max = 0;
         var _powers_learned = 0;
-        var _abilities_string = specials();
+        var _abilities_string = specials;
 
         var _discipline_prefix = get_discipline_data(obj_ini.psy_powers, "prefix");
         var _discipline_powers = get_discipline_data(obj_ini.psy_powers, "powers");
@@ -1081,7 +1078,7 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
             if (string_count(string(_power_index), _abilities_string) == 0) {
                 _powers_known_count++;
                 _powers_learned++;
-                obj_ini.spe[company][marine_number] += string(_discipline_prefix) + string(_power_index) + "|";
+                specials += string(_discipline_prefix) + string(_power_index) + "|";
                 array_push(powers_known, _discipline_powers[_power_index]);
             }
         }

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -922,13 +922,10 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
         return true;
     };
 
-    static age = function() {
-        var real_age = obj_ini.age[company][marine_number];
-        return real_age;
-    }; // age
+    age = 0;
 
     static update_age = function(new_val) {
-        obj_ini.age[company][marine_number] = new_val;
+        age = new_val;
     };
 
     //TODO build epithets in to marine profile
@@ -2020,7 +2017,7 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
     static roll_age = scr_marine_spawn_age;
 
     static roll_experience = function() {
-        var _age_bonus = age();
+        var _age_bonus = age;
         var _gauss_sd_mod = 14;
 
         var _exp = _age_bonus;
@@ -2029,7 +2026,7 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
     };
 
     static assign_reactionary_traits = function() {
-        var _age = age();
+        var _age = age;
         var _exp = experience;
         var _total_score = _age + _exp;
 

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -2004,12 +2004,10 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
     };
 
     static in_jail = function() {
-        return god_status() >= 10;
+        return god_status >= 10;
     };
 
-    static god_status = function() {
-        return obj_ini.god[company][marine_number];
-    };
+    god_status = 0;
 
     static forge_point_generation = unit_forge_point_generation;
 

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -256,7 +256,7 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
                         obj_controller.turn,
                     ],
                 ]; //marines_promotion and demotion history
-                marine_ascension = (obj_controller.millenium * 1000) + obj_controller.year; // on what day did this marine begin to exist
+                marine_ascension = obj_controller.turn; // on what day did this marine begin to exist
             } else {
                 role_history = [];
                 marine_ascension = 0; // on what turn did this marine begin to exist
@@ -923,10 +923,6 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
     };
 
     age = 0;
-
-    static update_age = function(new_val) {
-        age = new_val;
-    };
 
     //TODO build epithets in to marine profile
     static add_epithet = function(epithet) {

--- a/scripts/scr_max_marine/scr_max_marine.gml
+++ b/scripts/scr_max_marine/scr_max_marine.gml
@@ -3,44 +3,34 @@ function scr_max_marine(max_type) {
 
     // Returns the marine with the highest value
 
-    var man_c, man_i, c, i, value, unit;
+    var man_c, man_i, value, unit;
     man_c = 0;
     man_i = 0;
-    c = 0;
-    i = 0;
     value = 0;
 
-    i = -1;
-    c = -1;
-    repeat (11) {
-        c += 1;
-        i = 0;
-        repeat (305) {
-            i += 1; // man_c[i]=0;man_i[i]=0;
-
-            if (obj_ini.name[c][i] != "") {
-                unit = fetch_unit([c, i]);
-                if (!is_struct(unit)) {
-                    continue;
+    for (co = 0; co <= obj_ini.companies; co++) {
+        for (var i = 0; i < company_length(co); i++) {
+            unit = fetch_unit([c, i]);
+            if (!is_struct(unit)) {
+                continue;
+            }
+            if (max_type == "chaos") {
+                if (unit.corruption > value) {
+                    value = unit.corruption;
+                    man_c = c;
+                    man_i = i;
                 }
-                if (max_type == "chaos") {
-                    if (unit.corruption > value) {
-                        value = unit.corruption;
-                        man_c = c;
-                        man_i = i;
-                    }
-                } else if (max_type == "age") {
-                    if (unit.age < value) {
-                        value = unit.age;
-                        man_c = c;
-                        man_i = i;
-                    }
-                } else if (max_type == "exp") {
-                    if (unit.experience > value) {
-                        value = unit.experience;
-                        man_c = c;
-                        man_i = i;
-                    }
+            } else if (max_type == "age") {
+                if (unit.age < value) {
+                    value = unit.age;
+                    man_c = c;
+                    man_i = i;
+                }
+            } else if (max_type == "exp") {
+                if (unit.experience > value) {
+                    value = unit.experience;
+                    man_c = c;
+                    man_i = i;
                 }
             }
         }

--- a/scripts/scr_max_marine/scr_max_marine.gml
+++ b/scripts/scr_max_marine/scr_max_marine.gml
@@ -30,8 +30,8 @@ function scr_max_marine(max_type) {
                         man_i = i;
                     }
                 } else if (max_type == "age") {
-                    if (obj_ini.age[c][i] < value) {
-                        value = obj_ini.age[c][i];
+                    if (unit.age < value) {
+                        value = unit.age;
                         man_c = c;
                         man_i = i;
                     }

--- a/scripts/scr_max_marine/scr_max_marine.gml
+++ b/scripts/scr_max_marine/scr_max_marine.gml
@@ -17,24 +17,24 @@ function scr_max_marine(max_type) {
             if (max_type == "chaos") {
                 if (unit.corruption > value) {
                     value = unit.corruption;
-                    man_c = c;
+                    man_c = co;
                     man_i = i;
                 }
             } else if (max_type == "age") {
                 if (unit.age < value) {
                     value = unit.age;
-                    man_c = c;
+                    man_c = co;
                     man_i = i;
                 }
             } else if (max_type == "exp") {
                 if (unit.experience > value) {
                     value = unit.experience;
-                    man_c = c;
+                    man_c = co;
                     man_i = i;
                 }
             }
         }
     }
 
-    return string(man_c) + "|" + string(man_i) + "|" + string(obj_ini.name[man_c][man_i]) + "|" + string(value) + "|";
+    return fetch_unit([man_c, man_i]);
 }

--- a/scripts/scr_max_marine/scr_max_marine.gml
+++ b/scripts/scr_max_marine/scr_max_marine.gml
@@ -10,7 +10,7 @@ function scr_max_marine(max_type) {
 
     for (co = 0; co <= obj_ini.companies; co++) {
         for (var i = 0; i < company_length(co); i++) {
-            unit = fetch_unit([c, i]);
+            unit = fetch_unit([co, i]);
             if (!is_struct(unit)) {
                 continue;
             }

--- a/scripts/scr_move_unit_info/scr_move_unit_info.gml
+++ b/scripts/scr_move_unit_info/scr_move_unit_info.gml
@@ -18,7 +18,6 @@ function scr_move_unit_info(start_company, end_company, start_slot, end_slot, ev
     obj_ini.wep2[end_company][end_slot] = obj_ini.wep2[start_company][start_slot];
     obj_ini.gear[end_company][end_slot] = obj_ini.gear[start_company][start_slot];
     obj_ini.armour[end_company][end_slot] = obj_ini.armour[start_company][start_slot];
-    obj_ini.age[end_company][end_slot] = obj_ini.age[start_company][start_slot];
     obj_ini.mobi[end_company][end_slot] = obj_ini.mobi[start_company][start_slot];
 
     var _temp_struct = fetch_unit([end_company, end_slot]);

--- a/scripts/scr_move_unit_info/scr_move_unit_info.gml
+++ b/scripts/scr_move_unit_info/scr_move_unit_info.gml
@@ -18,7 +18,6 @@ function scr_move_unit_info(start_company, end_company, start_slot, end_slot, ev
     obj_ini.wep2[end_company][end_slot] = obj_ini.wep2[start_company][start_slot];
     obj_ini.gear[end_company][end_slot] = obj_ini.gear[start_company][start_slot];
     obj_ini.armour[end_company][end_slot] = obj_ini.armour[start_company][start_slot];
-    obj_ini.god[end_company][end_slot] = obj_ini.god[start_company][start_slot];
     obj_ini.age[end_company][end_slot] = obj_ini.age[start_company][start_slot];
     obj_ini.mobi[end_company][end_slot] = obj_ini.mobi[start_company][start_slot];
 

--- a/scripts/scr_move_unit_info/scr_move_unit_info.gml
+++ b/scripts/scr_move_unit_info/scr_move_unit_info.gml
@@ -10,7 +10,6 @@ function scr_move_unit_info(start_company, end_company, start_slot, end_slot, ev
     if (eval_squad) {
         unit.movement_after_math(end_company, end_slot);
     }
-    obj_ini.spe[end_company][end_slot] = obj_ini.spe[start_company][start_slot];
     obj_ini.race[end_company][end_slot] = obj_ini.race[start_company][start_slot];
     obj_ini.name[end_company][end_slot] = obj_ini.name[start_company][start_slot];
     obj_ini.wep1[end_company][end_slot] = obj_ini.wep1[start_company][start_slot];

--- a/scripts/scr_player_combat_weapon_stacks/scr_player_combat_weapon_stacks.gml
+++ b/scripts/scr_player_combat_weapon_stacks/scr_player_combat_weapon_stacks.gml
@@ -380,9 +380,9 @@ function scr_add_unit_to_roster(unit, is_local = false, is_ally = false) {
     array_push(marine_hp, unit.hp());
     array_push(marine_mobi, unit.mobility_item());
     array_push(marine_exp, unit.experience);
-    array_push(marine_powers, unit.specials());
+    array_push(marine_powers, unit.specials);
     array_push(marine_ranged, unit.ranged_attack());
-    array_push(marine_powers, unit.specials());
+    array_push(marine_powers, unit.specials);
     array_push(marine_ac, unit.armour_calc());
     array_push(marine_attack, unit.melee_attack());
     array_push(marine_local, is_local);

--- a/scripts/scr_player_combat_weapon_stacks/scr_player_combat_weapon_stacks.gml
+++ b/scripts/scr_player_combat_weapon_stacks/scr_player_combat_weapon_stacks.gml
@@ -382,7 +382,6 @@ function scr_add_unit_to_roster(unit, is_local = false, is_ally = false) {
     array_push(marine_exp, unit.experience);
     array_push(marine_powers, unit.specials);
     array_push(marine_ranged, unit.ranged_attack());
-    array_push(marine_powers, unit.specials);
     array_push(marine_ac, unit.armour_calc());
     array_push(marine_attack, unit.melee_attack());
     array_push(marine_local, is_local);

--- a/scripts/scr_random_event/scr_random_event.gml
+++ b/scripts/scr_random_event/scr_random_event.gml
@@ -709,7 +709,7 @@ function scr_random_event(execute_now) {
         var cm_is_psyker = false;
         for (var i = 0; i < array_length(TTRPG[0]); i++) {
             var _unit = fetch_unit([0 ,i]);
-            if (_unit.role() == obj_ini.role[100][eROLE.CHAPTERMASTER] && string_count("0", _unit.special) > 0) {
+            if (_unit.role() == obj_ini.role[100][eROLE.CHAPTERMASTER] && string_count("0", _unit.specials) > 0) {
                 cm_is_psyker = true;
                 break;
             }

--- a/scripts/scr_random_event/scr_random_event.gml
+++ b/scripts/scr_random_event/scr_random_event.gml
@@ -707,8 +707,9 @@ function scr_random_event(execute_now) {
         var psyker_intolerant = scr_has_disadv("Psyker Intolerant");
         var has_chief_psyker = scr_role_count("Chief " + string(obj_ini.role[100][17]), "") >= 1;
         var cm_is_psyker = false;
-        for (var i = 1; i < 100; i++) {
-            if (obj_ini.role[0][i] == obj_ini.role[100][eROLE.CHAPTERMASTER] && string_count("0", obj_ini.spe[0][i]) > 0) {
+        for (var i = 0; i < array_length(TTRPG[0]); i++) {
+            var _unit = fetch_unit([0 ,i]);
+            if (_unit.role() == obj_ini.role[100][eROLE.CHAPTERMASTER] && string_count("0", _unit.special) > 0) {
                 cm_is_psyker = true;
                 break;
             }

--- a/scripts/scr_role_count/scr_role_count.gml
+++ b/scripts/scr_role_count/scr_role_count.gml
@@ -38,7 +38,7 @@ function scr_role_count(target_role, search_location = "", return_type = "count"
             if (!is_struct(unit) || unit.name() == "") {
                 continue;
             }
-            if ((unit.role() == target_role) && (obj_ini.god[coom][i] < 10)) {
+            if ((unit.role() == target_role) && (obj_ini.TTRPG[coom][i].god_status < 10)) {
                 count += 1;
                 if (return_type == "units") {
                     var _u = fetch_unit([coom, i]);

--- a/scripts/scr_roster/scr_roster.gml
+++ b/scripts/scr_roster/scr_roster.gml
@@ -663,7 +663,7 @@ function add_unit_to_battle(unit, meeting, is_local) {
         col = obj_controller.bat_command_column;
         new_combat.important_dudes++;
         new_combat.big_mofo = 1;
-        if (string_count("0", obj_ini.spe[cooh][va]) > 0) {
+        if (string_count("0", unit.specials) > 0) {
             new_combat.chapter_master_psyker = 1;
         } else {
             new_combat.chapter_master_psyker = 0;

--- a/scripts/scr_ship_occupants/scr_ship_occupants.gml
+++ b/scripts/scr_ship_occupants/scr_ship_occupants.gml
@@ -1,98 +1,59 @@
 function scr_ship_occupants(target_ship_id) {
-    var co, i, oc, ocn, ty, g, good, blur, unit;
-    co = -1;
-    i = -1;
-    ty = 0;
-    g = 0;
-    good = 0;
-    blur = "";
+    var unit_list = [];
 
-    repeat (200) {
-        i += 1;
-        oc[i] = "";
-        ocn[i] = 0;
+    // Crew
+    for (var co = 0; co < obj_ini.companies; co++) {
+        for (var i = 0; i <= company_length(co); i++) {
+            if (obj_ini.role[co][i] == "") {
+                continue;
+            }
+            var unit = fetch_unit([co, i]);
+            if (!is_struct(unit)) {
+                continue;
+            }
+            if (unit.ship_location != target_ship_id) {
+                continue;
+            }
+            array_push(unit_list, unit);
+        }
     }
+    var occupant_index = new UnitIndex(unit_list);
+    var strings_array = occupant_index.create_plural_strings_array();
 
-    i = 0;
-    for (co = 0; co <= 10; co++) {
-        i = 0;
-        repeat (500) {
-            i += 1;
-            if (obj_ini.role[co][i] != "") {
-                unit = fetch_unit([co, i]);
-                if (!is_struct(unit)) {
-                    continue;
-                }
-                if (unit.ship_location != target_ship_id) {
-                    good = 0;
-                }
-                g = 0;
-                repeat (100) {
-                    g += 1;
-                    if (good == 0) {
-                        if (oc[g] == unit.role()) {
-                            good = 1;
-                            ocn[g] += 1;
-                            break;
-                        }
-                    }
-                }
-                if (good == 0) {
-                    ty += 1;
-                    oc[ty] = unit.role();
-                    ocn[ty] = 1;
-                    good = 1;
-                }
+    // Vehicles (not compatible with UnitIndex - tally role strings directly)
+    var veh_index = {};
+    var veh_keys = [];
+    for (var co = 0; co < obj_ini.companies; co++) {
+        for (var i = 0; i <= 100; i++) {
+            if (obj_ini.veh_role[co][i] == "" || obj_ini.veh_lid[co][i] != target_ship_id) {
+                continue;
+            }
+            var veh_role = obj_ini.veh_role[co][i];
+            if (!struct_exists(veh_index, veh_role)) {
+                veh_index[$ veh_role] = 1;
+                array_push(veh_keys, veh_role);
+            } else {
+                veh_index[$ veh_role] += 1;
             }
         }
     }
-    i = 0;
-    co = -1;
-    for (co = 0; co <= 10; co++) {
-        i = 0;
-        repeat (100) {
-            i += 1;
-            if ((obj_ini.veh_role[co][i] != "") && (obj_ini.veh_lid[co][i] == target_ship_id)) {
-                good = 0;
-                g = 0;
-                repeat (100) {
-                    g += 1;
-                    if (good == 0) {
-                        if (oc[g] == obj_ini.veh_role[co][i]) {
-                            good = 1;
-                            ocn[g] += 1;
-                        }
-                    }
-                }
-                if (good == 0) {
-                    ty += 1;
-                    oc[ty] = obj_ini.veh_role[co][i];
-                    ocn[ty] = 1;
-                    good = 1;
-                }
-            }
+    for (var i = 0; i < array_length(veh_keys); i++) {
+        var _role = veh_keys[i];
+        var _count = veh_index[$ _role];
+        if (_count == 1) {
+            array_push(strings_array, {str1: _role, bold: true, italic: false});
+        } else {
+            array_push(strings_array, string_plural_count(_role, _count, false));
         }
     }
 
-    i = 0;
-    good = 1;
-    repeat (100) {
-        i += 1;
-        if (good == 1) {
-            if (ocn[i] == 1) {
-                blur += string(ocn[i]) + "x " + string(oc[i]);
-            }
-            if (ocn[i] > 1) {
-                blur += string(ocn[i]) + "x " + string(oc[i]) + "s";
-            }
-            if (ocn[i + 1] > 0) {
-                blur += ", ";
-            }
-            if (ocn[i + 1] == 0) {
-                blur += ".";
-                good = 0;
-            }
-        }
+    // Build final string
+    var blur = "";
+    var _total = array_length(strings_array);
+    for (var i = 0; i < _total; i++) {
+        var entry = strings_array[i];
+        blur += is_struct(entry) ? entry.str1 : string(entry);
+        blur += (i < _total - 1) ? ", " : ".";
     }
 
     return blur;

--- a/scripts/scr_ship_occupants/scr_ship_occupants.gml
+++ b/scripts/scr_ship_occupants/scr_ship_occupants.gml
@@ -3,7 +3,8 @@ function scr_ship_occupants(target_ship_id) {
 
     // Crew
     for (var co = 0; co < obj_ini.companies; co++) {
-        for (var i = 0; i <= company_length(co); i++) {
+        var _co_length = company_length(co);
+        for (var i = 0; i < _co_length; i++) {
             if (obj_ini.role[co][i] == "") {
                 continue;
             }

--- a/scripts/scr_unit_detail_text/scr_unit_detail_text.gml
+++ b/scripts/scr_unit_detail_text/scr_unit_detail_text.gml
@@ -49,7 +49,7 @@ function scr_unit_detail_text() {
         if (ascension_date == "0") {
             ascension_date = "unknown";
         }
-        unit_data_string += $"{round(age())} years old. Ascended to an Astartes in the {ascension_date} year.";
+        unit_data_string += $"{round(age} years old. Ascended to an Astartes in the {ascension_date} year.";
         if (struct_exists(spawn_data, "recruit_data")) {
             var recruit_data = spawn_data.recruit_data;
             unit_data_string += "\n";

--- a/scripts/scr_unit_detail_text/scr_unit_detail_text.gml
+++ b/scripts/scr_unit_detail_text/scr_unit_detail_text.gml
@@ -49,7 +49,7 @@ function scr_unit_detail_text() {
         if (ascension_date == "0") {
             ascension_date = "unknown";
         }
-        unit_data_string += $"{round(age} years old. Ascended to an Astartes in the {ascension_date} year.";
+        unit_data_string += $"{round(age)} years old. Ascended to an Astartes in the {ascension_date} year.";
         if (struct_exists(spawn_data, "recruit_data")) {
             var recruit_data = spawn_data.recruit_data;
             unit_data_string += "\n";

--- a/scripts/scr_unit_quick_find_pane/scr_unit_quick_find_pane.gml
+++ b/scripts/scr_unit_quick_find_pane/scr_unit_quick_find_pane.gml
@@ -673,7 +673,7 @@ function jail_selection() {
         _unit = display_unit[f];
         if (_unit.controllable()) {
             if (is_struct(display_unit[f]) && !_unit.in_jail()) {
-                obj_ini.god[_unit.company][_unit.marine_number] += 10;
+                display_unit[f].god_status += 10;
                 ma_god[f] += 10;
                 man_sel[f] = 0;
             }

--- a/scripts/scr_unit_spawn_functions/scr_unit_spawn_functions.gml
+++ b/scripts/scr_unit_spawn_functions/scr_unit_spawn_functions.gml
@@ -1,6 +1,5 @@
 /// @self Struct.TTRPG_stats
 function scr_marine_spawn_age() {
-    var _age = 0;
     var _minimum_age = 0;
     var _maximum_age = 0;
     var _apply_gauss = false;
@@ -130,15 +129,14 @@ function scr_marine_spawn_age() {
     if (_apply_gauss == true) {
         if (_maximum_age != 0) {
             _gauss_sd_mod = (_maximum_age - _minimum_age) / _gauss_sd_mod;
-            _age = gauss_positive(_minimum_age, _gauss_sd_mod);
+            age = round(gauss_positive(_minimum_age, _gauss_sd_mod));
         } else {
-            _age = gauss_positive(_minimum_age, _minimum_age / _gauss_sd_mod);
+            age = round(gauss_positive(_minimum_age, _minimum_age / _gauss_sd_mod));
         }
     } else {
-        _age = irandom_range(_minimum_age, _maximum_age);
+        age = irandom_range(_minimum_age, _maximum_age);
     }
 
-    update_age(round(_age));
 }
 
 /// @self Struct.TTRPG_stats
@@ -154,10 +152,9 @@ function scr_marine_spawn_armour() {
         }
     };
 
-    var _age = age();
     var _role = role();
     var _exp = experience;
-    var _total_score = _age + _exp + (scr_has_adv("Crafters") ? 50 : 0);
+    var _total_score = age + _exp + (scr_has_adv("Crafters") ? 50 : 0);
     var _company = company;
 
     var _armour_weighted_lists = {


### PR DESCRIPTION
<!--- YOU CAN DELETE ALL OF THIS AFTER READING. -->

<!--- Make use of markdown lists. They make stuff much easier to read through. -->
<!--- Explain why and what your changes do in simple terms. --->
<!--- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. --->

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->

<!--- "Inspired" by the CDDA PR template -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the static 501-slot arrays and all parallel fields; units now own `age`, `specials`, and `god_status`. Company rosters and spawns are fully dynamic, loops/serialization use real lengths, and marine ascension is turn-based.

- **Refactors**
  - Replaced fixed 2D mirrors with per‑company dynamic arrays; dropped `age/spe/god` mirrors and stored those on the unit.
  - `find_company_open_slot` grows mirrors/`TTRPG` and returns a valid index; `scr_company_order` resizes mirrors to roster length.
  - `scr_max_marine` returns a unit instead of a delimited string; dialogue and CM psyker checks read `unit.specials`. Ship occupants rebuilt to use `UnitIndex` and tally vehicle roles.

- **Bug Fixes**
  - Reclusiam/jail, role counts, and penitents now read/write `unit.god_status` and iterate current roster lengths.
  - Gene‑seed recovery and kill‑and‑recover thresholds use `unit.age` and `marine_ascension` (turn‑based).
  - Removed hardcoded bounds in crusade, equipment checks, force counting, ship occupants, CM detection, and religion collection.

<sup>Written for commit 7413137bf750c8a47a2ea89b36ebe05a6a528119. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

