### PR TITLE
ci(opencode): Swap pull_request_review_comment to issue_comment

### DIFF
--- a/.github/workflows/opencode_review.yml
+++ b/.github/workflows/opencode_review.yml
@@ -1,7 +1,7 @@
 name: opencode_review
 
 on:
-  pull_request_review_comment:
+  issue_comment:
     types: [created]
 
 jobs:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch the workflow trigger from pull_request_review_comment to issue_comment so the opencode review job runs on any new PR or issue comment. This fixes missed runs when comments were posted in the PR conversation instead of as code review comments.

<sup>Written for commit badb551aa8486817ac5d50d9317581a034464cb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1407?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

