### PR TITLE
ci: OpenCode shenanigans

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -33,11 +33,11 @@ jobs:
           persist-credentials: false
 
       - name: Run OpenCode
-        uses: anomalyco/opencode/github@v1.18.7
+        uses: anomalyco/opencode/github@v1.18.9
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
         with:
-          model: opencode/deepseek-v4-flash-free
-          variant: max
+          model: opencode/muse-spark-1.2-contributor-free
+          variant: xhigh
           share: false
           prompt: ${{ inputs.prompt || '' }}

--- a/.github/workflows/opencode_review.yml
+++ b/.github/workflows/opencode_review.yml
@@ -1,37 +1,93 @@
-name: opencode_review
+name: opencode-review
 
 on:
   issue_comment:
     types: [created]
 
 jobs:
-  opencode:
+  review:
     if: |
-      startsWith(github.event.comment.body, '/review')
+      github.event.issue.pull_request
+      && startsWith(github.event.comment.body, '/review')
       && contains(fromJson('["OWNER","MEMBER"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
+      contents: read
       pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
-          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Get PR number
+        id: pr-number
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request_target" ]; then
+            echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          else
+            echo "number=${{ github.event.issue.number }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Get PR details
+        id: pr-details
+        run: |
+          gh api /repos/${{ github.repository }}/pulls/${{ steps.pr-number.outputs.number }} > pr_data.json
+          echo "title<<EOF" >> $GITHUB_OUTPUT
+          jq -r .title pr_data.json >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          echo "sha=$(jq -r .head.sha pr_data.json)" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install OpenCode
+        run: curl -fsSL https://opencode.ai/install | bash
 
       - name: Run OpenCode
-        uses: anomalyco/opencode/github@v1.18.4
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
-        with:
-          model: opencode/deepseek-v4-flash-free
-          variant: max
-          agent: pr_review
-          share: false
-          prompt: |
-            Review this pull request:
-            - Check for code quality issues
-            - Look for potential bugs and regressions
-            - Suggest improvements
-            Respond terse. All technical substance stays. Only fluff dies.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPENCODE_PERMISSION: '{ "bash": {  "*": "deny", "gh*": "allow", "gh pr review*": "deny", "gh auth*": "deny", "gh api *DELETE*": "deny" } }'
+          PR_TITLE: ${{ steps.pr-details.outputs.title }}
+          PR_SHA: ${{ steps.pr-details.outputs.sha }}
+          PR_NUMBER: ${{ steps.pr-number.outputs.number }}
+        run: |
+          PR_BODY=$(jq -r .body pr_data.json)
+          cat > /tmp/prompt.txt <<PROMPT_EOF
+          A new pull request has been created: '$PR_TITLE'
+
+          <pr-number>
+          $PR_NUMBER
+          </pr-number>
+
+          <pr-description>
+          $PR_BODY
+          </pr-description>
+
+          Review this pull request:
+          - Look for potential bugs and regressions
+          - Check for code quality issues
+          - Suggest improvements
+          Respond terse. All technical substance stays. Only fluff dies.
+
+          Diffs are important but make sure you read the entire file to get proper context.
+          When critiquing, don't be a zealot if the code is readable.
+
+          Use the gh cli to create comments on the files for the violations.
+          Try to leave the comment on the exact line number.
+          If you have a suggested fix include it in a suggestion code block.
+          Write a comment instead of writing suggested change.
+
+          Command MUST be like this:
+          \`\`\`
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/${{ github.repository }}/pulls/$PR_NUMBER/comments \
+            -f 'body=[summary of issue]' -f 'commit_id=$PR_SHA' -f 'path=[path-to-file]' -F "line=[line]" -f 'side=RIGHT'
+          \`\`\`
+
+          Only create comments for actual violations. If the code follows all guidelines, comment using gh cli that it looks good and nothing else.
+          PROMPT_EOF
+          cat /tmp/prompt.txt | opencode run -m muse-spark-1.2-contributor-free --variant xhigh --agent pr_review

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,35 @@
+# Agent Guidance
+
+## Useful Links
+
+- GameMaker Manual GitHub: https://github.com/YoYoGames/GameMaker-Manual/develop/Manual/contents/GameMaker_Language/
+- GameMaker Manual: https://manual.gamemaker.io/beta/en/
+- GameMaker Forum (community evidence, working solutions, and tips): https://forum.gamemaker.io/
+
+## Sequential Execution
+
+Always proceed with each task, issue, or question sequentially, one-by-one, step-by-step; never at once.
+The only exception is when you use parallel sub-agents, each handling a separate thing in isolation.
+
+## Banned Symbols
+
+The entire codebase must use only 7-bit ASCII characters (Unicode range U+0000 to U+007F). Never use the following symbols:
+- Curly quotes (“ ” ‘ ’) -> use straight quotes (" ').
+- Em/En dashes (— –) -> use hyphen (-).
+- Math symbols (× ÷ ≠ ≤ ≥ ±) -> use ASCII equivalents (* / != <= >= +/-).
+- Bullets (• ▪ ◦) -> use asterisk (*) or hyphen (-).
+- Ellipsis (…) -> use three periods (...).
+- Arrows (→ ⇒) -> use ASCII (-> =>).
+
+If a single non-ASCII character outside of a mandatory UI string (i.e., a user-facing label that explicitly requires it) is found, the entire submission is rejected.
+
+## Reduce Comment Noise
+
+When code exists for a non-obvious reason, like a redundant function call left for explicitness, or a seemingly unnecessary check, you can add a comment explaining why. Anyone reading it later shouldn't have to guess or trace five call sites to figure out the obscure intent.
+But DON'T add comments explaining "what" is happening in each code-block, people can read on their own. Only explain "why", when really needed.
+
+## Misc Rules
+
+- Favor idiomatic terseness: ternary operators, nullish coalescing (??, ??=) where readable.
+- Write elegant, idiomatic, clean code, like a senior software developer.
+- Don't try to create new `.yy` files when creating new `.gml` scripts. They'll be created by GameMaker automatically.

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -13,6 +13,7 @@
   },
   "formatter": false,
   "instructions": [
+    "docs/AGENTS.md",
     "docs/GML_REFERENCE.md",
     "docs/CODE_STYLE.md"
   ],

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -3,31 +3,8 @@
   "agent": {
     "pr_review": {
       "mode": "primary",
-      "permission": {
-        "doom_loop": "deny",
-        "external_directory": "deny",
-        "edit": "deny",
-        "lsp": "deny",
-        "question": "deny"
-      }
-    },
-    "explore": {
-      "permission": {
-        "doom_loop": "deny",
-        "external_directory": "deny",
-        "edit": "deny",
-        "lsp": "deny",
-        "question": "deny"
-      }
-    },
-    "general": {
-      "permission": {
-        "doom_loop": "deny",
-        "external_directory": "deny",
-        "lsp": "deny",
-        "question": "deny"
-      }
-    },
+      "hidden": true
+    }
   },
   "compaction": {
     "auto": true,
@@ -40,5 +17,5 @@
     "docs/CODE_STYLE.md"
   ],
   "snapshot": false,
-  "model": "opencode/deepseek-v4-flash-free"
+  "model": "opencode/muse-spark-1.2-contributor-free"
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Rewrites the PR review workflow to use the `opencode` CLI with `gh` API-backed line comments, tightening permissions and upgrading the default model. Previously used the `anomalyco/opencode/github` action with `gh pr review`; now posts comments via `gh api /pulls/:number/comments` using exact line numbers.

- Workflow: renamed to opencode-review; single review job; triggers only on “/review” comments from `OWNER`/`MEMBER` on PRs.
- Permissions: `contents: read`, `pull-requests: write`; `OPENCODE_PERMISSION` allows only `gh*` and denies `gh pr review*`, `gh auth*`, and `gh api *DELETE*`.
- Execution: installs `opencode`; pulls PR number/title/body and head SHA via `gh`; runs `opencode run -m muse-spark-1.2-contributor-free --variant xhigh --agent pr_review`; posts inline comments with `gh api`.
- Config: hides `agent.pr_review`, removes unused agents, adds `docs/AGENTS.md` to `instructions`, and sets default model to `opencode/muse-spark-1.2-contributor-free`. Bumps `.github/workflows/opencode.yml` to `anomalyco/opencode/github@v1.18.9` and aligns model/variant.

To run: comment “/review” on a PR (ORG members/owners only).

<sup>Written for commit 572f80dacf3099d7b4ed111acfca31c25e09584e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

