### PR TITLE
fix: Mandatory modular checks skipped when no optional checks remain

### DIFF
--- a/scripts/scr_ComplexSet/scr_ComplexSet.gml
+++ b/scripts/scr_ComplexSet/scr_ComplexSet.gml
@@ -859,9 +859,9 @@ function ComplexSet(_unit) constructor {
             ];
         }
 
-        // Nothing optional left to check - short circuit immediately.
+        // Nothing optional left to check, but the mandatory pass still has to apply the item's draw data.
         if (remaining_component_checks <= 0) {
-            return true;
+            return modular_mandatory_checks(mod_item);
         }
 
         // ---------------- OPTIONAL CHECKS (gated, self-terminating) ----------------
@@ -883,6 +883,7 @@ function ComplexSet(_unit) constructor {
     static validate_modular_item = function(_mod, position) {
         _sub_comps = "none";
         _shadows = "none";
+        _overides = "none";
         if (position != "") {
             _mod.position = position;
         }

--- a/scripts/scr_ComplexSet/scr_ComplexSet.gml
+++ b/scripts/scr_ComplexSet/scr_ComplexSet.gml
@@ -880,6 +880,10 @@ function ComplexSet(_unit) constructor {
         return true;
     };
 
+    /// @desc Runs the checks for one modular item and applies it to its draw area if they pass.
+    /// @param {Struct} _mod
+    /// @param {String} position Overrides the item's own position when not blank
+    /// @returns {Bool|Undefined} False when the item is rejected, undefined otherwise
     static validate_modular_item = function(_mod, position) {
         _sub_comps = "none";
         _shadows = "none";


### PR DESCRIPTION
Opening the company screen right after loading on fresh boot raised an error on any company with bare-headed units (i.e scouts): `Variable ComplexSet._overides not set before reading it`

`base_modulars_checks()` short-circuits with `return true` once a modular item has no optional checks left, skipping `modular_mandatory_checks()` the only place `_overides` is set, and the pass that applies the item's draw data. `validate_modular_item()` then read it unset and thus complained.

Only items whose keys are all in `mandatory_check_keys` reach that branch: the three bare head entries, plus the `{sprite: ...}` packets `check_component_overides()` wraps bare sprite overrides in. The bare head entries stop erroring after the first draw, since `_mod.body_types = [0, 1, 2]` mutates the item struct and that struct lives in a global built at boot. Hence the error can only happen once per game session.

## Changes
- Short circuit now returns `modular_mandatory_checks(mod_item)` instead of `true`, so the mandatory pass can't be skipped. It applies the item's overides, offsets, subcomponents and shadows, not just `_overides`.
- Default `_overides` in `validate_modular_item()` alongside `_sub_comps` and `_shadows`.
- Add missing JSDoc for `validate_modular_item()`.
## Testing
- With the same save before and after the error reproduces reliably if from a fresh boot you load the save and then immediately open the 10th company screen, after the first occurrence it no longer occurs, regardless of reloading the save. With the fix the error does not occur at all even with a fresh boot.
    - Without the fix the error can also occur when starting a fresh game but ONLY if you don't go through the screen where it draws a dummy marine for coloring. If you go through the coloring screen then scouts won't be the first draw and it won't throw the error. With the fix it doesn't occur at all
## Note
- I am pretty sure `validate_modular_item` is not behaving as it should with the whole only false or undefined thing because why would someone intend that but it's not related to this bug and I didn't want to fix it. I only added the docs since I touched part of the function but fixing it (assuming it is behaving incorrectly) seemed out of scope, so instead I just wanted to note the odd behavior that is now documented here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a startup-only error when opening a company with bare-headed units by ensuring mandatory modular checks still run when optional checks are exhausted. Prevents `_overides` from being read before it’s set and consistently applies item draw data.

- **Bug Fixes**
  - In `base_modulars_checks`, short-circuit now calls `modular_mandatory_checks(mod_item)` instead of returning `true`.
  - Default `_overides = "none"` in `validate_modular_item()` alongside `_sub_comps` and `_shadows`.
  - Added JSDoc for `validate_modular_item()`.

<sup>Written for commit 6385ed516a3102c2705ad0e4baacd9f3447f3338. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

