### PR TITLE
ci: gobo_check refactor and fix

### DIFF
--- a/.github/workflows/gobo_check.yml
+++ b/.github/workflows/gobo_check.yml
@@ -24,22 +24,23 @@ jobs:
       - name: Setup Gobo
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-          curl -LO https://github.com/EttyKitty/Gobo/releases/download/v1.0.0/gobo-ubuntu.zip
-          unzip gobo-ubuntu.zip
+          gh release download --repo EttyKitty/GoboCat --pattern "gobo-linux-x64.zip"
+          unzip gobo-linux-x64.zip
           chmod +x ./gobo
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run Formatter
+      - name: Check Formatting
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
+          failed=0
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
-            echo "Formatting $file..."
-            ./gobo "$file"
+            echo "Checking $file..."
+            if ! ./gobo --check "$file"; then
+              echo "::error::Formatting issues found in $file"
+              failed=1
+            fi
           done
-
-      - name: Verify Formatting
-        run: |
-          if ! git diff --quiet; then
-            echo "::error::Some files are not properly formatted."
-            git diff --name-only
+          if [ $failed -eq 1 ]; then
             exit 1
           fi


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update CI `gobo_check` to download Gobo via `gh release` and run non-mutating format checks. Fixes release download failures and prevents CI from modifying files.

- **Bug Fixes**
  - Use `gh release download` from `EttyKitty/GoboCat` with `GH_TOKEN` to reliably fetch the binary.
  - Avoid changing files during CI by switching to `./gobo --check`.

- **Refactors**
  - Replace the separate “Run Formatter” and “Verify Formatting” steps with a single check that aggregates failures and prints clear errors per file.

<sup>Written for commit 570302fac433f8d82a5597b7a5928436ab06f3b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

