### PR TITLE
fix: And refactor alerts; fix popup overflow error; bump GM

### DIFF
--- a/ChapterMaster.yyp
+++ b/ChapterMaster.yyp
@@ -732,6 +732,7 @@
     {"id":{"name":"Logger","path":"scripts/Logger/Logger.yy",},},
     {"id":{"name":"macros","path":"scripts/macros/macros.yy",},},
     {"id":{"name":"NameGenerator","path":"scripts/NameGenerator/NameGenerator.yy",},},
+    {"id":{"name":"NotificationAlert","path":"scripts/NotificationAlert/NotificationAlert.yy",},},
     {"id":{"name":"object_get_depth","path":"scripts/object_get_depth/object_get_depth.yy",},},
     {"id":{"name":"scr_add_artifact","path":"scripts/scr_add_artifact/scr_add_artifact.yy",},},
     {"id":{"name":"scr_add_corruption","path":"scripts/scr_add_corruption/scr_add_corruption.yy",},},

--- a/ChapterMaster.yyp
+++ b/ChapterMaster.yyp
@@ -594,7 +594,7 @@
   "isEcma":false,
   "LibraryEmitters":[],
   "MetaData":{
-    "IDEVersion":"2026.100.0.1083",
+    "IDEVersion":"2026.100.0.1110",
   },
   "name":"ChapterMaster",
   "resources":[

--- a/objects/obj_turn_end/Alarm_1.gml
+++ b/objects/obj_turn_end/Alarm_1.gml
@@ -39,7 +39,7 @@ if (array_length(audience_stack) > 0) {
 
 current_popup += 1;
 
-if (popup[current_popup] != 0) {
+if (current_popup <= popups) {
     var pip = instance_create(0, 0, obj_popup);
     pip.title = popup_type[current_popup];
     pip.text = popup_text[current_popup];
@@ -84,7 +84,7 @@ if (popup[current_popup] != 0) {
     }
     pip.number = 1;
 }
-if ((current_popup > popups) || (popup[1] == 0)) {
+if ((current_popup > popups) || (popups == 0)) {
     if (popups_end == 0) {
         popups_end = 1;
     }

--- a/objects/obj_turn_end/Create_0.gml
+++ b/objects/obj_turn_end/Create_0.gml
@@ -35,20 +35,15 @@ afri = array_create(_fleet_size, 0);
 aesc = array_create(_fleet_size, 0);
 
 var _popup_size = 91;
-popup = array_create(_popup_size, 0);
-popup_type = array_create(_popup_size, "");
-popup_text = array_create(_popup_size, "");
-popup_image = array_create(_popup_size, "");
-popup_special = array_create(_popup_size, "");
+// 1-indexed queue: index 0 is a dead slot; arrays grow as popups are added by scr_popup
+popup = [0];
+popup_type = [""];
+popup_text = [""];
+popup_image = [""];
+popup_special = [""];
 
-alert = array_create(_popup_size, 0);
-alert_type = array_create(_popup_size, "");
-alert_text = array_create(_popup_size, "");
-
-alert_char = array_create(_popup_size, 0);
-alert_alpha = array_create(_popup_size, 0);
-alert_txt = array_create(_popup_size, "");
-alert_color = array_create(_popup_size, "");
+/// @type {Array<Struct.NotificationAlert>}
+alerts_list = [];
 
 battle = array_create(_popup_size, 0);
 battle_location = array_create(_popup_size, "");
@@ -68,11 +63,8 @@ audiences = 0;
 audience = 0;
 audience_stack = [];
 
-alert_alpha[1] = 0.2;
-alert_char[1] = 1;
-
 handle_discovered_governor_assasinations();
 
 alerts = 0;
-fast = 0; // This is increased, once the alert[i]=1 and >=fast then it begins to fade in and get letters
+fast = 0; // Playback cursor: alerts unlock (fade in + typewriter) once fast >= their position
 show = 0;

--- a/objects/obj_turn_end/Draw_64.gml
+++ b/objects/obj_turn_end/Draw_64.gml
@@ -3,10 +3,11 @@ draw_set_halign(fa_left);
 draw_set_color(CM_GREEN_COLOR);
 
 if ((alerts > 0) && (popups_end == 1)) {
-    for (var i = 1; i <= alerts; i++) {
-        set_alert_draw_colour(alert_color[i]);
-        draw_set_alpha(min(1, alert_alpha[i]));
-        draw_text(32, 46 + (i * 20), string_hash_to_newline(string(alert_txt[i])));
+    for (var i = 0; i < alerts; i++) {
+        var _alert = alerts_list[i];
+        set_alert_draw_colour(_alert.colour);
+        draw_set_alpha(min(1, _alert.alpha));
+        draw_text(32, 46 + ((i + 1) * 20), string_hash_to_newline(string(_alert.txt)));
     }
 }
 

--- a/objects/obj_turn_end/Step_0.gml
+++ b/objects/obj_turn_end/Step_0.gml
@@ -5,9 +5,14 @@ if (cooldown >= 0) {
 if ((alerts > 0) && (popups_end == 1) && (fadeout == 0)) {
     for (var i = 0; i < alerts; i++) {
         var _alert = alerts_list[i];
-        if ((fast >= (i + 1)) && (string_length(_alert.txt) < string_length(_alert.text))) {
+        var _suffix = "";
+        if (_alert.count > 1) {
+            _suffix = " x" + string(_alert.count);
+        }
+        var _target = _alert.text + _suffix;
+        if ((fast >= (i + 1)) && (string_length(_alert.txt) < string_length(_target))) {
             _alert.char += 1;
-            _alert.txt = string_copy(_alert.text, 0, _alert.char);
+            _alert.txt = string_copy(_target, 0, _alert.char);
         }
         if ((fast >= (i + 1)) && (_alert.alpha < 1)) {
             _alert.alpha += 0.03;

--- a/objects/obj_turn_end/Step_0.gml
+++ b/objects/obj_turn_end/Step_0.gml
@@ -3,21 +3,22 @@ if (cooldown >= 0) {
 }
 
 if ((alerts > 0) && (popups_end == 1) && (fadeout == 0)) {
-    for (var i = 1; i <= alerts; i++) {
-        if ((fast >= i) && (string_length(alert_txt[i]) < string_length(alert_text[i]))) {
-            alert_char[i] += 1;
-            alert_txt[i] = string_copy(alert_text[i], 0, alert_char[i]);
+    for (var i = 0; i < alerts; i++) {
+        var _alert = alerts_list[i];
+        if ((fast >= (i + 1)) && (string_length(_alert.txt) < string_length(_alert.text))) {
+            _alert.char += 1;
+            _alert.txt = string_copy(_alert.text, 0, _alert.char);
         }
-        if ((fast >= i) && (alert_alpha[i] < 1)) {
-            alert_alpha[i] += 0.03;
+        if ((fast >= (i + 1)) && (_alert.alpha < 1)) {
+            _alert.alpha += 0.03;
         }
     }
 }
 
 if (fadeout == 1) {
-    for (var i = 1; i <= alerts; i++) {
-        alert_alpha[i] -= 0.05;
-        if ((i == 1) && (alert_alpha[1] <= 0)) {
+    for (var i = 0; i < alerts; i++) {
+        alerts_list[i].alpha -= 0.05;
+        if ((i == 0) && (alerts_list[0].alpha <= 0)) {
             instance_destroy();
         }
     }

--- a/scripts/NotificationAlert/NotificationAlert.gml
+++ b/scripts/NotificationAlert/NotificationAlert.gml
@@ -10,7 +10,11 @@ function NotificationAlert(_colour, _type, _text) constructor {
 
     text = "-" + string(_text);
 
-    // Runtime playback state, owned by obj_turn_end:
+    /// Number of merged duplicates; displayed as a " xN" suffix
+    count = 1;
+
+    // Runtime playback state, owned by obj_turn_end
+
     alpha = 0;
     char = 0;
     txt = "";

--- a/scripts/NotificationAlert/NotificationAlert.gml
+++ b/scripts/NotificationAlert/NotificationAlert.gml
@@ -1,0 +1,17 @@
+/// @desc A single alert line queued for the turn-end report and played back by obj_turn_end.
+/// @param {String|Constant.Color|Real} _colour Valid colours: green, yellow, red, purple, GM colourcodes (c_ prefix), decimal, hexadecimal ($ prefix, 6 or 8 digits) and CSS (# prefix)
+/// @param {String} _type Alert category label (informational)
+/// @param {String} _text Alert body text
+function NotificationAlert(_colour, _type, _text) constructor {
+    colour = _colour;
+
+    /// Unused atm
+    type = _type;
+
+    text = "-" + string(_text);
+
+    // Runtime playback state, owned by obj_turn_end:
+    alpha = 0;
+    char = 0;
+    txt = "";
+}

--- a/scripts/NotificationAlert/NotificationAlert.yy
+++ b/scripts/NotificationAlert/NotificationAlert.yy
@@ -1,0 +1,13 @@
+{
+  "$GMScript":"v1",
+  "%Name":"NotificationAlert",
+  "isCompatibility":false,
+  "isDnD":false,
+  "name":"NotificationAlert",
+  "parent":{
+    "name":"Constructors",
+    "path":"folders/Scripts/Constructors.yy",
+  },
+  "resourceType":"GMScript",
+  "resourceVersion":"2.0",
+}

--- a/scripts/scr_alert/scr_alert.gml
+++ b/scripts/scr_alert/scr_alert.gml
@@ -29,14 +29,10 @@ function scr_alert(colour, alert_type, alert_text, xx = 0, yy = 0) {
 
     // if (obj_turn_end.alerts>0){
     if (instance_exists(obj_turn_end)) {
-        if ((obj_turn_end.alert_type[obj_turn_end.alerts] != "-" + string(alert_text)) && (alert_type != "blank") && (colour != "blank")) {
+        var _last = obj_turn_end.alerts;
+        if (((_last == 0) || (obj_turn_end.alerts_list[_last - 1].text != "-" + string(alert_text))) && (alert_type != "blank") && (colour != "blank")) {
             obj_turn_end.alerts += 1;
-            obj_turn_end.alert[obj_turn_end.alerts] = 1;
-            obj_turn_end.alert_color[obj_turn_end.alerts] = colour; // takes green, yellow, red, purple, default GM colorcodes(with c_ prefix), decimal, hexadecimal(with $ prefix, 6 or 8 digits) and CSS(with # prefix)
-            // if (colour="purple") then obj_turn_end.alert_color[obj_turn_end.alerts]="red";
-            obj_turn_end.alert_type[obj_turn_end.alerts] = alert_type;
-            obj_turn_end.alert_text[obj_turn_end.alerts] = "-" + string(alert_text);
-            obj_turn_end.alert[obj_turn_end.alerts] = 1;
+            obj_turn_end.alerts_list[obj_turn_end.alerts - 1] = new NotificationAlert(colour, alert_type, alert_text); // colour takes green, yellow, red, purple, default GM colorcodes(with c_ prefix), decimal, hexadecimal(with $ prefix, 6 or 8 digits) and CSS(with # prefix)
         }
     }
 

--- a/scripts/scr_alert/scr_alert.gml
+++ b/scripts/scr_alert/scr_alert.gml
@@ -30,9 +30,13 @@ function scr_alert(colour, alert_type, alert_text, xx = 0, yy = 0) {
     // if (obj_turn_end.alerts>0){
     if (instance_exists(obj_turn_end)) {
         var _last = obj_turn_end.alerts;
-        if (((_last == 0) || (obj_turn_end.alerts_list[_last - 1].text != "-" + string(alert_text))) && (alert_type != "blank") && (colour != "blank")) {
-            obj_turn_end.alerts += 1;
-            obj_turn_end.alerts_list[obj_turn_end.alerts - 1] = new NotificationAlert(colour, alert_type, alert_text); // colour takes green, yellow, red, purple, default GM colorcodes(with c_ prefix), decimal, hexadecimal(with $ prefix, 6 or 8 digits) and CSS(with # prefix)
+        if ((alert_type != "blank") && (colour != "blank")) {
+            if ((_last > 0) && (obj_turn_end.alerts_list[_last - 1].text == "-" + string(alert_text))) {
+                obj_turn_end.alerts_list[_last - 1].count += 1; // collapse duplicate into the last alert
+            } else {
+                obj_turn_end.alerts += 1;
+                obj_turn_end.alerts_list[obj_turn_end.alerts - 1] = new NotificationAlert(colour, alert_type, alert_text);
+            }
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a popup overflow crash and stabilizes alert playback by refactoring alerts into a struct-based dynamic list with duplicate collapsing and xN counts. Also bumps GameMaker to 2026.100.0.1110 to avoid a memory access bug.

- **Bug Fixes**
  - Bound popup creation: only spawn when current_popup <= popups; finish when popups == 0.
  - Collapse duplicate alerts; consecutive repeats merge and display " xN".

- **Refactors**
  - Added `NotificationAlert` constructor to encapsulate colour, type, text, count, and playback state (`alpha`, `char`, `txt`).
  - Replaced fixed-size alert arrays with dynamic `alerts_list`; popups now use a 1-indexed queue with a dead slot at 0.

<sup>Written for commit 1aa3bf94503b637c66b375eef3dddba97ce5b27d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

