### PR TITLE
refactor: Syntax cleanup

### DIFF
--- a/objects/obj_controller/Alarm_1.gml
+++ b/objects/obj_controller/Alarm_1.gml
@@ -257,7 +257,7 @@ if (_total_weight > 0) {
 
         for (var j = 0; j < _allocated_systems && array_length(_imperial_systems) > 0; j++) {
             var s = array_random_index(_imperial_systems);
-            var _current_system = _imperial_systems[s];
+            _current_system = _imperial_systems[s];
 
             _current_system.owner = _faction.faction_id;
             for (var p = 1; p <= _current_system.planets; p++) {

--- a/objects/obj_pnunit/Create_0.gml
+++ b/objects/obj_pnunit/Create_0.gml
@@ -146,7 +146,7 @@ tick_psychic_buffs = function() {
             for (var b = 0; b < array_length(_buffs); b++) {
                 var _name = _buffs[b];
                 if (self[$ _name][i] > 0) {
-                    self[$ _name][i] -= 1;
+                    self[$ _name][i]--;
                 }
             }
         }

--- a/scripts/AudioManager/AudioManager.gml
+++ b/scripts/AudioManager/AudioManager.gml
@@ -142,14 +142,12 @@ function AudioManager() constructor {
                 _count++;
                 _file = file_find_next();
             }
-
-            return _count;
         } catch (_ex) {
             ERROR_HANDLER.handle_exception(_ex);
-            return _count;
         } finally {
             file_find_close();
         }
+        return _count;
     };
 
     /// @desc Attempts to load and cache a streamed sound from two candidate paths.

--- a/scripts/scr_ComplexSet/scr_ComplexSet.gml
+++ b/scripts/scr_ComplexSet/scr_ComplexSet.gml
@@ -876,8 +876,6 @@ function ComplexSet(_unit) constructor {
         } else {
             return modular_mandatory_checks(mod_item);
         }
-
-        return true;
     };
 
     /// @desc Runs the checks for one modular item and applies it to its draw area if they pass.

--- a/scripts/scr_ComplexSet/scr_ComplexSet.gml
+++ b/scripts/scr_ComplexSet/scr_ComplexSet.gml
@@ -988,8 +988,8 @@ function ComplexSet(_unit) constructor {
                     component_final_draw_y += _offsets[1];
                 }
                 if (struct_exists(_override_data, "bans")) {
-                    for (var i = 0; i < array_length(_override_data.bans); i++) {
-                        array_push(banned, _override_data.bans[i]);
+                    for (var j = 0; j < array_length(_override_data.bans); j++) {
+                        array_push(banned, _override_data.bans[j]);
                     }
                 }
                 break;

--- a/scripts/scr_buttons/scr_buttons.gml
+++ b/scripts/scr_buttons/scr_buttons.gml
@@ -1418,7 +1418,6 @@ function ToggleButton(data = {}) constructor {
         var str1_h = string_height(str1);
         var _text_padding = w * 0.03;
         var text_x = x1 + _text_padding;
-        var text_y = y1 + _text_padding;
         var total_alpha;
 
         if (text_halign == fa_center) {

--- a/scripts/scr_load/scr_load.gml
+++ b/scripts/scr_load/scr_load.gml
@@ -20,11 +20,11 @@ function scr_load(save_part, save_id) {
     if ((save_part == 1) || (save_part == 0)) {
         LOGGER.info("Loading GLOBALS");
         // Globals
-        var globals = obj_saveload.GameSave.Save;
-        scr_load_chapter_icon(globals.icon_name, true);
-        global.chapter_name = globals.chapter_name;
-        global.custom = globals.custom;
-        global.game_seed = globals.game_seed;
+        var _globals = obj_saveload.GameSave.Save;
+        scr_load_chapter_icon(_globals.icon_name, true);
+        global.chapter_name = _globals.chapter_name;
+        global.custom = _globals.custom;
+        global.game_seed = _globals.game_seed;
     }
 
     if ((save_part == 2) || (save_part == 0)) {

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -1418,8 +1418,6 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
 
         var _wep1 = __get_weapon_struct(1);
         var _wep2 = __get_weapon_struct(2);
-        var _primary_weapon = _wep1;
-        var _secondary_weapon = _wep2;
 
         var _carrying_data = hands_carrying(!_is_ranged);
         var _carrying_value = _carrying_data[0];

--- a/scripts/scr_ork_planet_functions/scr_ork_planet_functions.gml
+++ b/scripts/scr_ork_planet_functions/scr_ork_planet_functions.gml
@@ -37,9 +37,10 @@ function ork_ship_production(planet) {
                     }
                     var nearestStar = instance_nearest(_fleet.x, _fleet.y, obj_star);
                     instance_deactivate_object(nearestStar);
+                    var targetStar = noone;
                     for (var j = 0; j < 10; j++) {
                         if (!locationOk) {
-                            var targetStar = instance_nearest(_fleet.x + choose(random(400), random(400) * -1), _fleet.y + choose(random(100), random(100) * -1), obj_star);
+                            targetStar = instance_nearest(_fleet.x + choose(random(400), random(400) * -1), _fleet.y + choose(random(100), random(100) * -1), obj_star);
                             if (targetStar.owner != eFACTION.ORK) {
                                 locationOk = true;
                             }

--- a/scripts/scr_reequip_units/scr_reequip_units.gml
+++ b/scripts/scr_reequip_units/scr_reequip_units.gml
@@ -272,9 +272,9 @@ function draw_popup_equip() {
     //TODO calc once and store in reactive string
     var _descriptor = "Marines";
     if (equipment_recipient_type == eEQUIP_TARGET_TYPE.DREADNOUGHT) {
-        var _descriptor = "Dreadnoughts";
+        _descriptor = "Dreadnoughts";
     } else if (equipment_recipient_type > eEQUIP_TARGET_TYPE.DREADNOUGHT) {
-        var _descriptor = "Vehicles";
+        _descriptor = "Vehicles";
     }
     draw_text(1292, 175, $"{comp} Company, {unit_count} {_descriptor}");
 

--- a/scripts/scr_unit_equip_functions/scr_unit_equip_functions.gml
+++ b/scripts/scr_unit_equip_functions/scr_unit_equip_functions.gml
@@ -564,10 +564,9 @@ function UnitEquipment(equipment_set, _unit = noone) constructor {
     }
     self.equipping_unit = _unit;
     var _slot_keys = global.unit_equip_slots;
-    var _slot, _item;
     for (var i = 0; i < STANDARD_EQUIP_SLOT_COUNT; i++) {
-        _slot = _slot_keys[i];
-        _item = equipment[$ _slot_keys[i]];
+        var _slot = _slot_keys[i];
+        var _item = equipment[$ _slot_keys[i]];
         if (!is_struct(_item)) {
             var _dp = _item != "" ? {name: _item} : undefined;
             equipment[$ _slot] = new EquipmentStruct(_dp, "");


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Cleaned up GML syntax and variable scoping across the codebase to clear GameMaker warnings and avoid subtle bugs. Also ensured `AudioManager` closes file searches before returning.

- **Bug Fixes**
  - Move `return _count` after the `finally` block in `AudioManager` so `file_find_close()` always runs; remove early/unreachable returns.
  - Rename reserved `globals` to `_globals` in `scr_load` and update references.
  - Fix scope/redeclaration issues: reuse `_current_system`, hoist `targetStar`, avoid re-declaring `_descriptor`, declare `_slot`/`_item` inside the loop, and adjust loop indices.
  - Remove unreachable/unused code and tiny cleanups: drop unused vars (`text_y`, `_primary_weapon`, `_secondary_weapon`), and use `--` for decrements.

<sup>Written for commit 706d6623e79187a57c8f1dad8f2b4b89d070c933. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

