### PR TITLE
fix: Insert escort selection value into escort_sel, not uid

### DIFF
--- a/scripts/scr_player_fleet_functions/scr_player_fleet_functions.gml
+++ b/scripts/scr_player_fleet_functions/scr_player_fleet_functions.gml
@@ -199,7 +199,7 @@ function move_ship_between_player_fleets(out_fleet, in_fleet, class, index) {
         array_insert(in_fleet.escort, 0, out_fleet.escort[index]);
         array_insert(in_fleet.escort_num, 0, out_fleet.escort_num[index]);
         array_insert(in_fleet.escort_uid, 0, out_fleet.escort_uid[index]);
-        array_insert(in_fleet.escort_sel, 0, out_fleet.escort_uid[index]);
+        array_insert(in_fleet.escort_sel, 0, out_fleet.escort_sel[index]);
         in_fleet.escort_number++;
         array_delete(out_fleet.escort, index, 1);
         array_delete(out_fleet.escort_num, index, 1);


### PR DESCRIPTION

## What's wrong

`move_ship_between_player_fleets` in
`scripts/scr_player_fleet_functions/scr_player_fleet_functions.gml` moves a
single ship between two player fleets by shifting its data across four
parallel arrays per ship class (identity, number, uid, selection). In the
escort branch:

```gml
} else if (class == "escort") {
    array_insert(in_fleet.escort, 0, out_fleet.escort[index]);
    array_insert(in_fleet.escort_num, 0, out_fleet.escort_num[index]);
    array_insert(in_fleet.escort_uid, 0, out_fleet.escort_uid[index]);
    array_insert(in_fleet.escort_sel, 0, out_fleet.escort_uid[index]);
    in_fleet.escort_number++;
    ...
```

The fourth line inserts `out_fleet.escort_uid[index]` — the ship's uid —
into the destination's `escort_sel` array, instead of
`out_fleet.escort_sel[index]`.

## Why this is clearly unintended

- The capital and frigate branches of the exact same function handle their
  four parallel arrays correctly:
  `array_insert(in_fleet.capital_sel, 0, out_fleet.capital_sel[index]);` and
  `array_insert(in_fleet.frigate_sel, 0, out_fleet.frigate_sel[index]);`
  both insert from the matching `_sel` source array. The escort branch is
  the only one of the three that substitutes a different source array
  (`escort_uid` instead of `escort_sel`) for this line — a straightforward
  copy-paste slip between the three near-identical branches.
- `escort_sel` (and its capital/frigate counterparts) are read elsewhere as
  boolean selection flags (used, for example, by
  `split_selected_into_new_fleet` to decide which ships are selected for a
  split). A uid value inserted there is a large nonzero number, which
  evaluates truthy regardless of the ship's actual selection state, so it
  silently corrupts selection tracking for the destination fleet.
- No compensating fixup exists anywhere downstream, and there's no comment
  or history suggesting this substitution is deliberate.

## Before / after behavior

**Before:** every escort ship transferred between player fleets (via fleet
splits or other ship moves) has its destination `escort_sel` entry set to
its own uid instead of a selection flag. Selection-dependent UI and logic
(e.g. deciding which escorts are "selected" for a further split) reads
whatever truthy/falsy value that uid happens to produce, rather than the
ship's actual prior selection state. Over repeated transfers, an affected
fleet's `escort_sel` array fills with uid values instead of 0/1 flags.

**After:** the escort branch inserts `out_fleet.escort_sel[index]`, matching
the capital/frigate branches, so the destination fleet's selection array
carries an actual selection flag.

Player-facing impact: any UI that highlights or acts on "selected" escorts
in a fleet that received a transferred ship (e.g. multi-select for a further
split or bulk order) can misbehave on that fleet — ships can appear selected
when the player never selected them, because the corrupted `escort_sel`
entry reads as truthy.

## How to observe in game

1. Split an escort ship out of a player fleet into a new fleet (or otherwise
   trigger `move_ship_between_player_fleets` with `class == "escort"`).
2. Inspect the new fleet's `escort_sel` array in a save file — before the
   fix it contains the ship's uid where a 0/1 selection flag belongs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug in `move_ship_between_player_fleets` where the escort branch wrote a uid into `in_fleet.escort_sel` instead of the selection flag. Now inserts `out_fleet.escort_sel[index]`, matching capital/frigate behavior and preserving correct escort selection after transfers.

<sup>Written for commit 7e323f6cd776612f0012ae2652a8618912bb06a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

