### PR TITLE
fix: migrate marine specials from the legacy spe array

### DIFF
--- a/objects/obj_ini/Create_0.gml
+++ b/objects/obj_ini/Create_0.gml
@@ -319,6 +319,48 @@ deserialize = function(save_data) {
         }
     }
 
+    /// @desc Restores marine `specials` from obj_ini.spe, the parallel array it used to live in.
+    ///    Saves predating that move carry no `specials` key at all, as it was a method and jsonify_marine_struct() skips methods.
+    ///    `powers_known` was already a plain field and did round-trip, so without this those psykers load knowing powers with no discipline behind them.
+    /// @param {Array<Array<String>>} _legacy_specials The saved spe array, indexed [company][marine]
+    /// @returns {undefined}
+    function migrate_legacy_marine_specials(_legacy_specials) {
+        if (!is_array(_legacy_specials)) {
+            return;
+        }
+        var _migrated = 0;
+        var _company_count = min(array_length(_legacy_specials), array_length(TTRPG));
+        for (var _coy = 0; _coy < _company_count; _coy++) {
+            var _company_row = _legacy_specials[_coy];
+            if (!is_array(_company_row)) {
+                continue; // the legacy array is ragged; stray non-array rows carry nothing
+            }
+            var _row_length = array_length(_company_row);
+            for (var _mar = 0; _mar < _row_length; _mar++) {
+                var _legacy_string = _company_row[_mar];
+                if (!is_string(_legacy_string) || _legacy_string == "") {
+                    continue;
+                }
+                var _unit = fetch_unit([_coy, _mar]);
+                if (!is_struct(_unit)) {
+                    continue;
+                }
+                if (is_string(_unit.specials) && _unit.specials != "") {
+                    continue;
+                }
+                _unit.specials = _legacy_string;
+                _migrated++;
+            }
+        }
+        if (_migrated > 0) {
+            LOGGER.info($"Migrated specials for {_migrated} marines from the legacy obj_ini.spe array");
+        }
+    }
+
+    if (struct_exists(save_data, "spe")) {
+        migrate_legacy_marine_specials(save_data[$ "spe"]);
+    }
+
     var _squad_structs = save_data[$ "squad_structs"];
     if (is_struct(_squad_structs)) {
         squads = {};

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -1067,8 +1067,19 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data = {}
         return _specials_array;
     };
 
+    /// @desc The discipline this unit's powers belong to, read from the prefix of its first entry
+    ///    in `specials`.
+    /// @returns {string} The discipline name, or "" when the unit has no discipline recorded
     static psy_discipline = function() {
         var _specials_array = specials_array();
+        // Only psykers should reach here, but arriving without an entry is harmless in itself as there is simply no discipline to report.
+        if (array_length(_specials_array) == 0) {
+            // Powers with no specials behind them cannot legitimately occur.
+            if (array_length(powers_known) > 0) {
+                LOGGER.error($"{name()} ({company}:{marine_number}) knows powers but has no specials entry");
+            }
+            return "";
+        }
         var _first_power_prefix = string_letters(_specials_array[0]);
         var _discipline = match_power_prefix(_first_power_prefix);
 


### PR DESCRIPTION
Loading a save made before the `obj_ini.spe` parallel array refactor crashed as soon as you opened a Librarian's panel in the company management view. `specials` used to be a method reading `obj_ini.spe[company][marine_number]`, and `jsonify_marine_struct()` skips methods so old saves carry no `specials` key at all, while `powers_known` was a plain field and round-tripped fine. `psy_discipline()` then reads `_specials_array[0]` on an empty array throwing an error. Fresh saves post refactor do not create the issue and legacy saves will be non-breaking with the refactor after first load and stored non-breaking after first fresh save.

## Changes
- Add `migrate_legacy_marine_specials()` to `obj_ini` `deserialize`, restoring `specials` from the legacy `spe` array when present. Skips marines that already carry their own string, and is bounded by TTRPG so the padding rows past company 10 never reach `fetch_unit()` and thus can't create cascading errors if any legacy save put data in them.
- Guard `psy_discipline()` against an empty specials, throw an error when a unit has powers but no discipline. This pairing cannot legitimately occur, so the guard acts as catch in case the migration shim creates weird broken marines in some circumstance or else a marine somehow ends up with specials but no discipline. Marines with no discipline but no specials will just get gracefully ejected instead as the most likely case is an unguarded call to `psy_discipline()` created them and they present no issue regardless.
## Testing
- Loaded old and new saves side by side. The crash only reproduces on legacy saves without the migration shim, and the migration causes no observable issues.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash when opening the Librarian panel on legacy saves by restoring marine specials from the old `spe` array. Also prevents errors when a unit has no specials.

- **Bug Fixes**
  - Migrate legacy `spe` data during deserialize to repopulate each marine’s specials; skip marines that already have a value and bound iteration to `TTRPG`.
  - Guard psy_discipline to handle empty specials and log when powers exist without a discipline, preventing out-of-bounds errors on old saves.

<sup>Written for commit 09fe0c417fb24322c9b079b74081b3f643349db2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

