### PR TITLE
fix: crash when marine has no armour

### DIFF
--- a/scripts/scr_unit_equip_functions/scr_unit_equip_functions.gml
+++ b/scripts/scr_unit_equip_functions/scr_unit_equip_functions.gml
@@ -825,8 +825,6 @@ function UnitEquipment(equipment_set, _unit = noone) constructor {
                     _marines_without_exp++;
                 }
             }
-
-                var _unit_armour_data = _unit.get_armour_data();
             if (slot == eEQUIPMENT_SLOT.ARMOUR && !get_item("armour").has_tag("dreadnought")) {
                 if (_unit.is_dreadnought()) {
                     equipment_found_and_valid[slot] = false;

--- a/scripts/scr_unit_equip_functions/scr_unit_equip_functions.gml
+++ b/scripts/scr_unit_equip_functions/scr_unit_equip_functions.gml
@@ -826,9 +826,9 @@ function UnitEquipment(equipment_set, _unit = noone) constructor {
                 }
             }
 
-            if (slot == eEQUIPMENT_SLOT.ARMOUR && !get_item("armour").has_tag("dreadnought")) {
                 var _unit_armour_data = _unit.get_armour_data();
-                if (_unit_armour_data.has_tag("dreadnought")) {
+            if (slot == eEQUIPMENT_SLOT.ARMOUR && !get_item("armour").has_tag("dreadnought")) {
+                if (_unit.is_dreadnought()) {
                     equipment_found_and_valid[slot] = false;
                     warning += "Marines may not exit Dreadnoughts.";
                 }


### PR DESCRIPTION
<!--- YOU CAN DELETE ALL OF THIS AFTER READING. -->

<!--- Make use of markdown lists. They make stuff much easier to read through. -->
<!--- Explain why and what your changes do in simple terms. --->
<!--- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. --->

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->

<!--- "Inspired" by the CDDA PR template -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed a crash when a marine has no armour by using `_unit.is_dreadnought()` instead of an armour tag check, avoiding null access and keeping the “Marines may not exit Dreadnoughts” rule. Removed a redundant line.

<sup>Written for commit e536b7a4e8a8f2effe3f5fc410b85ac04f2f6a0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

