### PR TITLE
fix: more risk improvements

### DIFF
--- a/objects/obj_ini/Create_0.gml
+++ b/objects/obj_ini/Create_0.gml
@@ -317,13 +317,10 @@ deserialize = function(save_data) {
             var _squad = new UnitSquad();
             _squad.load_json_data(_squad_structs[$ _squad_uid]);
             squads[$ _squad_uid] = _squad;
-            for (var s = 0; s < array_length(_squad.members); s++) {
+            for (var s = array_length(_squad.members) -1; s >= 0; s--) {
                 _squad.members[s] = fetch_unit_uid(_squad.members[s]);
-            }
-
-            for (var s = array_length(_squad.members) - 1; s >= 0; s--) {
-                if (!is_struct(_squad.members[s])) {
-                    array_delete(_squad.members, s, 1);
+                if (is_undefined(_squad.members[s])){
+                    array_delete(_squad.members , s);
                 }
             }
         }

--- a/objects/obj_ini/Create_0.gml
+++ b/objects/obj_ini/Create_0.gml
@@ -320,7 +320,7 @@ deserialize = function(save_data) {
             for (var s = array_length(_squad.members) -1; s >= 0; s--) {
                 _squad.members[s] = fetch_unit_uid(_squad.members[s]);
                 if (is_undefined(_squad.members[s])){
-                    array_delete(_squad.members , s);
+                    array_delete(_squad.members, s, 1);
                 }
             }
         }

--- a/scripts/scr_apothecary_ground/scr_apothecary_ground.gml
+++ b/scripts/scr_apothecary_ground/scr_apothecary_ground.gml
@@ -17,9 +17,8 @@ enum eSYSTEM_LOC {
 
 /// @self Struct.SpecialistPointHandler
 function calculate_full_chapter_spread() {
-    obj_controller.command = 0;
-    obj_controller.marines = 0;
-    var _mar_loc, is_healer, _is_tech, key_val, veh_location, array_slot, _unit;
+    tally_marines();
+    var  veh_location, array_slot;
     var _tech_spread = {};
     var _apoth_spread = {};
     var _unit_spread = {};
@@ -29,23 +28,16 @@ function calculate_full_chapter_spread() {
         var _company_length = max(_marine_len, _veh_len);
 
         for (var v = 0; v < _company_length; v++) {
-            key_val = "";
+            var key_val = "";
             if (v < _marine_len) {
-                _unit = fetch_unit([company, v]);
-                _mar_loc = _unit.marine_location();
-                if (_unit.base_group == "astartes") {
-                    if (_unit.IsSpecialist()) {
-                        obj_controller.command++;
-                    } else {
-                        obj_controller.marines++;
-                    }
-                }
+                var _unit = fetch_unit([company, v]);
+                var _mar_loc = _unit.marine_location();
                 forge_equipment_maintenance += _unit.equipment_maintenance_burden();
-                _is_tech = _unit.IsSpecialist(SPECIALISTS_TECHS);
+                var _is_tech = _unit.IsSpecialist(SPECIALISTS_TECHS);
                 if (_is_tech) {
                     add_forge_points_to_stack(_unit);
                 }
-                is_healer = ((_unit.IsSpecialist(SPECIALISTS_APOTHECARIES, true) && _unit.gear() == "Narthecium") || (_unit.role() == "Sister Hospitaler")) && _unit.hp() >= 10;
+                var is_healer = ((_unit.IsSpecialist(SPECIALISTS_APOTHECARIES, true) && _unit.gear() == "Narthecium") || (_unit.role() == "Sister Hospitaler")) && _unit.hp() >= 10;
                 if (is_healer) {
                     add_apoth_points_to_stack(_unit);
                 }

--- a/scripts/scr_company_order/scr_company_order.gml
+++ b/scripts/scr_company_order/scr_company_order.gml
@@ -24,8 +24,12 @@ function tally_marines() {
     obj_controller.command = 0;
     obj_controller.marines = 0;
     for (var co = 0; co <= obj_ini.companies; co++) {
-        for (var i = 0; i < company_length(co); i++) {
+        for (var i = company_length(co) - 1; i >= 0 ; i--) {
             var _unit = fetch_unit([co, i]);
+            if (!is_struct(_unit)){
+                array_delete(obj_ini.TTRPG[co],i,1);
+                continue;
+            }
             if (_unit.base_group != "astartes") {
                 continue;
             }

--- a/scripts/scr_company_order/scr_company_order.gml
+++ b/scripts/scr_company_order/scr_company_order.gml
@@ -20,14 +20,23 @@ function company_length(company) {
     return array_length(obj_ini.TTRPG[company]);
 }
 
+function normalise_marine_numbers(company, start_index,length){
+    for (var l = start_index; l < length; l++) {
+        obj_ini.TTRPG[company][l].marine_number = l;
+    }
+}
+
 function tally_marines() {
     obj_controller.command = 0;
     obj_controller.marines = 0;
     for (var co = 0; co <= obj_ini.companies; co++) {
-        for (var i = company_length(co) - 1; i >= 0 ; i--) {
+        var _len = company_length(co);
+        for (var i = _len - 1; i >= 0 ; i--) {
             var _unit = fetch_unit([co, i]);
             if (!is_struct(_unit)){
                 array_delete(obj_ini.TTRPG[co],i,1);
+                _len--;
+                normalise_marine_numbers(co, i, _len);
                 continue;
             }
             if (_unit.base_group != "astartes") {

--- a/scripts/scr_kill_unit/scr_kill_unit.gml
+++ b/scripts/scr_kill_unit/scr_kill_unit.gml
@@ -26,9 +26,7 @@ function scr_kill_unit() {
         }
         array_delete(obj_ini.TTRPG[company], marine_number, 1);
         var _len = company_length(company);
-        for (var i = marine_number; i < _len; i++) {
-            obj_ini.TTRPG[company][i].marine_number = i;
-        }
+        normalise_marine_numbers(company, marine_number, _len);
         var _is_astartes = base_group == "astartes";
         if (_is_astartes) {
             if (IsSpecialist()) {

--- a/scripts/scr_squads/scr_squads.gml
+++ b/scripts/scr_squads/scr_squads.gml
@@ -635,7 +635,7 @@ function UnitSquad(squad_type = undefined, company = 0) constructor {
     static member_loop = function(member_func, data_pack) {
         member_length = array_length(members);
         for (var i = 0; i < member_length; i++) {
-            var _unit = fetch_unit(members[i]);
+            var _unit = members[i];
             if (!is_struct(_unit)) {
                 array_delete(members, i, 1);
                 member_length--;


### PR DESCRIPTION
<!--- YOU CAN DELETE ALL OF THIS AFTER READING. -->

<!--- Make use of markdown lists. They make stuff much easier to read through. -->
<!--- Explain why and what your changes do in simple terms. --->
<!--- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. --->

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->

<!--- "Inspired" by the CDDA PR template -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes crashes and miscounts in chapter spread and squads by cleaning invalid unit entries, normalizing `marine_number` after deletions, and centralizing marine/command tallying. Reverse iteration prevents array-delete issues during deserialization and member loops.

- **Bug Fixes**
  - Squad deserialization resolves member UIDs and prunes undefined entries in one reverse pass.
  - UnitSquad member loop uses resolved members directly and prunes non-struct entries safely.
  - Added `normalise_marine_numbers` to reindex `marine_number` after deletions; `tally_marines` now reverse-iterates, removes invalid `obj_ini.TTRPG` slots, updates command/marine counts, and `calculate_full_chapter_spread` calls it.

<sup>Written for commit 364dc10b246fb8bcd882cf7862698a37ebf7e03c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

