### PR TITLE
fix: squad saving and loading

### DIFF
--- a/objects/obj_ini/Create_0.gml
+++ b/objects/obj_ini/Create_0.gml
@@ -309,14 +309,13 @@ deserialize = function(save_data) {
 
     var _squad_structs = save_data[$ "squad_structs"];
     if (is_struct(_squad_structs)) {
-        squads = {};
-        var _squad_uids = struct_get_names(_squad_structs);
-        var _squad_count = array_length(_squad_uids);
-        for (var i = 0; i < _squad_count; i++) {
-            var _squad_uid = _squad_uids[i];
             var _data = _squad_structs[$ _squad_uid];
             var _squad = new UnitSquad();
-            _squad.load(_data);
+            try {
+                _squad.load(_data);
+            } catch (e) {
+                LOGGER.exception("Failed to load squad " + _squad_uid, e);
+            }
         }
     }
 

--- a/objects/obj_ini/Create_0.gml
+++ b/objects/obj_ini/Create_0.gml
@@ -309,13 +309,14 @@ deserialize = function(save_data) {
 
     var _squad_structs = save_data[$ "squad_structs"];
     if (is_struct(_squad_structs)) {
+        squads = {};
+        var _squad_uids = struct_get_names(_squad_structs);
+        var _squad_count = array_length(_squad_uids);
+        for (var i = 0; i < _squad_count; i++) {
+            var _squad_uid = _squad_uids[i];
             var _data = _squad_structs[$ _squad_uid];
             var _squad = new UnitSquad();
-            try {
-                _squad.load(_data);
-            } catch (e) {
-                LOGGER.exception("Failed to load squad " + _squad_uid, e);
-            }
+            _squad.load(_data);
         }
     }
 

--- a/objects/obj_ini/Create_0.gml
+++ b/objects/obj_ini/Create_0.gml
@@ -316,7 +316,11 @@ deserialize = function(save_data) {
             var _squad_uid = _squad_uids[i];
             var _data = _squad_structs[$ _squad_uid];
             var _squad = new UnitSquad();
-            _squad.load(_data);
+            try {
+                _squad.load(_data);
+            } catch (e) {
+                LOGGER.exception("Failed to load squad " + _squad_uid, e);
+            }
         }
     }
 

--- a/objects/obj_ini/Create_0.gml
+++ b/objects/obj_ini/Create_0.gml
@@ -160,7 +160,7 @@ serialize = function() {
 
         for (var s = 0; s < array_length(_squad.members); s++) {
             if (is_struct(_squad.members[s])) {
-                _squad.members[i] = _squad.members[s].uid;
+                _squad.members[s] = _squad.members[s].uid;
             }
         }
     }
@@ -176,7 +176,7 @@ serialize = function() {
         squad_types,
         artifact_list: _artifact_list,
         marine_structs: _marines,
-        squad_structs: squads,
+        squad_structs: _squad_copies,
         equipment,
         gene_slaves, // squads // marines,
         chapter_data,
@@ -314,18 +314,10 @@ deserialize = function(save_data) {
         var _squad_count = array_length(_squad_uids);
         for (var i = 0; i < _squad_count; i++) {
             var _squad_uid = _squad_uids[i];
+            var _data = _squad_structs[$ _squad_uid];
             var _squad = new UnitSquad();
-            _squad.load_json_data(_squad_structs[$ _squad_uid]);
-            squads[$ _squad_uid] = _squad;
-            for (var s = 0; s < array_length(_squad.members); s++) {
-                _squad.members[s] = fetch_unit_uid(_squad.members[s]);
-            }
+            _squad.load(_data);
 
-            for (var s = array_length(_squad.members) - 1; s >= 0; s--) {
-                if (!is_struct(_squad.members[s])) {
-                    array_delete(_squad.members, s, 1);
-                }
-            }
         }
     }
 

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -2370,7 +2370,7 @@ function fetch_unit_careful() {}
 
 function fetch_unit_uid(uuid) {
     for (var i = 0; i <= obj_ini.companies; i++) {
-        var _comp_length = array_length(obj_ini.TTRPG[i]);
+        var _comp_length = company_length(i);
         for (var s = 0; s < _comp_length; s++) {
             var _unit = fetch_unit([i, s]);
             if (!is_struct(_unit)) {

--- a/scripts/scr_squads/scr_squads.gml
+++ b/scripts/scr_squads/scr_squads.gml
@@ -483,6 +483,7 @@ function UnitSquad(squad_type = undefined, company = 0) constructor {
                 array_delete(members, s, 1);
             }
         }
+        determine_leader();
     };
 
     //this dermine the relative coherency of a squad on the basis that a squad needs to more or less be all together in order ot undertake squad actions

--- a/scripts/scr_squads/scr_squads.gml
+++ b/scripts/scr_squads/scr_squads.gml
@@ -471,10 +471,17 @@ function UnitSquad(squad_type = undefined, company = 0) constructor {
     };
 
     //function for loading in squad save data
-    static load_json_data = function(data) {
-        var names = variable_struct_get_names(data);
-        for (var i = 0; i < array_length(names); i++) {
-            variable_struct_set(self, names[i], variable_struct_get(data, names[i]));
+    static load = function(data) {
+        move_data_to_current_scope(data);
+        obj_ini.squads[$ uid] = self;
+        for (var s = 0; s < array_length(members); s++) {
+            members[s] = fetch_unit_uid(members[s]);
+        }
+
+        for (var s = array_length(members) - 1; s >= 0; s--) {
+            if (!is_struct(members[s])) {
+                array_delete(members, s, 1);
+            }
         }
     };
 


### PR DESCRIPTION
<!--- YOU CAN DELETE ALL OF THIS AFTER READING. -->

<!--- Make use of markdown lists. They make stuff much easier to read through. -->
<!--- Explain why and what your changes do in simple terms. --->
<!--- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. --->

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->

<!--- "Inspired" by the CDDA PR template -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes squad persistence and leader restoration after save/load. Previously we saved wrong member indices and didn’t register or resolve squads on load, so squads vanished or loaded empty and leaders were lost.

- Serialize: use the correct member index when converting to uids; write `squad_structs` from `_squad_copies` instead of live `squads`.
- Deserialize: call `UnitSquad.load`, which moves data into the instance, registers it in `obj_ini.squads`, resolves member IDs via `fetch_unit_uid`, prunes invalid members, restores the leader, and logs/continues on per-squad load errors.
- Lookup: `fetch_unit_uid` now uses `company_length(i)` for bounds to avoid out-of-range access.
- Migration: rename calls from `load_json_data` to `load`.

<sup>Written for commit a99b5f01543018556731f1e66af40a93ebaa2883. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

