### PR TITLE
fix(ui): correct layouts, equipment lists, popup rendering, and CJK fonts

### DIFF
--- a/objects/obj_popup/Create_0.gml
+++ b/objects/obj_popup/Create_0.gml
@@ -303,10 +303,5 @@ sel2 = 0;
 sel3 = 0;
 sel4 = 0;
 sel5 = 0;
-vehicle_equipment = 0;
 warning = "";
 item_name = [];
-
-move_to_next_stage = function() {
-    return scr_hit(0, 0, room_width, room_height) || press_exclusive(vk_enter) || press_exclusive(vk_space) || press_exclusive(vk_enter);
-};

--- a/objects/obj_popup/Create_0.gml
+++ b/objects/obj_popup/Create_0.gml
@@ -1,15 +1,8 @@
 type = 0;
 size = 2;
 y_scale = 1;
-if (size == 1) {
-    sprite_index = spr_popup_small;
-}
-if (size == 2) {
-    sprite_index = spr_popup_medium;
-}
-if (size == 3) {
-    sprite_index = spr_popup_large;
-}
+sprite_index = spr_popup_medium;
+
 // Popup windows draw in Draw GUI; hide the automatic instance sprite.
 image_alpha = 0;
 image_speed = 0;
@@ -24,9 +17,6 @@ if (instance_exists(obj_controller)) {
         master_crafted = obj_controller.popup_master_crafted;
     }
 }
-type = 0;
-size = 2;
-image = "";
 title = "";
 fancy_title = 0;
 text_center = 0;

--- a/objects/obj_popup/Create_0.gml
+++ b/objects/obj_popup/Create_0.gml
@@ -10,6 +10,9 @@ if (size == 2) {
 if (size == 3) {
     sprite_index = spr_popup_large;
 }
+// Popup windows draw in Draw GUI; hide the automatic instance sprite.
+image_alpha = 0;
+image_speed = 0;
 image_wid = 0;
 image_hei = 0;
 image = "";

--- a/objects/obj_tooltip/Draw_75.gml
+++ b/objects/obj_tooltip/Draw_75.gml
@@ -1,126 +1,129 @@
-/// @description Insert description here
-// You can write your code in this editor
+var _tooltip_count = array_length(tooltip_data);
 
-for (var i = 0; i < array_length(tooltip_data); i++) {
-    var _tooltip = string_hash_to_newline(tooltip_data[i].tooltip);
-    var _width = tooltip_data[i].width;
-    var _coords = tooltip_data[i].coords;
-    var _text_color = tooltip_data[i].text_color;
-    var _font = tooltip_data[i].font;
-    var _header = string_hash_to_newline(tooltip_data[i].header);
-    var _header_font = tooltip_data[i].header_font;
-    var _footer = string_hash_to_newline(tooltip_data[i].footer);
-    var _footer_font = tooltip_data[i].footer_font;
-    var _force_width = tooltip_data[i].force_width;
-    var _cost = tooltip_data[i].cost;
-
-    var _draw_font = cjk_font(_font);
-    var _draw_header_font = cjk_font(_header_font);
-    var _draw_footer_font = cjk_font(_footer_font);
+if (_tooltip_count > 0) {
+    var _gui_width = display_get_gui_width();
+    var _gui_height = display_get_gui_height();
 
     var _screen_vpadding = 30;
     var _screen_hpadding = 60;
-    var _header_h = 0;
-    var _header_w = 0;
-    var _footer_h = 0;
-    var _footer_w = 0;
     var _cursor_offset = 20;
-
-    // Calculate padding and rectangle size
     var _text_padding_x = 12;
     var _text_padding_y = 12;
+    for (var i = 0; i < _tooltip_count; i++) {
+        var _tooltip = string_hash_to_newline(tooltip_data[i].tooltip);
+        var _width = tooltip_data[i].width;
+        var _coords = tooltip_data[i].coords;
+        var _text_color = tooltip_data[i].text_color;
+        var _font = tooltip_data[i].font;
+        var _header = string_hash_to_newline(tooltip_data[i].header);
+        var _header_font = tooltip_data[i].header_font;
+        var _footer = string_hash_to_newline(tooltip_data[i].footer);
+        var _footer_font = tooltip_data[i].footer_font;
+        var _force_width = tooltip_data[i].force_width;
+        var _cost = tooltip_data[i].cost;
 
-    // Define tooltip position
-    var _rect_x = _coords[0] + _cursor_offset;
-    var _rect_y = _coords[1] + _cursor_offset;
-    var _rect_w = 0;
-    var _rect_h = 0;
+        var _draw_font = cjk_font(_font);
+        var _draw_header_font = cjk_font(_header_font);
+        var _draw_footer_font = cjk_font(_footer_font);
 
-    // Measurements
-    draw_set_font(_draw_font);
-    var _text_w = _force_width ? _width : min(string_width(_tooltip), _width);
-    var _text_h = string_height_ext(_tooltip, DEFAULT_LINE_GAP, _text_w);
+        var _header_h = 0;
+        var _header_w = 0;
+        var _footer_h = 0;
+        var _footer_w = 0;
 
-    if (_header != "") {
-        draw_set_font(_draw_header_font);
-        _header_w = _force_width ? _width : max(string_width(_header), _width);
-        _header_h = string_height_ext(_header, DEFAULT_LINE_GAP, _header_w);
-    }
+        var _rect_x = _coords[0] + _cursor_offset;
+        var _rect_y = _coords[1] + _cursor_offset;
+        var _rect_w = 0;
+        var _rect_h = 0;
 
-    if (_footer != "") {
-        draw_set_font(_draw_footer_font);
-        _footer_w = _force_width ? _width : max(string_width(_footer), _width);
-        _footer_h = string_height_ext(_footer, DEFAULT_LINE_GAP, _footer_w);
-    }
+        // Measurements
+        draw_set_font(_draw_font);
+        var _text_w = _force_width ? _width : min(string_width(_tooltip), _width);
+        var _text_h = string_height_ext(_tooltip, DEFAULT_LINE_GAP, _text_w);
 
-    // Layout
-    _rect_w = max(_header_w, _text_w, _footer_w) + _text_padding_x * 2;
-    var _content_h = _text_padding_y;
-
-    if (_header != "") {
-        _content_h += _header_h + DEFAULT_LINE_GAP;
-    }
-
-    _content_h += _text_h + DEFAULT_LINE_GAP;
-
-    if (_footer != "") {
-        _content_h += _footer_h + DEFAULT_LINE_GAP;
-    }
-
-    if (_cost != 0) {
-        _content_h += max(sprite_get_height(spr_requisition), string_height(string(_cost)));
-    }
-
-    _content_h += _text_padding_y;
-    _rect_h = _content_h;
-
-    // Check if the tooltip goes over the right part of the screen and flip left if so
-    if (_rect_x + _rect_w > display_get_gui_width() - _screen_hpadding) {
-        _rect_x = _coords[0] - _rect_w - _cursor_offset;
-    }
-
-    // Check if the tooltip goes over the bottom part of the screen and flip up if so
-    if (_rect_y + _rect_h > display_get_gui_height() - _screen_vpadding) {
-        _rect_y = _coords[1] - _rect_h - _cursor_offset;
-    }
-
-    var _content_x = _rect_x + _text_padding_x;
-    var _header_y = _rect_y + _text_padding_y;
-    var _text_y = _header_y + _header_h + DEFAULT_LINE_GAP;
-    var _footer_y = _text_y + _text_h + DEFAULT_LINE_GAP;
-    var _cost_y = _footer_y + _footer_h + DEFAULT_LINE_GAP;
-
-    // Drawing
-    add_draw_return_values();
-
-    draw_set_valign(fa_top);
-    draw_set_halign(fa_left);
-    draw_set_alpha(1);
-
-    draw_sprite_stretched(spr_data_slate_back, 0, _rect_x, _rect_y, _rect_w, _rect_h);
-    draw_rectangle_color_simple(_rect_x, _rect_y, _rect_w + _rect_x, _rect_h + _rect_y, 1, c_gray);
-    draw_rectangle_color_simple(_rect_x + 1, _rect_y + 1, _rect_w + _rect_x - 1, _rect_h + _rect_y - 1, 1, c_black);
-    draw_rectangle_color_simple(_rect_x + 2, _rect_y + 2, _rect_w + _rect_x - 2, _rect_h + _rect_y - 2, 1, c_gray);
-
-    if (_header != "") {
-        draw_set_font(_draw_header_font);
-        draw_text_ext_transformed_colour(_content_x, _header_y, _header, DEFAULT_LINE_GAP, _header_w, 1, 1, 0, _text_color, _text_color, _text_color, _text_color, 1);
-    }
-
-    draw_set_font(_draw_font);
-    draw_text_ext_transformed_colour(_content_x, _text_y, _tooltip, DEFAULT_LINE_GAP, _text_w, 1, 1, 0, _text_color, _text_color, _text_color, _text_color, 1);
-
-    if (_footer != "") {
-        draw_set_font(_draw_footer_font);
-        draw_text_ext_transformed_colour(_content_x, _footer_y, _footer, DEFAULT_LINE_GAP, _footer_w, 1, 1, 0, _text_color, _text_color, _text_color, _text_color, 1);
-        if (_cost != 0) {
-            var _cost_color = (obj_controller.requisition < _cost) ? c_red : COL_REQUISITION;
-            draw_sprite(spr_requisition, 0, _content_x, _cost_y);
-            draw_text_ext_transformed_colour(_content_x + sprite_get_width(spr_requisition), _cost_y, _cost, DEFAULT_LINE_GAP, string_width(string(_cost)), 1, 1, 0, _cost_color, _cost_color, _cost_color, _cost_color, 1);
+        if (_header != "") {
+            draw_set_font(_draw_header_font);
+            _header_w = _force_width ? _width : max(string_width(_header), _width);
+            _header_h = string_height_ext(_header, DEFAULT_LINE_GAP, _header_w);
         }
-    }
 
-    pop_draw_return_values();
+        if (_footer != "") {
+            draw_set_font(_draw_footer_font);
+            _footer_w = _force_width ? _width : max(string_width(_footer), _width);
+            _footer_h = string_height_ext(_footer, DEFAULT_LINE_GAP, _footer_w);
+        }
+
+        // Layout
+        _rect_w = max(_header_w, _text_w, _footer_w) + _text_padding_x * 2;
+        var _content_h = _text_padding_y;
+
+        if (_header != "") {
+            _content_h += _header_h + DEFAULT_LINE_GAP;
+        }
+
+        _content_h += _text_h + DEFAULT_LINE_GAP;
+
+        if (_footer != "") {
+            _content_h += _footer_h + DEFAULT_LINE_GAP;
+        }
+
+        if (_cost != 0) {
+            _content_h += max(sprite_get_height(spr_requisition), string_height(string(_cost)));
+        }
+
+        _content_h += _text_padding_y;
+        _rect_h = _content_h;
+
+        if (_rect_x + _rect_w > _gui_width - _screen_hpadding) {
+            _rect_x = _coords[0] - _rect_w - _cursor_offset;
+        }
+
+        if (_rect_y + _rect_h > _gui_height - _screen_vpadding) {
+            _rect_y = _coords[1] - _rect_h - _cursor_offset;
+        }
+
+        // Clamp failed flips to the GUI; pin oversized tooltips to the near edge.
+        _rect_x = clamp(_rect_x, 0, max(0, _gui_width - _rect_w - _screen_hpadding));
+        _rect_y = clamp(_rect_y, 0, max(0, _gui_height - _rect_h - _screen_vpadding));
+
+        var _content_x = _rect_x + _text_padding_x;
+        var _header_y = _rect_y + _text_padding_y;
+        var _text_y = _header_y + _header_h + DEFAULT_LINE_GAP;
+        var _footer_y = _text_y + _text_h + DEFAULT_LINE_GAP;
+        var _cost_y = _footer_y + _footer_h + DEFAULT_LINE_GAP;
+
+        // Drawing
+        add_draw_return_values();
+
+        draw_set_valign(fa_top);
+        draw_set_halign(fa_left);
+        draw_set_alpha(1);
+
+        draw_sprite_stretched(spr_data_slate_back, 0, _rect_x, _rect_y, _rect_w, _rect_h);
+        draw_rectangle_color_simple(_rect_x, _rect_y, _rect_w + _rect_x, _rect_h + _rect_y, 1, c_gray);
+        draw_rectangle_color_simple(_rect_x + 1, _rect_y + 1, _rect_w + _rect_x - 1, _rect_h + _rect_y - 1, 1, c_black);
+        draw_rectangle_color_simple(_rect_x + 2, _rect_y + 2, _rect_w + _rect_x - 2, _rect_h + _rect_y - 2, 1, c_gray);
+
+        if (_header != "") {
+            draw_set_font(_draw_header_font);
+            draw_text_ext_transformed_colour(_content_x, _header_y, _header, DEFAULT_LINE_GAP, _header_w, 1, 1, 0, _text_color, _text_color, _text_color, _text_color, 1);
+        }
+
+        draw_set_font(_draw_font);
+        draw_text_ext_transformed_colour(_content_x, _text_y, _tooltip, DEFAULT_LINE_GAP, _text_w, 1, 1, 0, _text_color, _text_color, _text_color, _text_color, 1);
+
+        if (_footer != "") {
+            draw_set_font(_draw_footer_font);
+            draw_text_ext_transformed_colour(_content_x, _footer_y, _footer, DEFAULT_LINE_GAP, _footer_w, 1, 1, 0, _text_color, _text_color, _text_color, _text_color, 1);
+            if (_cost != 0) {
+                var _cost_color = (obj_controller.requisition < _cost) ? c_red : COL_REQUISITION;
+                draw_sprite(spr_requisition, 0, _content_x, _cost_y);
+                draw_text_ext_transformed_colour(_content_x + sprite_get_width(spr_requisition), _cost_y, _cost, DEFAULT_LINE_GAP, string_width(string(_cost)), 1, 1, 0, _cost_color, _cost_color, _cost_color, _cost_color, 1);
+            }
+        }
+
+        pop_draw_return_values();
+    }
 }
 
 tooltip_data = [];

--- a/scripts/LocalizationManager/LocalizationManager.gml
+++ b/scripts/LocalizationManager/LocalizationManager.gml
@@ -1,20 +1,29 @@
 /// @desc Loads and queries localized strings stored in datafiles/lang/<language_code>.json.
 ///       English text is used as the translation key, so missing translations neatly fall back to it.
+/// @returns {Struct.LocalizationManager}
 function LocalizationManager() constructor {
+    CJK_FONT_LOAD_FAILED = -1;
     language = LANG_EN;
     needs_cjk = false;
     translations = {};
     cjk_fonts = {};
+    resolved_fonts = {};
     font_styles = {};
     // Keys already warned about as missing this language load, so draw-time arrays do not
     // flood LOGGER.error every frame for the same gap. Reset on each language load.
     reported_missing = {};
 
-    /// @param {string} _language Language code: LANG_EN, LANG_ZH, etc.
+    /// @desc Loads translations and font-resolution state for a language.
+    /// @param {String} _language Language code: LANG_EN, LANG_ZH, etc.
+    /// @returns {Undefined}
     static load_language = function(_language) {
+        var _language_changed = self.language != _language;
         self.language = _language;
         self.needs_cjk = _language != LANG_EN && string_count(LANG_ZH, _language) > 0;
         self.translations = self._load_lang_file(_language);
+        if (_language_changed) {
+            self.resolved_fonts = {};
+        }
         self.reported_missing = {};
         self._warn_missing_translations();
     };
@@ -175,29 +184,36 @@ function LocalizationManager() constructor {
         }
     };
 
-    /// @param {real} _size Point size used for the runtime fallback font.
-    /// @param {real} _base_font The font asset intended for this text.
-    /// @returns {real}
-    static get_font = function(_size, _base_font) {
+    /// @param {Real} _base_font The font asset intended for this text.
+    /// @returns {Real}
+    static get_font = function(_base_font) {
         if (!self.needs_cjk) {
             return _base_font;
         }
 
+        var _font_id = string(_base_font);
+        if (struct_exists(self.resolved_fonts, _font_id)) {
+            return self.resolved_fonts[$ _font_id];
+        }
+
+        var _size = font_get_size(_base_font);
         var _style = self._get_font_style(_base_font);
         var _key = string(_size) + ":" + string(_style.bold) + ":" + string(_style.italic);
+        var _fallback_font = self.CJK_FONT_LOAD_FAILED;
         if (struct_exists(self.cjk_fonts, _key)) {
-            return self.cjk_fonts[$ _key];
+            _fallback_font = self.cjk_fonts[$ _key];
+        } else {
+            _fallback_font = font_add(STR_CJK_FALLBACK_FONT, _size, _style.bold, _style.italic, 32, 65535);
+            if (!font_exists(_fallback_font)) {
+                LOGGER.error($"Failed to load CJK fallback font '{STR_CJK_FALLBACK_FONT}' at size {_size}. Chinese glyphs may render as blank boxes.");
+                _fallback_font = self.CJK_FONT_LOAD_FAILED;
+            }
+            self.cjk_fonts[$ _key] = _fallback_font;
         }
 
-        var _fallback_font = font_add(STR_CJK_FALLBACK_FONT, _size, _style.bold, _style.italic, 32, 65535);
-        if (!font_exists(_fallback_font)) {
-            LOGGER.error($"Failed to load CJK fallback font '{STR_CJK_FALLBACK_FONT}' at size {_size}. Chinese glyphs may render as blank boxes.");
-            self.cjk_fonts[$ _key] = _base_font;
-            return _base_font;
-        }
-
-        self.cjk_fonts[$ _key] = _fallback_font;
-        return _fallback_font;
+        var _effective_font = _fallback_font == self.CJK_FONT_LOAD_FAILED ? _base_font : _fallback_font;
+        self.resolved_fonts[$ _font_id] = _effective_font;
+        return _effective_font;
     };
 
     /// @desc Returns a font's bold/italic style, cached per font asset so detection (and any
@@ -228,7 +244,10 @@ function LocalizationManager() constructor {
             return _overrides[$ _name];
         }
 
-        var _style = { bold: false, italic: false };
+        var _style = {
+            bold: false,
+            italic: false,
+        };
         var _len = string_length(_name);
         if (_len == 0) {
             return _style;
@@ -291,14 +310,14 @@ function localize_array(_keys) {
 
 /// @desc Global shorthand for a font suitable for the current language, deriving
 ///       the point size from the base font asset so callers never hardcode sizes.
-/// @param {real} _base_font The font asset intended for this text.
-/// @returns {real}
+/// @param {Real} _base_font The font asset intended for this text.
+/// @returns {Real}
 function cjk_font(_base_font) {
-    var _size = font_get_size(_base_font);
-    if (variable_global_exists("localization_manager")) {
-        return global.localization_manager.get_font(_size, _base_font);
+    if (!variable_global_exists("localization_manager") || !global.localization_manager.needs_cjk) {
+        return _base_font;
     }
-    return _base_font;
+
+    return global.localization_manager.get_font(_base_font);
 }
 
 /// @desc Explicit registry of styled font assets used by the CJK fallback. The CJK runtime font
@@ -308,10 +327,22 @@ function cjk_font(_base_font) {
 /// @returns {Struct}
 function font_style_overrides() {
     static _overrides = {
-        fnt_40k_14b: { bold: true, italic: false },
-        fnt_40k_30b: { bold: true, italic: false },
-        fnt_40k_12i: { bold: false, italic: true },
-        fnt_40k_14i: { bold: false, italic: true },
+        fnt_40k_14b: {
+            bold: true,
+            italic: false,
+        },
+        fnt_40k_30b: {
+            bold: true,
+            italic: false,
+        },
+        fnt_40k_12i: {
+            bold: false,
+            italic: true,
+        },
+        fnt_40k_14i: {
+            bold: false,
+            italic: true,
+        },
     };
     return _overrides;
 }

--- a/scripts/scr_popup_functions/scr_popup_functions.gml
+++ b/scripts/scr_popup_functions/scr_popup_functions.gml
@@ -77,10 +77,11 @@ function popup_default_close() {
 }
 
 /// @self Asset.GMObject.obj_popup
+/// @desc Draws the popup window selected by the instance's size and type.
+/// @returns {Undefined}
 function popup_window_draw() {
     if ((size == 0) || (size == 2)) {
         sprite_index = spr_popup_medium;
-        image_alpha = 0;
         width = sprite_width - 50;
         draw_sprite_ext(spr_popup_medium, type, ((1600 - sprite_width) / 2), ((900 - sprite_height) / 2), 1, y_scale, 0, c_white, 1);
         if (image != "") {
@@ -89,7 +90,6 @@ function popup_window_draw() {
         }
     } else if (size == 1) {
         sprite_index = spr_popup_small;
-        image_alpha = 0;
         width = sprite_width - 10;
         draw_sprite_ext(spr_popup_small, type, ((1600 - sprite_width) / 2), ((900 - sprite_height) / 2), 1, y_scale, 0, c_white, 1);
         if (image != "") {
@@ -99,7 +99,6 @@ function popup_window_draw() {
     } else if (size == 3) {
         var draw_y_scale = y_scale;
         sprite_index = spr_popup_large;
-        image_alpha = 0;
         width = sprite_width - 50;
         if (image == "debug") {
             y_scale_mod = 1.5;

--- a/scripts/scr_reequip_units/scr_reequip_units.gml
+++ b/scripts/scr_reequip_units/scr_reequip_units.gml
@@ -1,7 +1,7 @@
 enum eEQUIP_TARGET_TYPE {
     NONE = 0,
     MARINE = 1,
-    DREADNOUGHT,
+    DREADNOUGHT = eROLE.DREADNOUGHT,
     LAND_RAIDER = 50,
     RHINO = 51,
     PREDATOR = 52,
@@ -235,7 +235,7 @@ function set_up_equip_popup() {
         pip.allow_quality_change = true;
         pip.from_inventory = true;
 
-        //Forwards equip_target_type selection to the equipment_recipient_type variable used in mouse_50 obj_popup and weapons_equip script
+        // Forward the role-compatible target type used by scr_get_item_names().
         pip.equipment_recipient_type = equip_target_type;
         with (pip) {
             setup_UI_elements_equipment_selector(1000, 143);
@@ -248,7 +248,7 @@ function reload_items() {
     item_name = [];
     scr_get_item_names(
         item_name,
-        equipment_recipient_type, // eROLE
+        equipment_recipient_type, // eROLE-compatible target type
         equipment_area, // slot
         range_melee_radio.selection_val("val"),
         false, // include company standard

--- a/scripts/scr_reequip_units/scr_reequip_units.gml
+++ b/scripts/scr_reequip_units/scr_reequip_units.gml
@@ -113,6 +113,8 @@ function setup_UI_elements_equipment_selector(_x1, _y1) {
 }
 
 /// @self Asset.GMObject.obj_controller
+/// @desc Opens the equipment popup for the selected units.
+/// @returns {Undefined}
 function set_up_equip_popup() {
     if (instance_exists(obj_popup)) {
         return;
@@ -231,7 +233,6 @@ function set_up_equip_popup() {
         pip.company = managing;
         pip.unit_count = _units_selected_for_change;
         pip.unchangeable_armour = _unchangeable_armour;
-        pip.sprite_index = noone;
         pip.allow_quality_change = true;
         pip.from_inventory = true;
 

--- a/scripts/scr_reequip_units/scr_reequip_units.gml
+++ b/scripts/scr_reequip_units/scr_reequip_units.gml
@@ -258,6 +258,9 @@ function reload_items() {
 }
 
 /// @self Asset.GMObject.obj_popup Asset.GMObject.obj_creation_popup
+/// @desc Draws and handles the equipment popup.
+/// @param {Bool} [before_after_styling] ... Defaults to true.
+/// @returns {Undefined}
 function draw_popup_equip(before_after_styling = true) {
     main_slate.draw_with_dimensions();
     add_draw_return_values();
@@ -385,7 +388,6 @@ function draw_popup_equip(before_after_styling = true) {
         warning = _results.warning;
     }
 
-    //draw_set_halign(fa_center);
     if ((equipment_area == eEQUIPMENT_SLOT.WEAPON_ONE) || (equipment_area == eEQUIPMENT_SLOT.WEAPON_TWO)) {
         range_melee_radio.draw();
     }
@@ -400,9 +402,18 @@ function draw_popup_equip(before_after_styling = true) {
         reload_items();
     }
 
-    draw_set_color(255);
-    draw_set_halign(fa_center);
-    draw_text(_x1 + 286, _y1 + 427, warning);
+    if (warning != "") {
+        add_draw_return_values();
+        draw_set_color(255);
+        draw_set_halign(fa_center);
+        draw_set_valign(fa_top);
+        draw_set_font(fnt_40k_12);
+        var _warning_width = main_slate.width - 40;
+        var _warning_height = string_height_ext(warning, -1, _warning_width);
+        var _warning_bottom_y = _y1 + 443; // 5px above the Cancel/Equip buttons at _y1 + 448
+        draw_text_ext(_x1 + main_slate.width / 2, _warning_bottom_y - _warning_height, warning, -1, _warning_width);
+        pop_draw_return_values();
+    }
 
     if (cancel_button.draw()) {
         instance_destroy();

--- a/scripts/scr_ui_manage/scr_ui_manage.gml
+++ b/scripts/scr_ui_manage/scr_ui_manage.gml
@@ -1288,7 +1288,7 @@ function draw_selection_filter_group(_button, _all_label, _all_value, _entries, 
         sel_all = _all_value;
     }
 
-    var _row_x = _button.x2 + _button.v_gap;
+    var _row_x = _button.x2 + _button.h_gap;
     var _row_y = _top;
 
     for (var i = 1; i <= 8; i++) {
@@ -1312,7 +1312,7 @@ function draw_selection_filter_group(_button, _all_label, _all_value, _entries, 
         if (_button.draw()) {
             sel_all = _entries[i];
         }
-        _row_x = _button.x2 + _button.v_gap;
+        _row_x = _button.x2 + _button.h_gap;
     }
 
     return _row_y + _button.h + _button.v_gap;
@@ -1365,7 +1365,7 @@ function draw_manage_selection_buttons() {
     if (button.draw() && equip_possible) {
         set_up_equip_popup();
     }
-    action_button_x += button.w + button.v_gap;
+    action_button_x += button.w + button.h_gap;
 
     // // Promote button
     button.x1 = action_button_x;
@@ -1379,7 +1379,7 @@ function draw_manage_selection_buttons() {
             setup_promotion_popup();
         }
     }
-    action_button_x += button.w + button.v_gap;
+    action_button_x += button.w + button.h_gap;
 
     // // Put in jail button
     button.x1 = action_button_x;
@@ -1393,7 +1393,7 @@ function draw_manage_selection_buttons() {
             jail_selection();
         }
     }
-    action_button_x += button.w + button.v_gap;
+    action_button_x += button.w + button.h_gap;
 
     // // Add bionics button
     button.x1 = action_button_x;
@@ -1411,7 +1411,7 @@ function draw_manage_selection_buttons() {
         }
     }
 
-    var action_button_top_y = action_button_bottom_y - (button.h + button.h_gap);
+    var action_button_top_y = action_button_bottom_y - (button.h + button.v_gap);
     action_button_x = right_ui_block.x1 + 26;
     button.y1 = action_button_top_y;
 
@@ -1427,7 +1427,7 @@ function draw_manage_selection_buttons() {
             toggle_selection_borders();
         }
     }
-    action_button_x += button.w + button.v_gap;
+    action_button_x += button.w + button.h_gap;
 
     // // Reset changes button
     button.x1 = action_button_x;
@@ -1447,7 +1447,7 @@ function draw_manage_selection_buttons() {
         button.alpha = 0.5;
         button.draw(false);
     }
-    action_button_x += button.w + button.v_gap;
+    action_button_x += button.w + button.h_gap;
 
     // // Transfer to another company button
     button.x1 = action_button_x;
@@ -1464,7 +1464,7 @@ function draw_manage_selection_buttons() {
         button.alpha = 0.5;
         button.draw(false);
     }
-    action_button_x += button.w + button.v_gap;
+    action_button_x += button.w + button.h_gap;
 
     // // Move Ship button
     button.x1 = action_button_x;
@@ -1481,7 +1481,7 @@ function draw_manage_selection_buttons() {
         button.alpha = 0.5;
         button.draw(false);
     }
-    action_button_x += button.w + button.v_gap;
+    action_button_x += button.w + button.h_gap;
 
     // // Manage Tags button
     button.x1 = action_button_x;
@@ -1570,7 +1570,7 @@ function draw_manage_selection_buttons() {
             sel_all = "all";
         }
 
-        button.x1 = top_x + button.w + button.v_gap;
+        button.x1 = top_x + button.w + button.h_gap;
         button.update_loc();
         button.label = "Filter Mode";
         button.alpha = filter_mode ? 1 : 0.5;

--- a/scripts/scr_ui_manage/scr_ui_manage.gml
+++ b/scripts/scr_ui_manage/scr_ui_manage.gml
@@ -1268,6 +1268,57 @@ function scr_ui_manage() {
 }
 
 /// @self Asset.GMObject.obj_controller
+/// @desc Draws a wrapping selection-filter group and updates sel_all on click.
+/// @param {Struct.UnitButtonObject} _button The shared button used to draw each entry
+/// @param {String} _all_label Label for the leading button
+/// @param {String} _all_value Value sel_all takes when the leading button is pressed
+/// @param {Array<String>} _entries Filter names indexed 1..8; blank entries are skipped
+/// @param {Real} _left Left edge of the group
+/// @param {Real} _top Top edge of the group
+/// @param {Real} _right Right edge the rows must stay inside
+/// @returns {Real} The Y of the first free row beneath the group
+function draw_selection_filter_group(_button, _all_label, _all_value, _entries, _left, _top, _right) {
+    draw_set_font(_button.font);
+    _button.label = _all_label;
+    _button.alpha = 1;
+    _button.tooltip = "";
+    _button.x1 = _left;
+    _button.y1 = _top;
+    if (_button.draw()) {
+        sel_all = _all_value;
+    }
+
+    var _row_x = _button.x2 + _button.v_gap;
+    var _row_y = _top;
+
+    for (var i = 1; i <= 8; i++) {
+        if (_entries[i] == "") {
+            continue;
+        }
+
+        _button.label = string_truncate(_entries[i], 126);
+        _button.alpha = 1;
+        _button.x1 = _row_x;
+        _button.y1 = _row_y;
+        _button.update_loc(); // Measure before testing for row wrap.
+
+        if (_button.x2 > _right) {
+            _row_x = _left;
+            _row_y += _button.h + _button.v_gap;
+            _button.x1 = _row_x;
+            _button.y1 = _row_y;
+        }
+
+        if (_button.draw()) {
+            sel_all = _entries[i];
+        }
+        _row_x = _button.x2 + _button.v_gap;
+    }
+
+    return _row_y + _button.h + _button.v_gap;
+}
+
+/// @self Asset.GMObject.obj_controller
 /// @desc Draws and handles the Manage-screen selection controls.
 /// @returns {Undefined}
 function draw_manage_selection_buttons() {
@@ -1445,7 +1496,6 @@ function draw_manage_selection_buttons() {
             instance_destroy(obj_popup);
         }
     }
-    //new fixes for the load shit
     button.h = _load_button_h;
     button.x1 = right_ui_block.x1 + 26;
     button.y1 = action_button_bottom_y + 30 + _load_button_h_gap;
@@ -1494,22 +1544,14 @@ function draw_manage_selection_buttons() {
     var top_x = actions_block.x1 + 26;
     var top_y = actions_block.y1 + 70;
 
-    var inf_type_x = top_x;
-    var inf_type_y = top_y;
+    var _filter_right = actions_block.x2 - 26;
+    var _filter_next_y = top_y;
 
     if (sel_uni[1] != "") {
-        // How much space the selected unit takes
         draw_set_font(fnt_40k_30b);
         draw_text_transformed(actions_block.x1 + 26, actions_block.y1 + 6, $"Selection: {man_size} space", 0.5, 0.5, 0);
-        // List of selected units
         draw_set_font(fnt_40k_14);
         draw_text_ext(actions_block.x1 + 26, actions_block.y1 + 30, selecting_dudes, -1, 550);
-        // Options for the selected unit
-        // draw_set_font(fnt_40k_30b);
-        // draw_text_transformed(actions_block.x1 + 4, actions_block.x1 + 64,"Options:",0.5,0.5,0);
-
-        // Select all units button
-        // button reset code
 
         button.set_width = false;
         button.w = 0;
@@ -1536,73 +1578,12 @@ function draw_manage_selection_buttons() {
             filter_mode = !filter_mode;
         }
 
-        button.x1 = top_x;
-        button.update_loc();
-        button.y1 = top_y + button.h + button.v_gap + 4;
-        // Select all infantry button
         button.font = fnt_40k_12;
-        draw_set_font(fnt_40k_12);
-        button.label = "All Infantry";
-        button.alpha = 1;
-        if (button.draw()) {
-            sel_all = "man";
-        }
-
-        inf_type_x = button.x1 + button.w + button.v_gap;
-        inf_type_y = button.y1;
-
-        // Select infantry type buttons
-        for (var i = 1; i <= 8; i++) {
-            if (sel_uni[i] != "") {
-                if (i == 1) {
-                    button.x1 = inf_type_x;
-                    button.y1 = inf_type_y;
-                } else if (i == 5) {
-                    button.x1 = inf_type_x;
-                    button.y1 = inf_type_y + button.h + button.v_gap;
-                } else {
-                    button.x1 += button.w + button.v_gap;
-                }
-                button.label = string_truncate(sel_uni[i], 126);
-                button.alpha = 1;
-                if (button.draw()) {
-                    sel_all = sel_uni[i];
-                }
-            }
-        }
+        _filter_next_y = draw_selection_filter_group(button, "All Infantry", "man", sel_uni, top_x, top_y + button.h + button.v_gap + 4, _filter_right);
     }
 
-    // Select all vehicles button
     if (sel_veh[1] != "") {
-        button.x1 = top_x;
-        button.y1 = inf_type_y + (button.h + button.v_gap) * 2 + 4;
-        button.label = "All Vehicles";
-        button.alpha = 1;
-        if (button.draw()) {
-            sel_all = "vehicle";
-        }
-
-        var veh_type_x = button.x1 + button.w + button.v_gap;
-        var veh_type_y = button.y1;
-
-        // Select vehicle type buttons
-        for (var i = 1; i <= 8; i++) {
-            if (sel_veh[i] != "") {
-                if (i == 1) {
-                    button.x1 = veh_type_x;
-                    button.y1 = veh_type_y;
-                } else if (i == 5) {
-                    button.x1 = veh_type_x;
-                    button.y1 = veh_type_y + button.h + button.v_gap;
-                } else {
-                    button.x1 += button.w + button.v_gap;
-                }
-                button.label = string_truncate(sel_veh[i], 126);
-                button.alpha = 1;
-                if (button.draw()) {
-                    sel_all = sel_veh[i];
-                }
-            }
-        }
+        button.font = fnt_40k_12;
+        draw_selection_filter_group(button, "All Vehicles", "vehicle", sel_veh, top_x, _filter_next_y + 4, _filter_right);
     }
 }

--- a/scripts/scr_ui_manage/scr_ui_manage.gml
+++ b/scripts/scr_ui_manage/scr_ui_manage.gml
@@ -1103,13 +1103,12 @@ function scr_ui_manage() {
             draw_sprite_stretched(spr_arrow, 2, xx + 974, yy + 141, 31, 30);
             draw_sprite_stretched(spr_arrow, 3, xx + 974, yy + 791, 31, 30);
 
-            yy += 8;
             var _draw_selec_buttons = !obj_controller.unit_profile && !stats_displayed;
             if (_draw_selec_buttons && instance_exists(obj_popup)) {
                 _draw_selec_buttons = obj_popup.type != ePOPUP_TYPE.EQUIP;
             }
             if (_draw_selec_buttons && is_struct(obj_controller.unit_focus)) {
-                draw_manage_selection_buttons(xx, yy);
+                draw_manage_selection_buttons();
             }
 
             draw_set_color(#3f7e5d);
@@ -1269,7 +1268,9 @@ function scr_ui_manage() {
 }
 
 /// @self Asset.GMObject.obj_controller
-function draw_manage_selection_buttons(xx, yy) {
+/// @desc Draws and handles the Manage-screen selection controls.
+/// @returns {Undefined}
+function draw_manage_selection_buttons() {
     var sel_loading = obj_controller.selecting_ship;
     var _unit_focus = obj_controller.unit_focus;
     var _non_control_loc = location_out_of_player_control(selecting_location);
@@ -1287,7 +1288,6 @@ function draw_manage_selection_buttons(xx, yy) {
     gen_tooltip(health_tooltip);
 
     // Draw interaction and selection buttons
-    yy -= 8;
     draw_set_font(fnt_40k_14b);
     draw_set_color(#50a076);
     var button = new UnitButtonObject();


### PR DESCRIPTION
This is excluding the last perf commit (which is new scope creep) just a bunch of scope creep vaguely ui related fixes, refactors, and doc changes from my gear quality branch that I said would be finished at the end of the week like three weeks ago. There was maybe just a tiny bit of scope creep that I am suffering for. Regardless all the commits here should be mostly or entirely independent of each other so I can separate out any if needed.

## Changes
- Clamp final tooltip positions in objects/obj_tooltip/Draw_75.gml, while leaving already-contained top- and left-edge tooltips attached to the cursor and avoiding repeated hot-path calculations.
- Remove the unused selection-button position interface from scripts/scr_ui_manage/scr_ui_manage.gml.
- Replace fixed management filter rows with a panel-bounded wrapping helper in scripts/scr_ui_manage/scr_ui_manage.gml.
- Use horizontal and vertical UnitButtonObject gaps according to their direction in scripts/scr_ui_manage/scr_ui_manage.gml.
- Set the Dreadnought equipment target to eROLE.DREADNOUGHT in scripts/scr_reequip_units/scr_reequip_units.gml so both equipment selectors load Dreadnought item lists.
- Measure and wrap equipment warnings within the popup slate in scripts/scr_reequip_units/scr_reequip_units.gml.
- Suppress the automatic obj_popup sprite in objects/obj_popup/Create_0.gml and remove the redundant local suppression from the popup drawing and equipment setup functions.
- Simplify the initial popup sprite assignment and remove duplicate Create-event defaults in objects/obj_popup/Create_0.gml.
- Remove the unused vehicle_equipment field and move_to_next_stage method from objects/obj_popup/Create_0.gml.
- Cache resolved CJK fonts in LocalizationManager.gml, avoiding repeated draw-time size/style lookups while safely handling locale changes and fallback-load failures.
## Testing
- I did basic testing for anything that was testable in game and verified the game save/load/booted correctly. There are no obvious issues I observed in testing at least.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes tooltip placement, selection filter layout, equipment selectors, popup rendering, and CJK font performance. Previously, tooltips and filter buttons could overflow panels, Dreadnought equipment lists were incomplete, popups could double‑draw their instance sprite, and CJK font resolution repeated work per frame; now tooltips clamp within the GUI, filters wrap inside the panel, Dreadnoughts load correct items, the popup sprite is suppressed at creation, and CJK fonts are cached per base font.

- Tooltips: old behavior flipped near edges but could still go off‑screen; new behavior flips and then clamps within GUI bounds, pinning oversized tooltips and keeping top/left‑edge tooltips cursor‑attached to avoid jitter.
- Manage screen: replaces fixed two‑row filters with a panel‑bounded wrapping helper and uses horizontal/vertical gaps by direction to prevent overflow.
- Equipment: sets Dreadnought target to eROLE.DREADNOUGHT so both selectors load Dreadnought items; measures and wraps warning text within the popup slate.
- Popup: hides the automatic instance sprite in Create, removes redundant draw‑time suppression and unused fields, and simplifies initial sprite selection.
- Localization: caches resolved CJK fonts per base font, resets on language change, and uses a sentinel for failed fallback loads to avoid repeated size/style lookups.

**Review and migration**
- draw_manage_selection_buttons no longer takes coordinates; call sites should drop arguments.
- LocalizationManager.get_font now takes only the base font; callers that bypass cjk_font must remove the size argument.

<sup>Written for commit 9e9a20c65dafffe7baf94a02294d46572ea65377. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

