### PR TITLE
fix: typo determining garrison leader

### DIFF
--- a/scripts/scr_garrison/scr_garrison.gml
+++ b/scripts/scr_garrison/scr_garrison.gml
@@ -143,7 +143,7 @@ function GarrisonForce(system, planet, type = "garrison") constructor {
             if (!is_struct(_leader)) {
                 continue;
             }
-            if (!is_Struct(garrison_leader)) {
+            if (!is_struct(garrison_leader)) {
                 garrison_leader = _leader;
                 for (var r = 0; r < array_length(hierarchy); r++) {
                     if (hierarchy[r] == _leader.role()) {


### PR DESCRIPTION
<!--- YOU CAN DELETE ALL OF THIS AFTER READING. -->

<!--- Make use of markdown lists. They make stuff much easier to read through. -->
<!--- Explain why and what your changes do in simple terms. --->
<!--- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. --->

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->

<!--- "Inspired" by the CDDA PR template -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a typo in `scr_garrison.gml` that prevented correct leader selection. Previously the code called `is_Struct(...)`, which could fail and leave `garrison_leader` unset; now it uses `is_struct(...)` so the first valid `_leader` is assigned and hierarchy evaluation proceeds.

- Review: Search for other `is_Struct` occurrences and replace with `is_struct` if found.
- Validate: Initialize a garrison and confirm `garrison_leader` is set and hierarchy scoring runs without errors.

<sup>Written for commit a192457f9883f6f9c2b85b00438d4bec3c36ace3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

