### PR TITLE
fix: crash training chaplains

### DIFF
--- a/scripts/scr_specialist_training/scr_specialist_training.gml
+++ b/scripts/scr_specialist_training/scr_specialist_training.gml
@@ -241,7 +241,6 @@ function chaplain_training() {
                     _unit.update_mobility_item("");
                     scr_alert("green", "recruitment", $"{_unit.name_role()} begins training.", 0, 0);
                     with (obj_ini) {
-                        scr_company_order(marine_company);
                         scr_company_order(0);
                     }
                 } else {


### PR DESCRIPTION
<!--- YOU CAN DELETE ALL OF THIS AFTER READING. -->

<!--- Make use of markdown lists. They make stuff much easier to read through. -->
<!--- Explain why and what your changes do in simple terms. --->
<!--- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. --->

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->

<!--- "Inspired" by the CDDA PR template -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a crash when starting chaplain training by removing the redundant `scr_company_order(marine_company)` call. Previously the code issued an order to `marine_company` and then to `0`; now it only issues `scr_company_order(0)`, keeping the final behavior the same and avoiding null/undefined access.

- Confirm `marine_company` can be unset in this context and that the single `scr_company_order(0)` matches the intended default.
- Test starting chaplain training to ensure the alert fires and training begins without a crash.
- No migrations or config changes required.

<sup>Written for commit 28bcdfa52601aa5240ed286a986a0007c40903e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

