### PR TITLE
fix: crusade wrong unit reference

### DIFF
--- a/scripts/scr_crusade/scr_crusade.gml
+++ b/scripts/scr_crusade/scr_crusade.gml
@@ -119,7 +119,7 @@ function scr_crusade() {
 
                     clean[co] = 1;
                     marines_lost++;
-                    unit.kill(false, true);
+                    _unit.kill(false, true);
                 } else {
                     if (_unit.IsSpecialist(SPECIALISTS_APOTHECARIES) && (_unit.gear() == "Narthecium")) {
                         apoth++;


### PR DESCRIPTION
<!--- YOU CAN DELETE ALL OF THIS AFTER READING. -->

<!--- Make use of markdown lists. They make stuff much easier to read through. -->
<!--- Explain why and what your changes do in simple terms. --->
<!--- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. --->

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->

<!--- "Inspired" by the CDDA PR template -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a wrong unit reference in `scr_crusade`: when a marine is marked lost, we now call `_unit.kill(false, true)` on the current unit. Previously, the code called `unit.kill(...)`, which could reference a different or undefined instance, leading to the wrong unit being removed or a runtime error; now it reliably removes only the intended unit with no other behavior changes.

<sup>Written for commit 2abba9c1b1a11fc29f6dec9a516d6eaccdbe93d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

