### PR TITLE
fix: Purge world name() method used in wrong scope

### DIFF
--- a/scripts/scr_purge_world/scr_purge_world.gml
+++ b/scripts/scr_purge_world/scr_purge_world.gml
@@ -163,11 +163,12 @@ function scr_purge_world(action_type, action_score) {
     var _no_chaos = (planet_forces[eFACTION.HERETICS] + planet_forces[eFACTION.CHAOS]) == 0;
     if ((action_type == eDROP_TYPE.PURGEFIRE || action_type == eDROP_TYPE.PURGESELECTIVE) && _no_chaos && obj_controller.turn >= obj_controller.chaos_turn) {
         if (has_feature(eP_FEATURES.WARLORD10) && obj_controller.known[10] == 0 && obj_controller.faction_gender[10] == 1) {
+            var _name = name();
             with (obj_drop_select) {
                 var pop = instance_create(0, 0, obj_popup);
                 pop.image = "chaos_symbol";
                 pop.title = "Concealed Heresy";
-                pop.text = $"Your astartes set out and begin to cleanse {name()} of possible heresy.  The general populace appears to be devout in their faith, but a disturbing trend appears- the odd citizen cursing your forces, frothing at the mouth, and screaming out heresy most foul.  One week into the cleansing a large hostile force is detected approaching and encircling your forces.";
+                pop.text = $"Your astartes set out and begin to cleanse {_name} of possible heresy.  The general populace appears to be devout in their faith, but a disturbing trend appears- the odd citizen cursing your forces, frothing at the mouth, and screaming out heresy most foul.  One week into the cleansing a large hostile force is detected approaching and encircling your forces.";
                 exit;
             }
         }


### PR DESCRIPTION
<!--- YOU CAN DELETE ALL OF THIS AFTER READING. -->

<!--- Make use of markdown lists. They make stuff much easier to read through. -->
<!--- Explain why and what your changes do in simple terms. --->
<!--- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. --->

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->

<!--- "Inspired" by the CDDA PR template -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes world name resolution in the “Concealed Heresy” popup during Purge World. Previously, `name()` was called inside a `with (obj_drop_select)` block, resolving in the wrong scope; now the code caches the world name before the `with` and interpolates it, ensuring correct text and avoiding scope errors.

**Review notes**
- Trigger the Concealed Heresy popup (Purgefire/Selective, no Chaos, after `chaos_turn`, with `eP_FEATURES.WARLORD10`, `known[10]==0`, `faction_gender[10]==1`) and verify the popup references the current world name.

<sup>Written for commit ce1b20c75f3abe2244098bd941e35b896fabf32d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

