### PR TITLE
fix: Check garrison has leader before referencing

### DIFF
--- a/objects/obj_star_select/Draw_64.gml
+++ b/objects/obj_star_select/Draw_64.gml
@@ -238,7 +238,9 @@ try {
             if (garrison.garrison_force) {
                 draw_set_font(cjk_font(fnt_40k_14));
 
-                garrison_data_slate.sub_title = localize("Garrison Leader {0}", [garrison.garrison_leader.name_role()]);
+                if (!is_undefined(garrison.garrison_leader)){
+                    garrison_data_slate.sub_title = localize("Garrison Leader {0}", [garrison.garrison_leader.name_role()]);
+                }
                 garrison_data_slate.body_text = garrison.garrison_report();
 
                 garrison_data_slate.inside_method = function() {

--- a/objects/obj_star_select/Draw_64.gml
+++ b/objects/obj_star_select/Draw_64.gml
@@ -240,6 +240,10 @@ try {
 
                 if (!is_undefined(garrison.garrison_leader)){
                     garrison_data_slate.sub_title = localize("Garrison Leader {0}", [garrison.garrison_leader.name_role()]);
+                } else {
+                    garrison_data_slate.sub_title = "";
+                }
+                    garrison_data_slate.sub_title = localize("Garrison Leader {0}", [garrison.garrison_leader.name_role()]);
                 }
                 garrison_data_slate.body_text = garrison.garrison_report();
 

--- a/scripts/scr_garrison/scr_garrison.gml
+++ b/scripts/scr_garrison/scr_garrison.gml
@@ -31,7 +31,7 @@ function disposition_description_chart(dispo) {
 function GarrisonForce(system, planet, type = "garrison") constructor {
     garrison_squads = [];
     total_garrison = 0;
-    garrison_leader = false;
+    garrison_leader = undefined;
     garrison_force = false;
     members = [];
     time_on_planet = 0;


### PR DESCRIPTION
<!--- YOU CAN DELETE ALL OF THIS AFTER READING. -->

<!--- Make use of markdown lists. They make stuff much easier to read through. -->
<!--- Explain why and what your changes do in simple terms. --->
<!--- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. --->

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->

<!--- "Inspired" by the CDDA PR template -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents crashes when drawing garrison details by only referencing a garrison leader when present. Previously the draw code always called name_role(); now it sets the subtitle to empty when no leader exists.

- Initialize garrison_leader to undefined in GarrisonForce.
- Guard the subtitle assignment in Draw_64 with !is_undefined(...); fallback to "".
- Review: Draw_64 currently also assigns sub_title unconditionally after the guard, which still references garrison_leader; confirm and remove if unintended.

<sup>Written for commit b31ddc68aa601a8c97039d508676a12198c9d11b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

