### PR TITLE
fix: weapon one using getter not setter

### DIFF
--- a/scripts/scr_after_combat/scr_after_combat.gml
+++ b/scripts/scr_after_combat/scr_after_combat.gml
@@ -388,7 +388,7 @@ function after_combat_dead_marine_equipment_recovered(unit) {
             case "armour":
                 unit.update_armour("", false, _recover);
             case "wep1":
-                unit.weapon_one("", false, _recover);
+                unit.update_weapon_one("", false, _recover);
             case "wep2":
                 unit.update_weapon_two("", false, _recover);
             case "gear":


### PR DESCRIPTION
<!--- YOU CAN DELETE ALL OF THIS AFTER READING. -->

<!--- Make use of markdown lists. They make stuff much easier to read through. -->
<!--- Explain why and what your changes do in simple terms. --->
<!--- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. --->

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->

<!--- "Inspired" by the CDDA PR template -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes weapon slot 1 recovery after combat by calling the setter instead of the getter. Previously the `wep1` path called `unit.weapon_one(...)` (getter/no-op), so the recovered weapon was not applied and could cause invalid references; it now uses `unit.update_weapon_one(...)`.

- Aligns with `update_weapon_two` used for `wep2`.
- No changes to other equipment paths; no migrations required.

<sup>Written for commit afcb153db6cab7b5e2badfbefdefee5be3635570. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

