### PR TITLE
fix: fetch unit before reference

### DIFF
--- a/objects/obj_controller/Mouse_50.gml
+++ b/objects/obj_controller/Mouse_50.gml
@@ -32,6 +32,7 @@ if ((menu == eMENU.RECLUSIAM) && (cooldown <= 0) && (penitorium > 0)) {
             if ((mouse_x >= xx + 1508) && (mouse_x < xx + 1567)) {
                 cooldown = 20;
                 var c = penit_co[qp], e = penit_id[qp];
+                var _unit = fetch_unit([c, e]);
                 _unit.god_status -= 10;
                 re = 1;
             }


### PR DESCRIPTION
<!--- YOU CAN DELETE ALL OF THIS AFTER READING. -->

<!--- Make use of markdown lists. They make stuff much easier to read through. -->
<!--- Explain why and what your changes do in simple terms. --->
<!--- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. --->

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->

<!--- "Inspired" by the CDDA PR template -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures the unit is fetched before updating its god_status in the Reclusiam click handler, preventing undefined variable access. Previously, `_unit.god_status` could be modified without resolving `_unit`; now we call `fetch_unit([c, e])` and then apply the change.

- Verify `fetch_unit([c, e])` returns the intended unit and that the tuple order `[cohort, id]` is correct.
- Confirm no regressions in Reclusiam clicks: cooldown still applies and `re` is set as before.

<sup>Written for commit 4e11bd14a2736acc05043cb0b293edbff4341c82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

