### PR TITLE
fix: obj_star_select typo

### DIFF
--- a/objects/obj_star_select/Draw_64.gml
+++ b/objects/obj_star_select/Draw_64.gml
@@ -243,8 +243,7 @@ try {
                 } else {
                     garrison_data_slate.sub_title = "";
                 }
-                    garrison_data_slate.sub_title = localize("Garrison Leader {0}", [garrison.garrison_leader.name_role()]);
-                }
+
                 garrison_data_slate.body_text = garrison.garrison_report();
 
                 garrison_data_slate.inside_method = function() {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a stray unconditional assignment in `objects/obj_star_select/Draw_64.gml` that overwrote `garrison_data_slate.sub_title`. Previously the subtitle always showed the garrison leader; now it respects the existing condition (leader when applicable, else empty).

- Review: In the star selection UI, verify the subtitle shows the leader only when expected and is empty otherwise. No migrations or config changes.

<sup>Written for commit 37f49752fea6605bed6a0f795d2d86fc6fe9d971. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

