### PR TITLE
docs: Add some JSDocs

### DIFF
--- a/objects/obj_star_select/Create_0.gml
+++ b/objects/obj_star_select/Create_0.gml
@@ -1,4 +1,5 @@
 owner = 0;
+/// @type {Id.Instance.obj_star}
 target = instance_nearest(x, y, obj_star);
 loading = 0;
 loading_name = "";
@@ -57,6 +58,7 @@ torpedo = scr_item_count("Cyclonic Torpedo");
 
 /// @type {Struct.FeatureSelected}
 feature = "";
+/// @type {String|Struct.GarrisonForce}
 garrison = "";
 population = false;
 

--- a/objects/obj_star_select/Draw_64.gml
+++ b/objects/obj_star_select/Draw_64.gml
@@ -294,6 +294,7 @@ try {
         }
         if (current_button != "") {
             if (array_contains(["Build", "Base", "Arsenal", "Gene-Vault"], current_button)) {
+                /// @type {Id.Instance.obj_temp_build}
                 var building = instance_create(x, y, obj_temp_build);
                 building.target = target;
                 building.planet = obj_controller.selecting_planet;

--- a/scripts/scr_garrison/scr_garrison.gml
+++ b/scripts/scr_garrison/scr_garrison.gml
@@ -31,6 +31,7 @@ function disposition_description_chart(dispo) {
 function GarrisonForce(system, planet, type = "garrison") constructor {
     garrison_squads = [];
     total_garrison = 0;
+    /// @type {Undefined|Struct.TTRPG_stats}
     garrison_leader = undefined;
     garrison_force = false;
     members = [];


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds JSDoc type annotations to star selection and garrison code to improve editor hints and prevent type mistakes. No runtime or gameplay behavior changes.

- obj_star_select/Create_0.gml: annotate target as Id.Instance.obj_star; annotate garrison as String|Struct.GarrisonForce.
- obj_star_select/Draw_64.gml: annotate local building as Id.Instance.obj_temp_build in the build flow.
- scr_garrison.gml: annotate garrison_leader as Undefined|Struct.TTRPG_stats.
- No migrations or config changes; verify annotated types match actual instances and assignments.

<sup>Written for commit 8c2ef2535386f28b844cb383ef41941e2bc0130d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

