### PR TITLE
ci: Issue triage workflow

### DIFF
--- a/.github/workflows/opencode_issue_triage.yml
+++ b/.github/workflows/opencode_issue_triage.yml
@@ -26,15 +26,15 @@ jobs:
               "bash": {
                 "*": "deny",
                 "gh issue*": "allow",
-                "gh api *": "allow"
+                "gh api *": "allow",
+                "gh api *DELETE*": "deny"
               },
               "write": "deny",
               "edit": "deny",
               "webfetch": "deny"
             }
-        run: >-
-          opencode run -m muse-spark-1.2-contributor-free
-          "Issue #${{ github.event.issue.number }} opened.
+        run: |
+          opencode run -m muse-spark-1.2-contributor-free "Issue #${{ github.event.issue.number }} opened.
           Use \`gh issue view\` and \`gh issue list\` to search through existing issues to find potential duplicates.
           Consider:
           1. Similar titles or descriptions
@@ -55,18 +55,18 @@ jobs:
               "bash": {
                 "*": "deny",
                 "gh issue*": "allow",
-                "gh api *": "allow"
+                "gh api *": "allow",
+                "gh api *DELETE*": "deny"
               },
               "write": "deny",
               "edit": "deny"
             }
-        run: >-
+        run: |
           if gh issue view ${{ github.event.issue.number }} --json labels --jq '.labels[].name' | grep -q "Status: Duplicate"; then
             echo "Skipping investigation - duplicate"
             exit 0
           fi
 
-          opencode run -m muse-spark-1.2-contributor-free --agent explore
-          "Investigate issue #${{ github.event.issue.number }}.
+          opencode run -m muse-spark-1.2-contributor-free --agent explore "Investigate issue #${{ github.event.issue.number }}.
           Read relevant GML files, pinpoint likely source, then propose 1-3 fixes.
           Post as a reply comment."

--- a/.github/workflows/opencode_issue_triage.yml
+++ b/.github/workflows/opencode_issue_triage.yml
@@ -1,0 +1,72 @@
+name: opencode-issue-triage
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - run: curl -fsSL https://opencode.ai/install | bash
+
+      - name: Triage
+        env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPENCODE_PERMISSION: |
+            {
+              "bash": {
+                "*": "deny",
+                "gh issue*": "allow",
+                "gh api *": "allow"
+              },
+              "write": "deny",
+              "edit": "deny",
+              "webfetch": "deny"
+            }
+        run: >-
+          opencode run -m muse-spark-1.2-contributor-free
+          "Issue #${{ github.event.issue.number }} opened.
+          Use \`gh issue view\` and \`gh issue list\` to search through existing issues to find potential duplicates.
+          Consider:
+          1. Similar titles or descriptions
+          2. Same error messages or symptoms
+          If duplicates were found, use \`gh issue edit\` to add \`Status: Duplicate\` label, and post a comment with potential duplicates with links, in this format:
+          \`\`\`
+          This issue might be a duplicate of existing issues. Please check:
+          - #[issue_number]: [brief description of similarity]
+          \`\`\`
+          If no duplicates found, use \`gh issue edit\` to label \`Priority: X\` based on: crash/hardlock=\`Critical\`, error blocking gameplay=\`High\`, feature broken with workaround=\`Medium\`, visual/text=\`Low\`."
+
+      - name: Investigation
+        env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPENCODE_PERMISSION: |
+            {
+              "bash": {
+                "*": "deny",
+                "gh issue*": "allow",
+                "gh api *": "allow"
+              },
+              "write": "deny",
+              "edit": "deny"
+            }
+        run: >-
+          if gh issue view ${{ github.event.issue.number }} --json labels --jq '.labels[].name' | grep -q "Status: Duplicate"; then
+            echo "Skipping investigation - duplicate"
+            exit 0
+          fi
+
+          opencode run -m muse-spark-1.2-contributor-free --agent explore
+          "Investigate issue #${{ github.event.issue.number }}.
+          Read relevant GML files, pinpoint likely source, then propose 1-3 fixes.
+          Post as a reply comment."


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Automates triage for newly opened issues to standardize labeling and first-pass investigation. Previously manual; now the workflow detects duplicates, sets priority, and for non-duplicates posts an investigation comment with likely causes and fixes.

- Adds `.github/workflows/opencode_issue_triage.yml` triggered on `issues: opened`; uses `actions/checkout@v6`, installs `opencode`, and runs `opencode run -m muse-spark-1.2-contributor-free`.
- Duplicate path: applies `Status: Duplicate` and comments with links; otherwise sets one `Priority: Critical|High|Medium|Low` per rubric.
- Non-duplicate path: runs an Investigation step with `--agent explore` to examine repo files and comment 1–3 proposed fixes; skipped when duplicate.
- Permissions: job permissions `contents: read`, `issues: write`; `OPENCODE_PERMISSION` allows only `gh issue*` and `gh api *`, denies `write`/`edit`, blocks `gh api *DELETE*`; `webfetch` disabled in triage.
- Required: add `OPENCODE_API_KEY` repo secret; ensure labels `Status: Duplicate` and `Priority: Critical|High|Medium|Low` exist. Effective for new issues after merge to the default branch.

<sup>Written for commit f3eb3e6c04dbe2207834da6687033175f201f5be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

