### PR TITLE
ci: OpenCode workflow fixes

### DIFF
--- a/.github/workflows/opencode_issue_triage.yml
+++ b/.github/workflows/opencode_issue_triage.yml
@@ -34,7 +34,7 @@ jobs:
               "webfetch": "deny"
             }
         run: |
-          opencode run -m muse-spark-1.2-contributor-free "Issue #${{ github.event.issue.number }} opened.
+          opencode run -m opencode/muse-spark-1.2-contributor-free "Issue #${{ github.event.issue.number }} opened.
           Use \`gh issue view\` and \`gh issue list\` to search through existing issues to find potential duplicates.
           Consider:
           1. Similar titles or descriptions
@@ -67,6 +67,6 @@ jobs:
             exit 0
           fi
 
-          opencode run -m muse-spark-1.2-contributor-free --agent explore "Investigate issue #${{ github.event.issue.number }}.
+          opencode run -m opencode/muse-spark-1.2-contributor-free --agent explore "Investigate issue #${{ github.event.issue.number }}.
           Read relevant GML files, pinpoint likely source, then propose 1-3 fixes.
           Post as a reply comment."

--- a/.github/workflows/opencode_review.yml
+++ b/.github/workflows/opencode_review.yml
@@ -90,4 +90,4 @@ jobs:
 
           Only create comments for actual violations. If the code follows all guidelines, comment using gh cli that it looks good and nothing else.
           PROMPT_EOF
-          cat /tmp/prompt.txt | opencode run -m muse-spark-1.2-contributor-free --variant xhigh --agent pr_review
+          cat /tmp/prompt.txt | opencode run -m opencode/muse-spark-1.2-contributor-free --variant xhigh --agent pr_review


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Uses the fully qualified OpenCode model in both triage and PR review workflows so runs resolve reliably. Previously used `muse-spark-1.2-contributor-free`; now uses `opencode/muse-spark-1.2-contributor-free` in all steps.

- Changes are limited to `.github/workflows/opencode_issue_triage.yml` and `.github/workflows/opencode_review.yml`.
- Verify by: opening a test issue and confirming logs show `opencode/muse-spark-1.2-contributor-free`, and triggering the review workflow on a PR to see the same.
- No secrets, permissions, or migration changes.

<sup>Written for commit 8170aa5b94345aaf3fa5efedc75bcaa9cf9db7fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

