### PR TITLE
ci: Create issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,50 @@
+name: Bug report
+description: Report an issue that should be fixed
+body:
+  - type: input
+    id: game-version
+    attributes:
+      label: Game version
+      description: What version of ChapterMaster are you using?
+      placeholder: e.g., main-2026-08-19-1803, v0.11.1
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating System
+      description: What OS are you using?
+      placeholder: e.g., macOS 26.0.1, Ubuntu 22.04, Windows 11
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe the bug you encountered
+      placeholder: What happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce this issue?
+      placeholder: |
+        1.
+        2.
+        3.
+    validations:
+      required: false
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: Attach a screenshots, if needed
+      placeholder: Drop screenshots here
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,4 +1,5 @@
-name: Bug report
+name: 🐞 Bug report
+type: Bug
 description: Report an issue that should be fixed
 body:
   - type: input

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,4 +1,4 @@
-name: 🐞 Bug report
+name: 🐞 Bug Report
 type: Bug
 description: Report an issue that should be fixed
 body:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Discord Community
+    url: https://discord.gg/zAGpqHzsXQ
+    about: For support, troubleshooting, questions, and discussion.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,19 @@
+name: 🚀 Feature Request
+description: Suggest an idea, feature, or enhancement
+type: Feature
+
+body:
+  - type: checkboxes
+    id: verified
+    attributes:
+      label: Feature hasn't been suggested before.
+      options:
+        - label: I have searched and verified this feature I'm about to request hasn't been suggested before.
+          required: true
+
+  - type: textarea
+    attributes:
+      label: Describe the enhancement you want to request
+      description: What do you want to change or add? What are the benefits of implementing this? Try to be detailed so we can understand your request better.
+    validations:
+      required: true


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds structured GitHub issue templates for bugs and features, disables blank issues, and routes questions to Discord to keep reports actionable. Previously anyone could open a blank issue; now users must choose a template. No build or runtime impact.

- Bug report requires game version, operating system, and description; steps to reproduce and screenshots are optional.
- Feature request requires confirming it isn’t a duplicate and a detailed description.
- Templates include GitHub type metadata (`Bug`, `Feature`) for categorization.
- Disables “Open a blank issue” and adds a “💬 Discord Community” contact link: https://discord.gg/zAGpqHzsXQ.

<sup>Written for commit a67a09bdb884825e60d2aa8d884e0a3318304844. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

