### PR TITLE
fix: Apothecary premature training disable, negative eta

### DIFF
--- a/scripts/scr_specialist_training/scr_specialist_training.gml
+++ b/scripts/scr_specialist_training/scr_specialist_training.gml
@@ -167,6 +167,8 @@ function apothecary_training() {
         } else if ((apothecary_recruit_points >= 4) && (recruit_count == 0)) {
             var random_marine = spec_data_set(eROLE_TAG.Apothecary);
             if (random_marine == "none") {
+                training_apothecary = 0;
+                scr_alert("red", "recruitment", $"No marines available for {obj_ini.player_role_data[eROLE.APOTHECARY].role} training", 0, 0);
                 return;
             }
             var _unit = fetch_unit(random_marine);
@@ -177,9 +179,6 @@ function apothecary_training() {
             _unit.update_gear("");
             _unit.update_mobility_item("");
             scr_alert("green", "recruitment", _unit.name_role() + " begins training.", 0, 0);
-        } else {
-            training_apothecary = 0;
-            scr_alert("red", "recruitment", $"No marines available for {obj_ini.player_role_data[eROLE.APOTHECARY].role} training", 0, 0);
         }
     }
 }

--- a/scripts/scr_specialist_training/scr_specialist_training.gml
+++ b/scripts/scr_specialist_training/scr_specialist_training.gml
@@ -130,19 +130,14 @@ function apothecary_training() {
 
     var novice_type = string("{0} Aspirant", _apoth_role.role);
     if (training_apothecary > 0) {
-        recruit_count = scr_role_count(novice_type, "");
+        /// @type {Array<Struct.TTRPG_stats>}
+        var _aspirants = scr_role_count(novice_type, "", "units");
+        recruit_count = array_length(_aspirants);
 
         if (apothecary_recruit_points >= 48) {
             if (recruit_count > 0) {
-                var random_marine = scr_random_marine(novice_type, 0);
-                if (random_marine == "none") {
-                    return;
-                }
                 /// @type {Struct.TTRPG_stats}
-                var _unit = fetch_unit(random_marine);
-                if (!is_struct(_unit)) {
-                    return;
-                }
+                var _unit = _aspirants[irandom(recruit_count - 1)];
 
                 apothecary_recruit_points -= 48;
                 scr_alert("green", "recruitment", _unit.name_role() + " has finished training.", 0, 0);

--- a/scripts/scr_specialist_training/scr_specialist_training.gml
+++ b/scripts/scr_specialist_training/scr_specialist_training.gml
@@ -119,6 +119,8 @@ function spec_data_set(specialist) {
 }
 
 /// @self Asset.GMObject.obj_controller
+/// @desc Runs one turn of apothecary training: accrues recruitment points, then graduates a waiting aspirant or recruits a new one.
+/// @returns {Undefined}
 function apothecary_training() {
     // ** Training **
     // * Apothecary *


### PR DESCRIPTION
Closes #1465

Apothecary training could disable itself while an aspirant was still training, and aspirants outside company 0 could fail to graduate. This allowed recruitment points to continue accumulating and caused the displayed graduation time to become negative.

## Changes

- Only disable apothecary training when no eligible marine can be found.
- Select the graduating aspirant from the same chapter-wide search used to count them.
- Document the apothecary training turn handler.

## Testing

- Reproduced the reported training and graduation issues in-game before applying the fixes.
- Repeated the same scenarios afterward and could no longer reproduce either issue. No obvious new problems were observed during testing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes apothecary training so it only disables when no eligible marine exists and graduates are chosen from the chapter-wide candidate set; prevents negative graduation time and runaway recruitment points. Previously, training could disable while an aspirant was still training, and graduation searched only company 0; now the graduate is selected from the same chapter-wide results used to count aspirants. Addresses #1465.

- Graduation: use the chapter-wide `scr_role_count(..., "units")` results both to count and select the aspirant, removing count/selection mismatch.
- Disable: move disable-and-alert into the “no eligible marine” branch, stopping silent point accrual when no candidates exist.
- Docs: add a function comment describing the apothecary training turn handler.

<sup>Written for commit 13bec771bab38460884c51f0b872a49fa0dfc205. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

