### PR TITLE
fix: radical Inquisitor mission acceptance and resolution

### DIFF
--- a/scripts/scr_inquisition_fleet_functions/scr_inquisition_fleet_functions.gml
+++ b/scripts/scr_inquisition_fleet_functions/scr_inquisition_fleet_functions.gml
@@ -35,6 +35,7 @@ function radical_inquisitor_mission_ship_arrival() {
         alter_disposition(eFACTION.INQUISITION, -15);
         scr_popup("Inquisitor Mission Failed", "The radical Inquisitor has departed from the planned intercept coordinates.  They will now be nearly impossible to track- the mission is a failure.", "inquisition", "");
         scr_event_log("red", "Inquisition Mission Failed: The radical Inquisitor has departed from the planned intercept coordinates.");
+        resolve_radical_inquisitor_mission(_radical_inquisitor);
     } else {
         action = "";
         var _gender = string_gender_third_person(_radical_inquisitor.inquisitor_gender);

--- a/scripts/scr_inquisition_fleet_functions/scr_inquisition_fleet_functions.gml
+++ b/scripts/scr_inquisition_fleet_functions/scr_inquisition_fleet_functions.gml
@@ -21,7 +21,7 @@ function radical_inquisitor_mission_ship_arrival() {
     //TODO make a centralised player_fleet present method
     var _p_fleet = instance_nearest(x, y, obj_p_fleet);
     var _intercept_fleet = noone;
-    if (point_distance(x, y, _p_fleet.x, _p_fleet.y) < 10 && instance_exists(_p_fleet.orbiting)) {
+    if (instance_exists(_p_fleet) && point_distance(x, y, _p_fleet.x, _p_fleet.y) < 10 && instance_exists(_p_fleet.orbiting)) {
         _intercept_fleet = _p_fleet;
     }
 

--- a/scripts/scr_inquisition_fleet_functions/scr_inquisition_fleet_functions.gml
+++ b/scripts/scr_inquisition_fleet_functions/scr_inquisition_fleet_functions.gml
@@ -20,7 +20,7 @@ function hunt_player_serfs(planet, system) {
 function radical_inquisitor_mission_ship_arrival() {
     //TODO make a centralised player_fleet present method
     var _p_fleet = instance_nearest(x, y, obj_p_fleet);
-    var _intercept_fleet = -1;
+    var _intercept_fleet = noone;
     if (point_distance(x, y, _p_fleet.x, _p_fleet.y) < 10 && instance_exists(_p_fleet.orbiting)) {
         _intercept_fleet = _p_fleet;
     }

--- a/scripts/scr_inquisition_mission/scr_inquisition_mission.gml
+++ b/scripts/scr_inquisition_mission/scr_inquisition_mission.gml
@@ -299,8 +299,11 @@ function mission_inquistion_hunt_inquisitor(star_id = noone) {
     ];
 
     var _mission_data = {
+        mission_id: scr_uuid_generate(),
         inquisitor_name: _name,
         inquisitor_gender: _gender,
+        system: _star.name,
+        planet: planet,
     };
     var _pop_data = {
         system: _star.name,
@@ -356,6 +359,56 @@ function init_mission_hunt_inquisitor() {
     reset_popup_options();
 }
 
+/// @desc Clears only the resolved radical inquisitor mission's log entry.
+/// @param {Struct} _mission_data Mission data carrying its ID and target location.
+/// @returns {Bool} Whether the matching mission log entry was cleared.
+function resolve_radical_inquisitor_mission(_mission_data) {
+    if (!is_struct(_mission_data) || !struct_exists(_mission_data, "mission_id") || !struct_exists(_mission_data, "system") || !struct_exists(_mission_data, "planet")) {
+        LOGGER.error("Radical inquisitor mission data is missing its ID or target location");
+        return false;
+    }
+
+    var _mission_star = find_star_by_name(_mission_data.system);
+    if (_mission_star == noone) {
+        LOGGER.error($"Radical inquisitor mission target system {_mission_data.system} could not be found");
+        return false;
+    }
+
+    var _planet = _mission_data.planet;
+    var _mission_id = _mission_data.mission_id;
+    var _mission_removed = false;
+
+    with (_mission_star) {
+        var _problem_count = array_length(p_problem[_planet]);
+        for (var i = 0; i < _problem_count; i++) {
+            if (p_problem[_planet][i] != "inquisitor") {
+                continue;
+            }
+
+            var _stored_data = p_problem_other_data[_planet][i];
+            if (!is_struct(_stored_data) || !struct_exists(_stored_data, "mission_id")) {
+                continue;
+            }
+
+            if (_stored_data.mission_id != _mission_id) {
+                continue;
+            }
+
+            p_problem[_planet][i] = "";
+            p_timer[_planet][i] = -1;
+            p_problem_other_data[_planet][i] = {};
+            _mission_removed = true;
+            break;
+        }
+    }
+
+    if (!_mission_removed) {
+        LOGGER.error($"No radical inquisitor mission entry matches mission ID {_mission_id}");
+    }
+
+    return _mission_removed;
+}
+
 /// @self Asset.GMObject.obj_popup
 function mission_hunt_inquisitor_hear_out_radical_inquisitor() {
     var _offer = choose(1, 1, 2, 2, 3);
@@ -402,6 +455,7 @@ function mission_hunt_inquisitor_hear_out_radical_inquisitor() {
         text = $"{global.chapter_name} allow communications.  As soon as the vox turns on {global.chapter_name} hear a sickly, hateful voice.  They begin to speak of the inevitable death of your marines, the fall of all that is and ever shall be, and " + string(gender_pronoun) + " Lord of Decay.  Their ship is fired upon and destroyed without hesitation.";
         reset_popup_options();
         scr_event_log("", "Inquisition Mission Completed: The radical Inquisitor has been purged.");
+        resolve_radical_inquisitor_mission(pop_data);
         exit;
     }
     exit;
@@ -425,6 +479,7 @@ function mission_hunt_inquisitor_take_artifact_bribe() {
     image = "artifact_recovered";
     scr_event_log("", "Artifact Recovered from radical Inquisitor.");
     scr_event_log("", "Inquisition Mission Completed: The radical Inquisitor has been purged.");
+    resolve_radical_inquisitor_mission(pop_data);
 
     add_event({e_id: "inquisitor_spared", duration: irandom_range(6, 18) + 1, variation: 1});
 }
@@ -444,6 +499,7 @@ function mission_hunt_inquisitor_take_artifact_double_cross() {
     image = "exploding_ship";
     scr_event_log("", "Artifact recovered from radical Inquisitor.");
     scr_event_log("", "Inquisition Mission Completed: The radical Inquisitor has been purged.");
+    resolve_radical_inquisitor_mission(pop_data);
 }
 
 /// @self Asset.GMObject.obj_popup
@@ -461,6 +517,7 @@ function mission_hunt_inquisitor_show_mercy() {
     reset_popup_options();
 
     scr_event_log("", "Inquisition Mission Completed?: The radical Inquisitor has been allowed to flee in order to weaken the forces of Chaos, as they promised.");
+    resolve_radical_inquisitor_mission(pop_data);
 
     add_event({e_id: "inquisitor_spared", duration: irandom_range(6, 18) + 1, variation: 2});
 }
@@ -488,6 +545,7 @@ function mission_hunt_inquisitor_destroy_inquisitor_ship() {
     reset_popup_options();
 
     scr_event_log("", "Inquisition Mission Completed: The radical Inquisitor has been purged.");
+    resolve_radical_inquisitor_mission(pop_data);
     with (pop_data.inquisitor_ship) {
         instance_destroy();
     }

--- a/scripts/scr_inquisition_mission/scr_inquisition_mission.gml
+++ b/scripts/scr_inquisition_mission/scr_inquisition_mission.gml
@@ -321,7 +321,6 @@ function mission_inquistion_hunt_inquisitor(star_id = noone) {
 function add_new_inquis_mission() {
     if (add_new_problem(pop_data.planet, pop_data.mission, pop_data.estimate, mission_star)) {
         new_star_event_marker("green");
-        mission_is_go = true;
     }
 }
 
@@ -351,7 +350,6 @@ function init_mission_hunt_inquisitor() {
 
     if (add_new_problem(pop_data.planet, pop_data.mission, pop_data.estimate, mission_star, pop_data.mission_data)) {
         new_star_event_marker("green");
-        mission_is_go = true;
     }
 
     title = "Inquisition Mission Accepted";

--- a/scripts/scr_inquisition_mission/scr_inquisition_mission.gml
+++ b/scripts/scr_inquisition_mission/scr_inquisition_mission.gml
@@ -350,6 +350,10 @@ function init_mission_hunt_inquisitor() {
         new_star_event_marker("green");
         mission_is_go = true;
     }
+
+    title = "Inquisition Mission Accepted";
+    text = $"{global.chapter_name} will intercept the radical Inquisitor {pop_data.mission_data.inquisitor_name} at {mission_star.name}, expected within {pop_data.estimate} months.";
+    reset_popup_options();
 }
 
 /// @self Asset.GMObject.obj_popup


### PR DESCRIPTION
The radical Inquisitor mission could be accepted repeatedly, treated as intercepted when the player was elsewhere, and remain active after reaching a completion outcome. These fixes address all three reported problems.

## Changes

- Close the mission acceptance flow after accepting, preventing repeated clicks from spawning duplicate Inquisitor fleets and mission entries.
- Correct the missing-intercept check so the mission fails when no player fleet is present at the destination.
- Assign each radical Inquisitor mission a unique ID and use it to clear only the corresponding mission entry after every success or failure outcome.
- Remove unused `mission_is_go` assignments from the affected mission setup functions.

## Testing

- Reproduced the reported bugs using debug mode before applying the fixes.
- Repeated the same mission flows after applying the fixes and could no longer reproduce any of the reported behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the radical Inquisitor mission so it accepts only once, fails when no fleet intercepts, and clears its mission entry after every completion outcome.

- Changed the no-intercept sentinel from `-1` to `noone` and added an `instance_exists` guard so the failure path runs safely when no player fleet is present.
- Each mission now gets a unique ID, and `resolve_radical_inquisitor_mission` clears only the matching entry on every success or failure path, preserving concurrent missions.
- Accepting now closes the flow with a confirmation popup, so repeated clicks can't spawn duplicate Inquisitor fleets or mission entries.
- Removed unreachable `mission_is_go` writes.

<sup>Written for commit ba98c325dfb1a2cb8748fc0fa77878f39372669e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

