### PR TITLE
fix: Apply the custom Chapter Master role livery

### DIFF
--- a/objects/obj_creation/Draw_0.gml
+++ b/objects/obj_creation/Draw_0.gml
@@ -824,6 +824,9 @@ try {
                     highlighting = 0;
                     old_highlight = 0;
                 }
+                if (goto_slide == eCREATION_SLIDES.CHAPTERLIVERY) {
+                    update_creation_roles_radio();
+                }
             }
         }
     }

--- a/scripts/scr_complex_colour_kit/scr_complex_colour_kit.gml
+++ b/scripts/scr_complex_colour_kit/scr_complex_colour_kit.gml
@@ -40,6 +40,10 @@ function get_marine_icon_set(key) {
     return variable_clone(sprite_set);
 }
 
+/// @desc Sets the full livery shader uniforms for one role, optionally layering a unit's company and personal livery over them.
+/// @param {String} setup_role Role name of the marine being drawn.
+/// @param {Struct.TTRPG_stats|Struct.DummyMarine|String} [unit] Unit whose company and personal livery override the role livery, or "none".
+/// @returns {Struct} Texture draw requests keyed by texture or icon name.
 function setup_complex_livery_shader(setup_role, unit = "none") {
     shader_reset();
     shader_set(full_livery_shader);
@@ -75,6 +79,8 @@ function setup_complex_livery_shader(setup_role, unit = "none") {
                 data_set = _full_liveries[eROLE.TECHMARINE];
             } else if (is_specialist(setup_role, SPECIALISTS_CHAPLAINS)) {
                 data_set = _full_liveries[eROLE.CHAPLAIN];
+            } else if (setup_role == _roles[eROLE.CHAPTERMASTER]) {
+                data_set = _full_liveries[eROLE.CHAPTERMASTER];
             }
         } else {
             for (var i = 0; i < array_length(_roles) && i < array_length(_full_liveries); i++) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes two chapter creation bugs around the Chapter Master role: the custom role livery is now applied instead of falling back to the default chapter livery, and navigating back to the livery slide restores the Chapter Master option in the role radio.

<sup>Written for commit b01b1045a1f9f59d5121fb0f6b92af763c24cd2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

