### PR TITLE
fix: Assign owners to added home system planets

### DIFF
--- a/scripts/scr_system_spawn_functions/scr_system_spawn_functions.gml
+++ b/scripts/scr_system_spawn_functions/scr_system_spawn_functions.gml
@@ -154,13 +154,24 @@ function set_player_recruit_planet(recruit_planet) {
     }
 }
 
-/// @param {Id.Instance.obj_star} chosen_star
+/// @desc Turns the chosen star into the player's home system, expanding it to the requested
+/// planet count and placing the monastery and recruiting worlds.
+/// @param {Id.Instance.obj_star} chosen_star Star to convert into the home system.
+/// @returns {Undefined}
 function set_player_homeworld_star(chosen_star) {
     with (chosen_star) {
         if (obj_ini.recruit_relative_loc == 1 && obj_ini.home_planet_count == 0) {
             obj_ini.home_planet_count++;
         }
         planets = obj_ini.home_planet_count + 1;
+
+        for (var _slot = 1; _slot <= planets; _slot++) {
+            if (p_owner[_slot] == eFACTION.NONE) {
+                p_owner[_slot] = eFACTION.IMPERIUM;
+                p_first[_slot] = eFACTION.IMPERIUM;
+            }
+        }
+
         var _home_planet = irandom_range(1, planets);
 
         player_home_planet(_home_planet);


### PR DESCRIPTION
Just to note, any save that has this bug will still have a broken planet as this fix does not retroactively fix the malformed generation when a save with it is deserialized. It's not impossible to make a migration shim to fix saves with the bug but this doesn't add one. I can add one though just let me know.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes home system expansion creating ownerless planets by assigning newly added planets to the Imperium faction, so they can be garrisoned and receive a starting governor disposition. Saves that already have the bug are not retroactively fixed by this change.

<sup>Written for commit ba45bdfc1427a7060c69fcda77ed58964f4db752. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

