### PR TITLE
fix: collect_planet_group loc array error

### DIFF
--- a/scripts/scr_PlanetData/scr_PlanetData.gml
+++ b/scripts/scr_PlanetData/scr_PlanetData.gml
@@ -281,7 +281,7 @@ function PlanetData(_planet, _system) constructor {
     };
 
     static collect_planet_group = function(group = "all", opposite = false, search_conditions = {companies: "all"}, return_as_UnitGroup = true) {
-        return collect_role_group(group, [system.name, planet], opposite, search_conditions, return_as_UnitGroup);
+        return collect_role_group(group, [system.name, planet, -1], opposite, search_conditions, return_as_UnitGroup);
     };
 
     defence_lasers = system.p_lasers[planet];


### PR DESCRIPTION
Closes #1482

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `collect_planet_group` passing a malformed location array to `collect_role_group`, which expects a 3-element array. Adds `-1` as the third element to match the expected format. Closes #1482.

<sup>Written for commit 92fb89c8140a4b8c4492c769ca5851f49be34c1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

