### PR TITLE
chore: Bump GM to 2026.100.0.1110

### DIFF
--- a/ChapterMaster.yyp
+++ b/ChapterMaster.yyp
@@ -606,7 +606,7 @@
   "isEcma":false,
   "LibraryEmitters":[],
   "MetaData":{
-    "IDEVersion":"2026.100.0.1083",
+    "IDEVersion":"2026.100.0.1110",
   },
   "name":"ChapterMaster",
   "resources":[


### PR DESCRIPTION
Doing this yet again, because it got debumped. Again: 1083 has a critical memory access bug - https://github.com/YoYoGames/GameMaker-Bugs/issues/15518

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps GameMaker to 2026.100.0.1110 to fix a critical memory access bug in 2026.100.0.1083.

<sup>Written for commit f4b8862f309c479be16749a0c4622107ced930e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

