### PR TITLE
fix: Reenable genestealers start spawn

### DIFF
--- a/objects/obj_controller/Alarm_1.gml
+++ b/objects/obj_controller/Alarm_1.gml
@@ -26,7 +26,7 @@ var _spawn_factions = [
         faction_id: eFACTION.CHAOS,
     },
     {
-        enabled: false,
+        enabled: true,
         weight: 1,
         faction_id: eFACTION.GENESTEALER,
     },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Re-enables genestealers as a spawnable faction in the controller's faction pool.

<sup>Written for commit 9ce780fddf4872f6b35f645354f182645e6f3822. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

