### PR TITLE
fix: Repair demon summon ship battle

### DIFF
--- a/scripts/ArtifactStruct/ArtifactStruct.gml
+++ b/scripts/ArtifactStruct/ArtifactStruct.gml
@@ -203,6 +203,7 @@ function ArtifactStruct(_type_name = "", _tags = [], _identification_timer = 0, 
     };
 
     /// @desc Destroys the artifact. Daemonic artifacts destroyed while on a ship may trigger a demon summoning battle.
+    /// @returns {Undefined}
     static destroy_artifact = function() {
         if (has_tag("daemonic")) {
             var _resolved = __resolve_location();
@@ -210,13 +211,20 @@ function ArtifactStruct(_type_name = "", _tags = [], _identification_timer = 0, 
                 var demonSummonChance = roll_dice_chapter(1, 100, "high");
 
                 if ((demonSummonChance <= DEMON_SUMMON_THRESHOLD) && (obj_ini.ship_carrying[_resolved.ship_id] > 0)) {
+                    instance_deactivate_all_safe();
+                    instance_activate_object(obj_star);
+
                     /// @type {Asset.GMObject.obj_ncombat}
                     var _combat = instance_create_depth(0, 0, 0, obj_ncombat);
                     _combat.battle_special = "ship_demon";
                     _combat.formation_set = 1;
                     _combat.enemy = DEMON_SUMMON_ENEMIES;
                     _combat.battle_id = _resolved.ship_id;
+
+                    instance_deactivate_object(obj_star);
+                    setup_battle_formations();
                     scr_ship_battle(_resolved.ship_id, 999);
+                    main_map_defaults();
                 }
             }
         }

--- a/scripts/scr_ship_battle/scr_ship_battle.gml
+++ b/scripts/scr_ship_battle/scr_ship_battle.gml
@@ -1,3 +1,7 @@
+/// @desc Builds the player roster for a boarding battle aboard the target ship.
+/// @param {Real} target_ship_id Index into obj_ini.ship of the ship the battle is fought over.
+/// @param {Real} cooridor_width Second ship index whose occupants also count as present.
+/// @returns {Undefined}
 function scr_ship_battle(target_ship_id, cooridor_width) {
     // determine occupants
     // determine who is fighting
@@ -5,32 +9,17 @@ function scr_ship_battle(target_ship_id, cooridor_width) {
     // set battle special
 
     // if (argument2=true){
-    var co, v, stop, okay, sofar, _unit;
-    co = 0;
-    v = 0;
-    stop = 0;
-    okay = 0;
-    sofar = 0;
+    var sofar = 0;
 
-    repeat (3600) {
-        if (co < 11) {
-            v += 1;
-            okay = 0;
+    for (var co = 0; co < array_length(obj_ini.TTRPG); co++) {
+        var _company_length = company_length(co);
 
-            if (v > 300) {
-                co += 1;
-                v = 1;
+        for (var v = 0; v < _company_length; v++) {
+            var okay = 0;
+            var _unit = fetch_unit([co, v]);
+            if (!is_struct(_unit)) {
+                continue;
             }
-
-            if (co > 10) {
-                stop = 1;
-            }
-
-            if (stop == 0) {
-                _unit = fetch_unit([co, v]);
-                if (!is_struct(_unit)) {
-                    continue;
-                }
                 if ((_unit.ship_location == target_ship_id) && _unit.hp()) {
                     okay = 1;
                 }
@@ -213,7 +202,6 @@ function scr_ship_battle(target_ship_id, cooridor_width) {
                     targ = instance_nearest(col * 10, 240, obj_pnunit);
                     with (targ) {
                         scr_add_unit_to_roster(_unit);
-                    }
                 }
             }
         }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the demon summon ship battle, which previously crashed with index-out-of-bounds errors during roster building and left map instances active over the battle.

- Now iterates each company's valid bounds, so the first marine in each company can also join.
- Performs the normal combat-scene handoff, applies the configured formation, and closes the Librarium after the battle is built.

<sup>Written for commit fd20c2d4f8f4fc88c0f7607893df10b97c66caa4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

