### PR TITLE
fix: Honor chapter point limits

### DIFF
--- a/ChapterMaster.yyp
+++ b/ChapterMaster.yyp
@@ -554,7 +554,7 @@
     {"$GMIncludedFile":"","%Name":"7.JSON","CopyToMask":-1,"filePath":"datafiles/main/chapters","name":"7.JSON","resourceType":"GMIncludedFile","resourceVersion":"2.0",},
     {"$GMIncludedFile":"","%Name":"8.JSON","CopyToMask":-1,"filePath":"datafiles/main/chapters","name":"8.JSON","resourceType":"GMIncludedFile","resourceVersion":"2.0",},
     {"$GMIncludedFile":"","%Name":"9.JSON","CopyToMask":-1,"filePath":"datafiles/main/chapters","name":"9.JSON","resourceType":"GMIncludedFile","resourceVersion":"2.0",},
-    {"$GMIncludedFile":"","%Name":"template.JSON","CopyToMask":-1,"filePath":"datafiles/main/chapters","name":"template.JSON","resourceType":"GMIncludedFile","resourceVersion":"2.0",},
+    {"$GMIncludedFile":"","%Name":"chapter_template.json","CopyToMask":-1,"filePath":"datafiles/main/chapters","name":"chapter_template.json","resourceType":"GMIncludedFile","resourceVersion":"2.0",},
     {"$GMIncludedFile":"","%Name":"help.ini","CopyToMask":9223372036854775807,"filePath":"datafiles/main","name":"help.ini","resourceType":"GMIncludedFile","resourceVersion":"2.0",},
     {"$GMIncludedFile":"","%Name":"name_loader.json","CopyToMask":-1,"filePath":"datafiles/main","name":"name_loader.json","resourceType":"GMIncludedFile","resourceVersion":"2.0",},
     {"$GMIncludedFile":"","%Name":"chaos.json","CopyToMask":-1,"filePath":"datafiles/main/names","name":"chaos.json","resourceType":"GMIncludedFile","resourceVersion":"2.0",},

--- a/datafiles/main/chapters/1.JSON
+++ b/datafiles/main/chapters/1.JSON
@@ -6,7 +6,7 @@
     "flavor": "The Dark Angels are the Progenitor Chapter formed from the First Legion of Primarch Lion El'Jonson. Though through their secretive nature their allegiance and actions may be questionable, they are some of the most deadly and well-armed Astartes in the Imperium", //the short description that appears on popup when you hover over a chapter image
     "battle_cry": "Repent! For tomorrow you die!", //this is where you cry. I mean this is where you say what are you crying about. I mean... fuck it just type shit here to scream at people
     "origin": 1, //[1] Founding [2] Successor [3] Other [4] Custom
-    "points": 150, //creation points, feel free to cheat here for more wild stuff in custom if you don't like doing it via files
+    "points": 250, //creation points, feel free to cheat here for more wild stuff in custom if you don't like doing it via files
     "founding": 1, //ID of the progenitor chapter, as per fiels in datafiles/main/chapters
     "successors": 19, //write how many successors your chapter has. Go bonkers. Show them you got the seed to have 666 successors
     "splash": 1, //the more artsy image on the left side of selection screen. Highly advised to use the same number as chapter ID

--- a/datafiles/main/chapters/10.JSON
+++ b/datafiles/main/chapters/10.JSON
@@ -4,7 +4,7 @@
         "name": "Black Templars",
         "flavor": "Not adhering to the Codex Astartes, Black Templars are a Chapter on an Eternal Crusade with unique organization and high numbers. Masters of assault, they charge at the enemy with zeal unmatched. They hate psykers, and as such, have no Librarians.",
         "origin": 2, // 1 - Founding, 2 -successor, 3 - Other/non-canon/fanmade, 4 - Custom
-        "points": 200,
+        "points": 250,
         "founding": 4, // The id of the founding chapter, 0 for unknown or none
         "splash": 10,
         "icon_name": "black_templars",

--- a/datafiles/main/chapters/11.JSON
+++ b/datafiles/main/chapters/11.JSON
@@ -4,7 +4,7 @@
         "name": "Minotaurs",
         "flavor": "Bronze-clad Astartes of unknown Founding, the Minotaurs prefer to channel their righteous fury in a massive storm of fire, with tanks and artillery. They could be considered the Inquisition’s attack dog, since they often attack fellow chapters suspected of heresy.",
         "origin": 2, // 1 - Founding, 2 - Successor, 3 - Other/non-canon/fanmade, 4 - Custom
-        "points": 450,
+        "points": 250,
         "founding": 10, // The id of the founding chapter, 0 for unknown or none, 10 for random
         "splash": 11, // in \images\creation\chapters\splash folder, the img number, 1 being Dark Angels etc.
         "icon_name": "minotaurs",

--- a/datafiles/main/chapters/12.JSON
+++ b/datafiles/main/chapters/12.JSON
@@ -4,7 +4,7 @@
         "name": "Blood Ravens",
         "flavor": "Of unknown origins and Founding, the origins of the Blood Ravens are shrouded in mystery and are believed to be tied to a dark truth. This elusive Chapter is drawn to the pursuit of knowledge and ancient lore and produces an unusually high number of Librarians.",
         "origin": 2, // 1 - Founding, 2 - Successor, 3 - Other/non-canon/fanmade, 4 - Custom
-        "points": 100,
+        "points": 250,
         "founding": 10, // The id of the founding chapter, 0 for unknown or none, 10 for random
         "splash": 12, // in \images\creation\chapters\splash folder, the img number, 1 being Dark Angels etc.
         "icon_name": "blood_ravens",

--- a/datafiles/main/chapters/13.JSON
+++ b/datafiles/main/chapters/13.JSON
@@ -4,7 +4,7 @@
         "name": "Crimson Fists",
         "flavor": "An Imperial Fists descendant, the Crimson Fists are more level-minded than their Progenitor and brother chapters.  They suffer the same lacking zygotes as their ancestors, and more resemble the Ultramarines in their balanced approach to combat. After surviving a devastating Ork WAAAGH! the chapter clings dearly to its future.",
         "origin": 2, // 1 - Founding, 2 - Successor, 3 - Other/non-canon/fanmade, 4 - Custom
-        "points": 150,
+        "points": 250,
         "founding": 4, // The id of the founding chapter, 0 for unknown or none, 10 for random
         "splash": 13, // in \images\creation\chapters\splash folder, the img number, 1 being Dark Angels etc.
         "icon_name": "crimson_fists",

--- a/datafiles/main/chapters/14.JSON
+++ b/datafiles/main/chapters/14.JSON
@@ -4,7 +4,7 @@
         "name": "Lamenters",
         "flavor": "The Lamenter's accursed and haunted legacy seems to taint much of what they have achieved; their victories often become bitter ashes in their hands.  Nearly extinct, they fight their last days on behalf of the common folk in a crusade of endless penitence.",
         "origin": 2, // 1 - Founding, 2 - Successor, 3 - Other/non-canon/fanmade, 4 - Custom
-        "points": 150,
+        "points": 250,
         "founding": 5, // The id of the founding chapter, 0 for unknown or none, 10 for random
         "splash": 14, // in \images\creation\chapters\splash folder, the img number, 1 being Dark Angels etc.
         "icon_name": "lamenters",

--- a/datafiles/main/chapters/15.JSON
+++ b/datafiles/main/chapters/15.JSON
@@ -4,7 +4,7 @@
         "name": "Carcharodons",
         "flavor": "Rumored to be Successors of the Raven Guard, these Astartes are known for their sudden attacks and shock assaults. Travelling through the Imperium via self-sufficient Nomad-Predation based fleets, no enemy is safe from the fury of these bloodthirsty Space Marines.",
         "origin": 2, // 1 - Founding, 2 - Successor, 3 - Other/non-canon/fanmade, 4 - Custom
-        "points": 100,
+        "points": 250,
         "founding": 9, // The id of the founding chapter, 0 for unknown or none, 10 for random
         "splash": 99, // in \images\creation\chapters\splash folder, the img number, 1 being Dark Angels etc.
         "icon_name": "carcharodons",

--- a/datafiles/main/chapters/16.JSON
+++ b/datafiles/main/chapters/16.JSON
@@ -4,7 +4,7 @@
         "name": "Soul Drinkers",
         "flavor": "Sharing ancestry of the Black Templars or Crimson fists. As proud sons of Dorn they share the strong void combat traditions, fielding a large amount of Battle Barges. As well as being fearsome in close combat. Whispers of the Ruinous Powers are however quite enticing.",
         "origin": 2, // 1 - Founding, 2 - Successor, 3 - Other/non-canon/fanmade, 4 - Custom
-        "points": 200,
+        "points": 250,
         "founding": 4, // The id of the founding chapter, 0 for unknown or none, 10 for random
         "splash": 16, // in \images\creation\chapters\splash folder, the img number, 1 being Dark Angels etc.
         "icon_name": "soul_drinkers",

--- a/datafiles/main/chapters/17.JSON
+++ b/datafiles/main/chapters/17.JSON
@@ -4,7 +4,7 @@
         "name": "Angry Marines",
         "flavor": "Frothing with pathological rage since the day their Primarch emerged from his pod with naught but a dented copy of battletoads.  Every last Angry Marine is a homicidal, suicidal berserker with a voice that projects, and are always angry, all the time.  A /tg/ classic.",
         "origin": 3, // 1 - Founding, 2 - Successor, 3 - Other/non-canon/fanmade, 4 - Custom
-        "points": 100,
+        "points": 250,
         "founding": 0, // The id of the founding chapter, 0 for unknown or none, 10 for random
         "splash": 17, // in \images\creation\chapters\splash folder, the img number, 1 being Dark Angels etc.
         "icon_name": "angry_marines",

--- a/datafiles/main/chapters/2.JSON
+++ b/datafiles/main/chapters/2.JSON
@@ -4,7 +4,7 @@
         "name": "White Scars",
         "flavor": "Known and feared for their highly mobile way of war, the White Scars are the masters of lightning strikes and hit-and-run tactics.  They are particularly adept in the use of Attack Bikes and field large numbers of them.",
         "origin": 1, // 1 - Founding, 2 -successor, 3 - Other/non-canon/fanmade, 4 - Custom
-        "points": 150,
+        "points": 250,
         "founding": 0, // The id of the founding chapter, 0 for unknown or none
         "splash": 2,
         "icon_name": "white_scars",

--- a/datafiles/main/chapters/3.JSON
+++ b/datafiles/main/chapters/3.JSON
@@ -4,7 +4,7 @@
         "name": "Space Wolves",
         "flavor": "Brave sky warriors hailing from the icy deathworld of Fenris, the Space Wolves are a non-Codex compliant chapter, and deadly in close combat.  They fight on their own terms and damn any who wish otherwise.",
         "origin": 1, // 1 - Founding, 2 -successor, 3 - Other/non-canon/fanmade, 4 - Custom
-        "points": 150,
+        "points": 250,
         "founding": 0, // The id of the founding chapter, 0 for unknown or none
         "splash": 3,
         "icon_name": "space_wolves",

--- a/datafiles/main/chapters/31.JSON
+++ b/datafiles/main/chapters/31.JSON
@@ -4,7 +4,7 @@
         "name": "Red Scorpions",
         "flavor": "No records remain of the chapter's founding or from which Space Marine Legion their geneseed was first taken. This secrecy has led to some of the Imperium's hierarchy questioning the loyalty of a chapter that keeps its history secret and holds itself answerable to the Emperor alone. Despite this, the chapter assists wherever it can, carrying out thousands of relief missions.",
         "origin": 2, // 1 - Founding, 2 -successor, 3 - Other/non-canon/fanmade, 4 - Custom
-        "points": 150,
+        "points": 250,
         "founding": 0, // The id of the founding chapter, 0 for unknown or none
         "splash": 22, // this will get reworked
         "icon_name": "red_scorpions",

--- a/datafiles/main/chapters/32.JSON
+++ b/datafiles/main/chapters/32.JSON
@@ -4,7 +4,7 @@
         "name": "Tome Keepers",
         "flavor": "The Tome Keepers are renowned for their diligent record-keeping and strategic insights, particularly against Xenos such as the Necrons. After each battle, Tome Keepers meticulously record their observations of their foe and devise new tactics for their destruction. Their knowledge has shortened wars that the Administratum thought would take years.",
         "origin": 2, // 1 - Founding, 2 -successor, 3 - Other/non-canon/fanmade, 4 - Custom
-        "points": 100,
+        "points": 250,
         "founding": 7, // The id of the founding chapter, 0 for unknown or none
         "splash": 32, // this will get reworked
         "icon_name": "tome_keepers",

--- a/datafiles/main/chapters/33.json
+++ b/datafiles/main/chapters/33.json
@@ -4,7 +4,7 @@
         "name": "Deathwatch",
         "flavor": "Known as the Shield that Slays, they are the Chamber Militant of the Ordo Xenos, charged with protecting it in its search of information, containment, and ultimate destruction of all xeno species. Consisting of Battle-Brothers drawn from many Chapters, the Deathwatch operates from Watch Fortresses and Watch Stations across the whole of the Imperium.",
         "origin": 3, // 1 - Founding, 2 - Successor, 3 - Other/non-canon/fanmade, 4 - Custom
-        "points": 150,
+        "points": 250,
         "founding": 0, // The id of the founding chapter, 0 for unknown or none, 10 for random
         "splash": 33, // in \images\creation\chapters\splash folder, the img number, 1 being Dark Angels etc.
         "icon_name": "deathwatch",

--- a/datafiles/main/chapters/34.json
+++ b/datafiles/main/chapters/34.json
@@ -101,7 +101,7 @@
     "squad_name": "Squad",
     "recruiting": "Death",
     "custom_squads": {},
-    "points": 0.0,
+    "points": 250,
     "names": {
       "hchaplain": "Appollus",
       "clibrarian": "Luciferus",

--- a/datafiles/main/chapters/35.json
+++ b/datafiles/main/chapters/35.json
@@ -4,7 +4,7 @@
         "name": "Celestial Lions",
         "flavor": "The Celestial Lions are a Space Marine chapter nearly annihilated by the Inquisition after they dared question Inquisitorial atrocities on Armageddon, with their remnants saved from extinction only through the intervention of the Black Templars. Currently they have barely a hundred brothers left.",
         "origin": 2, // 1 - Founding, 2 - Successor, 3 - Other/non-canon/fanmade, 4 - Custom
-        "points": 150,
+        "points": 250,
         "founding": 4, // The id of the founding chapter, 0 for unknown or none, 10 for random
         "splash": 98, // in \images\creation\chapters\splash folder, the img number, 1 being Dark Angels etc.
         "icon_name": "celestial_lions",

--- a/datafiles/main/chapters/36.json
+++ b/datafiles/main/chapters/36.json
@@ -4,7 +4,7 @@
         "name": "Raptors",
         "flavor": "The Raptors are a Successor Chapter of the Raven Guard, created in the Second Founding. They are famous for their exceptional survival abilities, and extremely skilled in guerrilla warfare and infiltration operations",
         "origin": 2, // 1 - Founding, 2 - Successor, 3 - Other/non-canon/fanmade, 4 - Custom
-        "points": 150,
+        "points": 250,
         "founding": 9, // The id of the founding chapter, 0 for unknown or none, 10 for random
         "splash": 36, // in \images\creation\chapters\splash folder, the img number, 1 being Dark Angels etc.
         "icon_name": "raptors",

--- a/datafiles/main/chapters/37.json
+++ b/datafiles/main/chapters/37.json
@@ -4,7 +4,7 @@
         "name": "Consecrators",
         "flavor": "The Consecrators are a secretive Dark Angels successor chapter dedicated to preserving ancient technologies and traditions from the early Imperium, maintaining a substantial armory of rare Heresy-era weaponry and equipment while continuing their parent chapter's hunt for the Fallen Angels.",
         "origin": 2, // 1 - Founding, 2 - Successor, 3 - Other/non-canon/fanmade, 4 - Custom
-        "points": 150,
+        "points": 250,
         "founding": 0, // The id of the founding chapter, 0 for unknown or none, 10 for random
         "splash": 1, // in \images\creation\chapters\splash folder, the img number, 1 being Dark Angels etc.
         "icon_name": "consecrators",

--- a/datafiles/main/chapters/4.JSON
+++ b/datafiles/main/chapters/4.JSON
@@ -4,7 +4,7 @@
         "name": "Imperial Fists",
         "flavor": "Siege-masters of utmost excellence, the Imperial Fists stoicism has lead them to great victories and horrifying defeats. To them, the idea of a tactical retreat is utterly inconsiderable. They hold ground on Terra vigilantly, refusing to back down from any fight.",
         "origin": 1, // 1 - Founding, 2 -successor, 3 - Other/non-canon/fanmade, 4 - Custom
-        "points": 150,
+        "points": 250,
         "founding": 0, // The id of the founding chapter, 0 for unknown or none
         "splash": 4,
         "icon_name": "imperial_fists",

--- a/datafiles/main/chapters/5.JSON
+++ b/datafiles/main/chapters/5.JSON
@@ -4,7 +4,7 @@
         "name": "Blood Angels",
         "flavor": "One of the most noble and renowned chapters, their combat record belies a dark flaw in their gene-seed caused by the death of their primarch. Their primarch had wings and a propensity for close combat, and this shows in their extensive use of jump packs and close quarters weapons.",
         "origin": 1, // 1 - Founding, 2 -successor, 3 - Other/non-canon/fanmade, 4 - Custom
-        "points": 150,
+        "points": 250,
         "founding": 0, // The id of the founding chapter, 0 for unknown or none
         "splash": 5,
         "icon_name": "blood_angels",

--- a/datafiles/main/chapters/6.JSON
+++ b/datafiles/main/chapters/6.JSON
@@ -4,7 +4,7 @@
         "name": "Iron Hands",
         "flavor": "The flesh is weak, and the weak shall perish. Such is the creed of these mercilessly efficient cyborg warriors. A chapter with strong ties to the Mechanicum, they crush the foes of the Emperor and Machine God alike with a plethora of exotic technology and ancient weaponry.",
         "origin": 1, // 1 - Founding, 2 -successor, 3 - Other/non-canon/fanmade, 4 - Custom
-        "points": 150,
+        "points": 250,
         "founding": 0, // The id of the founding chapter, 0 for unknown or none
         "splash": 6,
         "icon_name": "iron_hands",

--- a/datafiles/main/chapters/7.JSON
+++ b/datafiles/main/chapters/7.JSON
@@ -4,7 +4,7 @@
         "name": "Ultramarines",
         "flavor": "An honourable and venerated chapter, the Ultramarines are considered to be amongst the best of the best. Their Primarch was the author of the great tome of the “Codex Astartes”, and they are considered exemplars of what a perfect Space Marine Chapter should be like.",
         "origin": 1, // 1 - Founding, 2 -successor, 3 - Other/non-canon/fanmade, 4 - Custom
-        "points": 150,
+        "points": 250,
         "founding": 0, // The id of the founding chapter, 0 for unknown or none
         "splash": 7,
         "icon_name": "ultramarines",

--- a/datafiles/main/chapters/8.JSON
+++ b/datafiles/main/chapters/8.JSON
@@ -4,7 +4,7 @@
         "name": "Salamanders",
         "flavor": "Followers of the Promethean Cult, the jet-black skinned Salamanders are forgemasters of legend. They are armed with the best wargear available and prefer flame based weaponry. Their only drawback is their low numbers and slow recruiting.",
         "origin": 1, // 1 - Founding, 2 -successor, 3 - Other/non-canon/fanmade, 4 - Custom
-        "points": 150,
+        "points": 250,
         "founding": 0, // The id of the founding chapter, 0 for unknown or none
         "splash": 8,
         "icon_name": "salamanders",

--- a/datafiles/main/chapters/9.JSON
+++ b/datafiles/main/chapters/9.JSON
@@ -4,7 +4,7 @@
         "name": "Raven Guard",
         "flavor": "Clinging to the shadows and riding the edge of lightning the Raven Guard strike out at the hated enemy with stealth and speed. Using lightning strikes, hit and run tactics, and guerrilla warfare, they are known for being there one second and gone the next.",
         "origin": 1, // 1 - Founding, 2 -successor, 3 - Other/non-canon/fanmade, 4 - Custom
-        "points": 150,
+        "points": 250,
         "founding": 0, // The id of the founding chapter, 0 for unknown or none
         "splash": 9,
         "icon_name": "raven_guard",

--- a/datafiles/main/chapters/chapter_template.json
+++ b/datafiles/main/chapters/chapter_template.json
@@ -1,10 +1,28 @@
 {
     "chapter": {
+        /*
+        * * This folder contains premade chapters. Each file is named <id>.JSON to
+        * * match the "id" stored inside it.
+        * *
+        * * Do not place custom chapters in this folder. They must be saved in
+        * * %LocalAppData%\ChapterMaster\ and named chaptersave#<id>.json.
+        * *
+        * * Custom chapters use IDs 21 through 30, corresponding to the ten custom
+        * * slots on the chapter select screen. For example, chaptersave#21.json
+        * * must contain "id": 21.
+        * *
+        * * To create a custom chapter, copy this template or an existing premade
+        * * chapter, change its "id" to a number from 21 through 30, and save it in
+        * * %LocalAppData%\ChapterMaster\ using the matching filename.
+        * *
+        * * Starting a game in a custom slot rewrites its file, so keep a separate
+        * * copy of any chapter you want to preserve.
+        */
         "id": 1,
         "name": "Chapter Name",
         "flavor": "Chapter Lore",
         "origin": 3, // 1 - Founding, 2 - Successor, 3 - Other/non-canon/fanmade, 4 - Custom
-        "points": 150,
+        "points": 250,
         "founding": 0, // The id of the founding chapter, 0 for unknown or none, 10 for random
         "splash": 1, // in \images\creation\chapters\splash folder, the img number, 1 being Dark Angels etc.
         "icon_name": "unknown",

--- a/scripts/scr_chapter_new/scr_chapter_new.gml
+++ b/scripts/scr_chapter_new/scr_chapter_new.gml
@@ -230,7 +230,7 @@ function scr_chapter_new(chapter_identifier) {
         }
 
         global.chapter_creation_object = chapter_obj;
-        maxpoints = 150;
+        maxpoints = (is_real(chapter_obj.points) && chapter_obj.points >= 1) ? floor(chapter_obj.points) : 250;
     }
 
     #region Custom Chapter
@@ -246,7 +246,7 @@ function scr_chapter_new(chapter_identifier) {
             return false;
         }
         global.chapter_creation_object = chapter_obj;
-        maxpoints = 100;
+        maxpoints = (is_real(chapter_obj.points) && chapter_obj.points >= 1) ? floor(chapter_obj.points) : 100;
     }
     #endregion
 

--- a/scripts/scr_save_chapter/scr_save_chapter.gml
+++ b/scripts/scr_save_chapter/scr_save_chapter.gml
@@ -5,6 +5,7 @@ function scr_save_chapter(chapter_id) {
     var custom_splash = 97;
     var chap = new ChapterData();
     chap.id = chapter_id;
+    chap.points = maxpoints;
     chap.splash = custom_splash;
     chap.name = chapter_name;
     chap.flavor = "Your Chapter";


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes chapter creation to respect each chapter's defined point limit instead of using hardcoded values. Premade chapters now use their `points` field (all set to 250), while custom chapters keep a 100-point default. Also saves the active point limit when a chapter is saved, so it persists.

<sup>Written for commit 25e1bda6fdb6e753a8b6e9cd6991e04195952787. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

