### PR TITLE
fix: Preserve warp storm ETA sentinel

### DIFF
--- a/scripts/scr_fleet_functions/scr_fleet_functions.gml
+++ b/scripts/scr_fleet_functions/scr_fleet_functions.gml
@@ -224,7 +224,7 @@ function set_fleet_movement(_fastest_route = true, _new_action = "move", _minimu
     // Finalize Movement State
     fleet_unregister_from_star(id);
     action = _new_action;
-    action_eta = clamp(_eta, _minimum_eta, _maximum_eta);
+    action_eta = _eta > 5000 ? _eta : clamp(_eta, _minimum_eta, _maximum_eta);
 }
 
 /// @param {Id.Instance.obj_en_fleet|Id.Instance.obj_p_fleet} fleet


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Preserves the warp storm sentinel ETA during fleet movement by skipping the clamp for values above 5000, while regular ETAs still get clamped to the allowed range.

<sup>Written for commit c6fee0b0ee40218c1a5a9713af5faed95b595227. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

