### PR TITLE
fix: Activate player units for STC theft battle

### DIFF
--- a/objects/obj_popup/Alarm_0.gml
+++ b/objects/obj_popup/Alarm_0.gml
@@ -23,6 +23,7 @@ if (battle_special == 3.1) {
 
     instance_deactivate_all_safe();
     instance_activate_object(obj_ncombat);
+    instance_activate_object(obj_pnunit);
 
     _roster = new Roster();
     with (_roster) {
@@ -36,6 +37,7 @@ if (battle_special == 3.1) {
             add_to_battle();
         } else {
             instance_destroy(obj_ncombat);
+            instance_destroy(obj_pnunit);
             instance_activate_all();
             delete _roster;
         }


### PR DESCRIPTION
Closes #1494

Tested by reproducing the reported crash in game prior to the fix. Post fix the crash could not be reproduced.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the crash in the Mechanicus STC theft battle by reactivating player unit columns alongside combat units.

Closes #1494. The battle deactivated all instances but only reactivated `obj_ncombat`, leaving `obj_pnunit` columns inactive. `instance_nearest` ignores deactivated instances, so marine placement columns were skipped and the setup alarm threw an error.

<sup>Written for commit ad77c39bce6c30dc3aeac83ea4975064f541703f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

