### PR TITLE
ci(oc): Add external_dir perm

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -36,6 +36,7 @@ jobs:
         uses: anomalyco/opencode/github@v1.18.9
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          OPENCODE_PERMISSION: '{ "external_directory": "allow"}'
         with:
           model: opencode/muse-spark-1.2-contributor-free
           variant: xhigh

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -36,7 +36,7 @@ jobs:
         uses: anomalyco/opencode/github@v1.18.9
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
-          OPENCODE_PERMISSION: '{ "external_directory": "allow"}'
+          OPENCODE_PERMISSION: '{ "external_directory": { "/home/runner/work/**": "allow" } }'
         with:
           model: opencode/muse-spark-1.2-contributor-free
           variant: xhigh


### PR DESCRIPTION
The default is "ask", which causes dead-end, because the user can't respond during workflow execution. The workflow runs on a GitHub runner. I assume there is no risk in free access to external_dir.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets `OPENCODE_PERMISSION` to allow `external_directory` access in the opencode workflow. The default "ask" permission dead-ends the workflow since nobody can respond while it runs on a GitHub runner.

<sup>Written for commit 324498fda075067d781b5b2e339d9bb17839a606. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

