### PR TITLE
fix(adhoc manage): Allow adhoc manage to refresh correctly

### DIFF
--- a/scripts/scr_ui_manage/scr_ui_manage.gml
+++ b/scripts/scr_ui_manage/scr_ui_manage.gml
@@ -86,7 +86,7 @@ function load_marines_into_ship(system, ship, units, reload = false) {
     }
     selecting_ship = -1;
     if (managing == -1 && obj_controller.selection_data.purpose != "Ship Management") {
-        update_garrison_manage();
+        update_adhoc_manage();
     }
 }
 

--- a/scripts/scr_unit_quick_find_pane/scr_unit_quick_find_pane.gml
+++ b/scripts/scr_unit_quick_find_pane/scr_unit_quick_find_pane.gml
@@ -574,15 +574,16 @@ function exit_adhoc_manage() {
 }
 
 /// @self Asset.GMObject.obj_controller
-function update_garrison_manage() {
+function update_adhoc_manage() {
     location_viewer.update_garrison_log();
     var _selection = [];
-    var sys_name = "";
+    var _sys_name = "";
     var _ships = -1;
     var _planets = 0;
     if (struct_exists(selection_data, "system") && instance_exists(selection_data.system)) {
-        if (struct_exists(location_viewer.garrison_log, selection_data.system.name)) {
-            sys_name = selection_data.system.name;
+        var _sys = selection_data.system;
+        if (_sys.object_index == obj_star && struct_exists(location_viewer.garrison_log, _sys.name)) {
+            _sys_name = selection_data.system.name;
         }
     }
 
@@ -594,7 +595,7 @@ function update_garrison_manage() {
         _planets = selection_data.planets;
     }
 
-    _selection = collect_role_group("all", [sys_name, _planets, _ships]);
+    _selection = collect_role_group("all", [_sys_name, _planets, _ships]);
 
     if (array_length(_selection)) {
         group_selection(_selection, selection_data);
@@ -618,7 +619,7 @@ function update_general_manage_view() {
             unload = 0;
             alarm[6] = 30;
         } else if (managing == -1) {
-            update_garrison_manage();
+            update_adhoc_manage();
         }
     }
 }
@@ -684,7 +685,7 @@ function jail_selection() {
         alll = 0;
         update_general_manage_view();
     } else if (managing == -1) {
-        update_garrison_manage();
+        update_adhoc_manage();
     }
     sel_loading = -1;
     unload = 0;


### PR DESCRIPTION
<!--- YOU CAN DELETE ALL OF THIS AFTER READING. -->

- tested buy entering adhoc manage and jailing marines, no errors encountered
<!--- Make use of markdown lists. They make stuff much easier to read through. -->
<!--- Explain why and what your changes do in simple terms. --->
<!--- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. --->

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->

<!--- "Inspired" by the CDDA PR template -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the adhoc manage pane refreshing by renaming the update function and guarding garrison log lookups against non-star selections.

- Renames `update_garrison_manage` to `update_adhoc_manage` to match its purpose and updates all callers.
- Skips the garrison log lookup when the selected system is not a star, preventing errors on non-star selections.

<sup>Written for commit 684f45d57e8e11e2ff5c3e25238e4faf419e0e33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

