### PR TITLE
fix(ui): Move map overlays to the GUI layer

### DIFF
--- a/objects/obj_bomb_select/Draw_64.gml
+++ b/objects/obj_bomb_select/Draw_64.gml
@@ -1,8 +1,3 @@
-xx = camera_get_view_x(view_camera[0]);
-yy = camera_get_view_y(view_camera[0]);
-ww = camera_get_view_width(view_camera[0]);
-hh = camera_get_view_height(view_camera[0]);
-
 // Sets the bombard target, its forces and draws the ships wich will bombard said target
 bomb_window = {
     x1: 0,
@@ -14,8 +9,8 @@ bomb_window = {
     x3: 0,
     y3: 0,
 };
-bomb_window.x1 = xx + (ww / 2) - bomb_window.w / 2;
-bomb_window.y1 = yy + (hh / 2) - bomb_window.h / 2;
+bomb_window.x1 = (display_get_gui_width() / 2) - (bomb_window.w / 2);
+bomb_window.y1 = (display_get_gui_height() / 2) - (bomb_window.h / 2);
 bomb_window.x2 = bomb_window.x1 + bomb_window.w;
 bomb_window.y2 = bomb_window.y1 + bomb_window.h;
 bomb_window.x3 = bomb_window.x1 + (bomb_window.w / 2);

--- a/objects/obj_bomb_select/obj_bomb_select.yy
+++ b/objects/obj_bomb_select/obj_bomb_select.yy
@@ -6,7 +6,7 @@
     {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":4,"eventType":2,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
     {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":1,"eventType":2,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
     {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":56,"eventType":6,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
-    {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":0,"eventType":8,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
+    {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":64,"eventType":8,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
   ],
   "managed":true,
   "name":"obj_bomb_select",

--- a/objects/obj_controller/Draw_0.gml
+++ b/objects/obj_controller/Draw_0.gml
@@ -2,7 +2,6 @@
 try {
     scr_ui_manage();
     scr_ui_advisors();
-    scr_ui_tooltip();
     if (menu == eMENU.DIPLOMACY) {
         scr_ui_diplomacy();
     }

--- a/objects/obj_controller/Draw_0.gml
+++ b/objects/obj_controller/Draw_0.gml
@@ -5,9 +5,6 @@ try {
     if (menu == eMENU.DIPLOMACY) {
         scr_ui_diplomacy();
     }
-    if (menu == eMENU.SECRET_LAIR) {
-        scr_secret_lair_view();
-    }
 } catch (_exception) {
     ERROR_HANDLER.handle_exception(_exception);
     main_map_defaults();

--- a/objects/obj_controller/Draw_64.gml
+++ b/objects/obj_controller/Draw_64.gml
@@ -62,6 +62,7 @@ if (menu == eMENU.DIPLOMACY) {
 // Main UI
 if (!zoomed && !zui) {
     add_draw_return_values();
+    scr_ui_tooltip();
     if (menu == eMENU.DEFAULT) {
         location_viewer.draw();
         helpful_places_button.update({x1: 1451, y1: 62 + sprite_get_height(spr_new_banner)});

--- a/objects/obj_controller/Draw_64.gml
+++ b/objects/obj_controller/Draw_64.gml
@@ -252,6 +252,8 @@ try {
         }
     } else if (menu == eMENU.LIBRARIUM) {
         scr_librarium_gui();
+    } else if (menu == eMENU.SECRET_LAIR) {
+        scr_secret_lair_view();
     } else if (menu >= eMENU.SETTINGS && menu <= eMENU.FORMATIONS_SETTINGS) {
         scr_ui_settings();
     }

--- a/scripts/scr_secret_lair_view/scr_secret_lair_view.gml
+++ b/scripts/scr_secret_lair_view/scr_secret_lair_view.gml
@@ -1,9 +1,8 @@
-/// @function scr_secret_lair_view()
-/// @category UI
-/// @description Displays information on secret lairs
+/// @desc Displays information on secret lairs.
+/// @returns {Undefined}
 function scr_secret_lair_view() {
-    var xx = camera_get_view_x(view_camera[0]) + 25;
-    var yy = camera_get_view_y(view_camera[0]) + 165;
+    var xx = 25;
+    var yy = 165;
 
     add_draw_return_values();
     draw_sprite(spr_popup_large, 1, xx, yy);

--- a/scripts/scr_ui_tooltip/scr_ui_tooltip.gml
+++ b/scripts/scr_ui_tooltip/scr_ui_tooltip.gml
@@ -4,9 +4,6 @@ function scr_ui_tooltip() {
     if ((selected != noone) && (!instance_exists(selected))) {
         selected = noone;
     }
-    if (zoomed != 0) {
-        exit;
-    }
 
     var tooltip = "";
 

--- a/scripts/scr_ui_tooltip/scr_ui_tooltip.gml
+++ b/scripts/scr_ui_tooltip/scr_ui_tooltip.gml
@@ -1,6 +1,5 @@
-/// @function scr_ui_tooltip()
-/// @category UI
-/// @description Handles tooltip logics around the main play screen
+/// @desc Handles tooltip logics around the main play screen
+/// @returns {Undefined}
 function scr_ui_tooltip() {
     if ((selected != noone) && (!instance_exists(selected))) {
         selected = noone;
@@ -9,12 +8,10 @@ function scr_ui_tooltip() {
         exit;
     }
 
-    var xx = camera_get_view_x(view_camera[0]);
-    var yy = camera_get_view_y(view_camera[0]);
     var tooltip = "";
 
     // Requisition income tooltip
-    if (scr_hit(xx + 5, yy + 10, xx + 137, yy + 38)) {
+    if (scr_hit(5, 10, 137, 38)) {
         tooltip = "Requisition Points";
         tooltip += string("#Base Income: {0}{1}", income_base > 0 ? "+" : "", income_base);
         if (obj_ini.fleet_type == ePLAYER_BASE.HOME_WORLD) {
@@ -47,7 +44,7 @@ function scr_ui_tooltip() {
     }
 
     // Current Loyalty tooltip
-    if (scr_hit(xx + 247, yy + 10, xx + 328, yy + 38)) {
+    if (scr_hit(247, 10, 328, 38)) {
         for (var i = 1; i <= 20; i++) {
             if (loyal_num[i] > 1) {
                 tooltip += string(loyal[i]) + ": -" + string(loyal_num[i]) + "#";
@@ -62,29 +59,29 @@ function scr_ui_tooltip() {
     }
 
     // Stored Gene-Seed tooltip
-    if (scr_hit(xx + 373, yy + 10, xx + 443, yy + 38)) {
+    if (scr_hit(373, 10, 443, 38)) {
         tooltip = "Gene-Seed#" + obj_controller.apothecary_string;
         tooltip_draw(tooltip);
     }
     // Current Astartes tooltip
-    if (scr_hit(xx + 478, yy + 3, xx + 552, yy + 38)) {
+    if (scr_hit(478, 3, 552, 38)) {
         tooltip = "Astartes (Normal/Command)#" + string(obj_controller.marines);
         tooltip_draw(tooltip);
     }
     // Turn tooltip
     if ((menu == eMENU.DEFAULT) && (diplomacy <= 0)) {
-        if (scr_hit(xx + 1435, yy + 40, xx + 1580, yy + 267)) {
+        if (scr_hit(1435, 40, 1580, 267)) {
             tooltip = $"Turn :{obj_controller.turn}";
             tooltip_draw(tooltip);
         }
     }
     // Forge Points income tooltip
-    if (scr_hit(xx + 153, yy + 10, xx + 241, yy + 38)) {
+    if (scr_hit(153, 10, 241, 38)) {
         tooltip_draw(obj_controller.forge_string);
     }
 
     // Penitence/Blood Debt tooltip
-    if (scr_hit(xx + 923, yy + 10, xx + 1060, yy + 38) && (penitent == 1)) {
+    if (scr_hit(923, 10, 1060, 38) && (penitent == 1)) {
         var bd_decay_rate = min(0, (((penitent_turn + 1) * (penitent_turn + 1)) - 512) * -1);
 
         if (obj_controller.blood_debt == 1) {


### PR DESCRIPTION
- Prior to fix, reproduced the issues in all three affected areas. Resource tooltip hit areas scaled with the player camera zoom instead of staying aligned with the icons, while the bombardment window and Secret Lair panel just broadly rescaled and moved around depending on player zoom.
- After the change, all three remain correctly fixed in size and position, regardless of players zoom level. Buttons and hover highlights now align correctly with the cursor. Resource tooltips also no longer appear over the save/load screen or during space battle resolution, where previously the hover hit areas still worked despite the ui bar being hidden.
- spot checked various related/semi-related ui screens for regression and found none.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes map overlays so resource tooltips, the bombardment window, and the Secret Lair panel stay fixed in size and position regardless of player zoom.

- Tooltips now draw in GUI space, no longer appear over the save/load screen or during space battle resolution, and drop the now-dead zoom check.
- The bombardment window now renders in the GUI layer instead of the world.
- The Secret Lair panel now uses fixed GUI coordinates instead of camera offsets.

<sup>Written for commit 88315dea5244e714d35542e6f96ee498166fee7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

