### PR TITLE
ci(oc): Refactor /review workflow; Rewrite prompt

### DIFF
--- a/.github/workflows/opencode_review.yml
+++ b/.github/workflows/opencode_review.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout PR Branch
         run: gh pr checkout ${{ steps.pr-number.outputs.number }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.LYRA_PRS_ISSUES_PAT }}
 
       - name: Get PR details
         id: pr-details
@@ -44,7 +44,7 @@ jobs:
           echo "sha=$(jq -r .head.sha pr_data.json)" >> $GITHUB_OUTPUT
           echo "base=$(jq -r .base.ref pr_data.json)" >> $GITHUB_OUTPUT
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.LYRA_PRS_ISSUES_PAT }}
 
       - name: Install OpenCode
         run: curl -fsSL https://opencode.ai/install | bash
@@ -52,7 +52,7 @@ jobs:
       - name: Run OpenCode
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.LYRA_PRS_ISSUES_PAT }}
           OPENCODE_PERMISSION: '{ "external_directory": { "/home/runner/work/**": "allow", "/tmp/*": "allow" } }'
           PR_TITLE: ${{ steps.pr-details.outputs.title }}
           PR_SHA: ${{ steps.pr-details.outputs.sha }}

--- a/.github/workflows/opencode_review.yml
+++ b/.github/workflows/opencode_review.yml
@@ -44,7 +44,6 @@ jobs:
           echo "title<<EOF" >> $GITHUB_OUTPUT
           jq -r .title pr_data.json >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
-          echo "sha=$(jq -r .head.sha pr_data.json)" >> $GITHUB_OUTPUT
           echo "base=$(jq -r .base.ref pr_data.json)" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.LYRA_PRS_ISSUES_PAT }}
@@ -55,10 +54,11 @@ jobs:
       - name: Run OpenCode
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          GH_TOKEN: ${{ secrets.LYRA_PRS_ISSUES_PAT }}
           GITHUB_TOKEN: ${{ secrets.LYRA_PRS_ISSUES_PAT }}
           OPENCODE_PERMISSION: '{ "external_directory": { "/home/runner/work/**": "allow", "/tmp/*": "allow" } }'
           PR_TITLE: ${{ steps.pr-details.outputs.title }}
-          PR_SHA: ${{ steps.pr-details.outputs.sha }}
+          PR_SHA: ${{ steps.pr-git.outputs.sha }}
           PR_BASE: ${{ steps.pr-details.outputs.base }}
           PR_NUMBER: ${{ steps.pr-number.outputs.number }}
         run: |

--- a/.github/workflows/opencode_review.yml
+++ b/.github/workflows/opencode_review.yml
@@ -15,11 +15,6 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 1
-
       - name: Get PR number
         id: pr-number
         run: |
@@ -28,6 +23,16 @@ jobs:
           else
             echo "number=${{ github.event.issue.number }}" >> $GITHUB_OUTPUT
           fi
+    
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Checkout PR Branch
+        run: gh pr checkout ${{ steps.pr-number.outputs.number }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get PR details
         id: pr-details
@@ -37,6 +42,7 @@ jobs:
           jq -r .title pr_data.json >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
           echo "sha=$(jq -r .head.sha pr_data.json)" >> $GITHUB_OUTPUT
+          echo "base=$(jq -r .base.ref pr_data.json)" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -50,35 +56,30 @@ jobs:
           OPENCODE_PERMISSION: '{ "external_directory": { "/home/runner/work/**": "allow", "/tmp/*": "allow" } }'
           PR_TITLE: ${{ steps.pr-details.outputs.title }}
           PR_SHA: ${{ steps.pr-details.outputs.sha }}
+          PR_BASE: ${{ steps.pr-details.outputs.base }}
           PR_NUMBER: ${{ steps.pr-number.outputs.number }}
         run: |
           PR_BODY=$(jq -r .body pr_data.json)
           cat > /tmp/prompt.txt <<PROMPT_EOF
-          A new pull request has been created: '$PR_TITLE'
-
-          <pr-number>
-          $PR_NUMBER
-          </pr-number>
+          You are reviewing Pull Request #$PR_NUMBER: '$PR_TITLE'
+          Base branch: origin/$PR_BASE
+          Head commit: $PR_SHA
 
           <pr-description>
           $PR_BODY
           </pr-description>
 
-          Review this pull request:
-          - Look for potential bugs and regressions
-          - Check for code quality issues
-          - Suggest improvements
-          Respond terse. All technical substance stays. Only fluff dies.
+          Guidelines:
+          - Review the code for bugs, regressions, performance issues, code quality, and readability.
+          - Suggest improvments or fixes.
+          - Check the list of changed files using: git diff --name-only origin/$PR_BASE...HEAD
+          - Read local files directly from the workspace to maintain full context.
+          - Diffs are important but make sure you read the entire file when needed to get full context.
+          - Avoid running huge unbounded diff commands into stdout.
+          - Keep comments terse and actionable. Technical substance stays. Fluff dies.
+          - When critiquing, don't be a zealot if the code is overal readable.
 
-          Diffs are important but make sure you read the entire file to get proper context.
-          When critiquing, don't be a zealot if the code is readable.
-
-          Use the gh cli to create comments on the files for the violations.
-          Try to leave the comment on the exact line number.
-          If you have a suggested fix include it in a suggestion code block.
-          Write a comment instead of writing suggested change.
-
-          Command MUST be like this:
+          For specific code issues, post inline comments using:
           \`\`\`
           gh api \
             --method POST \
@@ -88,6 +89,12 @@ jobs:
             -f 'body=[summary of issue]' -f 'commit_id=$PR_SHA' -f 'path=[path-to-file]' -F "line=[line]" -f 'side=RIGHT'
           \`\`\`
 
-          Only create comments for actual violations. If the code follows all guidelines, comment using gh cli that it looks good and nothing else.
+          If you have a suggested fix include it in a suggestion code block.
+          Only create comments for actual violations.
+
+          When finished, ALWAYS post an overall summary comment to the PR thread:
+          \`gh pr comment $PR_NUMBER --body "[Your overall summary and verdict here]"\`
+          
+          If the code follows all guidelines, comment that it looks good and nothing else. Don't summarize or explain it.
           PROMPT_EOF
           cat /tmp/prompt.txt | opencode run -m opencode/muse-spark-1.2-contributor-free --variant xhigh --agent pr_review

--- a/.github/workflows/opencode_review.yml
+++ b/.github/workflows/opencode_review.yml
@@ -35,7 +35,7 @@ jobs:
           echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
         id: pr-git
         env:
-          GH_TOKEN: ${{ secrets.BOT_PAT }}
+          GH_TOKEN: ${{ secrets.LYRA_PRS_ISSUES_PAT }}
 
       - name: Get PR details
         id: pr-details

--- a/.github/workflows/opencode_review.yml
+++ b/.github/workflows/opencode_review.yml
@@ -25,14 +25,17 @@ jobs:
           fi
     
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Checkout PR Branch
-        run: gh pr checkout ${{ steps.pr-number.outputs.number }}
+        run: |
+          gh pr checkout ${{ steps.pr-number.outputs.number }}
+          echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+        id: pr-git
         env:
-          GH_TOKEN: ${{ secrets.LYRA_PRS_ISSUES_PAT }}
+          GH_TOKEN: ${{ secrets.BOT_PAT }}
 
       - name: Get PR details
         id: pr-details


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the `/review` workflow so review comments reflect the PR's actual code instead of the default branch.

- Checks out the PR branch with `gh pr checkout` instead of the repository default branch, and uses the resulting head commit SHA for diffs and inline comments.
- Captures the PR number before checkout to avoid a race condition.
- Passes the base branch into the prompt so diffs are computed against `origin/<base>...HEAD`.
- Rewrites the prompt to read full files for context and to always post a final summary comment.
- Uses `LYRA_PRS_ISSUES_PAT` for PR checkout, details, and review comments.

<sup>Written for commit 46f4cc9ebf5af02d6bfaaccb5c45e7d6563e34c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

