### PR TITLE
fix(diplomacy): Clear dialogue options on exit

### DIFF
--- a/scripts/scr_controller_helpers/scr_controller_helpers.gml
+++ b/scripts/scr_controller_helpers/scr_controller_helpers.gml
@@ -74,13 +74,14 @@ function scr_change_menu(wanted_menu, specific_area_function = undefined) {
     }
 }
 
+/// @desc Returns the controller to the main map state.
+/// @returns {Undefined}
 function main_map_defaults() {
     with (obj_controller) {
         menu = eMENU.DEFAULT;
         menu_lock = false;
         hide_banner = 0;
         location_viewer.update_garrison_log();
-        managing = 0;
         managing = 0;
         menu_adept = 0;
         view_squad = false;
@@ -89,6 +90,7 @@ function main_map_defaults() {
         hide_banner = 0;
         diplomacy = 0;
         audience = 0;
+        clear_diplo_choices();
         zoomed = 0;
     }
 }

--- a/scripts/scr_ui_diplomacy/scr_ui_diplomacy.gml
+++ b/scripts/scr_ui_diplomacy/scr_ui_diplomacy.gml
@@ -115,6 +115,7 @@ function exit_diplomacy_dialogue() {
         cooldown = 8;
         diplomacy = 0;
         force_goodbye = 0;
+        clear_diplo_choices();
         _close_diplomacy = false;
     }
     // No need to check for next audience


### PR DESCRIPTION
This was part of the broader chaos emissary fix I mentioned in discord but it's independently useful regardless of the chaos emissary option being enabled as at least one other path can leak dialogue options and this will fix that path and any others that may exist or get created in future without needing to play whack a mole with each site.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dialogue options leaking when exiting diplomacy, so stale choices no longer persist into other contexts.

- Calls `clear_diplo_choices()` when exiting diplomacy dialogue and when returning to the main map state.
- This covers the known leak path and future ones without needing to patch each site individually.

<sup>Written for commit 4917e02c012d9a6dba72d29ff03011adc058c90c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1509?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

