### PR TITLE
fix: Disable incomplete Chaos Emissary meeting

### DIFF
--- a/objects/obj_controller/Mouse_50.gml
+++ b/objects/obj_controller/Mouse_50.gml
@@ -175,7 +175,7 @@ if ((menu == eMENU.DIPLOMACY) && (diplomacy > 0) || ((diplomacy < -5) && (diplom
     }
 }
 // Diplomacy
-if ((zoomed == 0) && (cooldown <= 0) && (menu == eMENU.DIPLOMACY) && (diplomacy == 0)) {
+if (CHAOS_EMISSARY_ENABLED && (zoomed == 0) && (cooldown <= 0) && (menu == eMENU.DIPLOMACY) && (diplomacy == 0)) {
     xx += 55;
     yy -= 20;
     // Daemon emmissary

--- a/scripts/macros/macros.gml
+++ b/scripts/macros/macros.gml
@@ -38,6 +38,10 @@
 // Offmap shove distance for non-combatant fleets during battle resolution; must exceed room size so they read as !in_room().
 #macro FLEET_BATTLE_DISPLACEMENT 100000
 
+// Gates the "Meet Chaos Emissary" entry point on the diplomacy screen until the Chaos Emissary is implemented.
+// TODO set to true or just remove this macro once the emissary is implemented.
+#macro CHAOS_EMISSARY_ENABLED false
+
 #macro STR_ANY_POWER_ARMOUR "Any Power Armour"
 #macro STR_ANY_TERMINATOR_ARMOUR "Any Terminator Armour"
 

--- a/scripts/scr_ui_diplomacy/scr_ui_diplomacy.gml
+++ b/scripts/scr_ui_diplomacy/scr_ui_diplomacy.gml
@@ -488,18 +488,20 @@ function scr_ui_diplomacy() {
         scr_image("symbol", 1, xx + 525, yy + 174, 109, 54);
         scr_image("symbol", 2, xx + 1147, yy + 174, 217, 107);
 
-        //draw the meet chaos button
-        draw_set_font(cjk_font(fnt_40k_14b));
-        draw_set_halign(fa_left);
-        draw_set_color(CM_GREEN_COLOR);
-        draw_rectangle(xx + 688, yy + 240, xx + 1028, yy + 281, 0);
-        draw_set_color(c_black);
-        draw_text_transformed(xx + 688, yy + 241, localize("Meet Chaos Emissary"), 0.7, 0.7, 0);
-        //color blending stuff if hovering over the meeting chaos icon
-        if (point_in_rectangle(mouse_x, mouse_y, xx + 688, yy + 240, xx + 1028, yy + 281)) {
-            draw_set_alpha(0.2);
+        if (CHAOS_EMISSARY_ENABLED) {
+            //draw the meet chaos button
+            draw_set_font(cjk_font(fnt_40k_14b));
+            draw_set_halign(fa_left);
+            draw_set_color(CM_GREEN_COLOR);
             draw_rectangle(xx + 688, yy + 240, xx + 1028, yy + 281, 0);
-            draw_set_alpha(1);
+            draw_set_color(c_black);
+            draw_text_transformed(xx + 688, yy + 241, localize("Meet Chaos Emissary"), 0.7, 0.7, 0);
+            //color blending stuff if hovering over the meeting chaos icon
+            if (point_in_rectangle(mouse_x, mouse_y, xx + 688, yy + 240, xx + 1028, yy + 281)) {
+                draw_set_alpha(0.2);
+                draw_rectangle(xx + 688, yy + 240, xx + 1028, yy + 281, 0);
+                draw_set_alpha(1);
+            }
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Gates the incomplete "Meet Chaos Emissary" button on the diplomacy screen behind the new `CHAOS_EMISSARY_ENABLED` macro, hiding it until the feature is implemented.

**Migration**
- Set `CHAOS_EMISSARY_ENABLED` to `true` in `scripts/macros/macros.gml` once the emissary is implemented.

<sup>Written for commit ffac122b66dd0114abb0aeec77aa0db98ae40dcd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

