### PR TITLE
ci: Fix workflow var syntax

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -37,6 +37,7 @@ jobs:
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           OPENCODE_PERMISSION: '{ "external_directory": { "/home/runner/work/**": "allow" } }'
+          OPENCODE_MAIN_MODEL: ${{ vars.OPENCODE_MAIN_MODEL }}
         with:
           model: ${{ secrets.OPENCODE_MAIN_MODEL }}
           variant: xhigh

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -37,9 +37,8 @@ jobs:
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           OPENCODE_PERMISSION: '{ "external_directory": { "/home/runner/work/**": "allow" } }'
-          OPENCODE_MAIN_MODEL: ${{ vars.OPENCODE_MAIN_MODEL }}
         with:
-          model: ${{ secrets.OPENCODE_MAIN_MODEL }}
+          model: ${{ vars.OPENCODE_MAIN_MODEL }}
           variant: xhigh
           share: false
           prompt: ${{ inputs.prompt || '' }}

--- a/.github/workflows/opencode_issue_triage.yml
+++ b/.github/workflows/opencode_issue_triage.yml
@@ -25,7 +25,7 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OPENCODE_MAIN_MODEL: ${{ secrets.OPENCODE_MAIN_MODEL }}
+          OPENCODE_MAIN_MODEL: ${{ vars.OPENCODE_MAIN_MODEL }}
           OPENCODE_PERMISSION: '{ "bash": {  "*": "deny", "gh*": "allow", "gh pr review*": "deny" }, "external_directory": "allow"}'
         run: |
           PROMPT="Issue #${ISSUE_NUMBER} opened at ${REPO}.
@@ -58,7 +58,7 @@ jobs:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENCODE_PERMISSION: '{ "external_directory": "allow"}'
-          OPENCODE_MAIN_MODEL: ${{ secrets.OPENCODE_MAIN_MODEL }}
+          OPENCODE_MAIN_MODEL: ${{ vars.OPENCODE_MAIN_MODEL }}
         run: |
           if gh issue view "$ISSUE_NUMBER" --json labels --jq '.labels[].name' | grep -q "^Status: Duplicate$"; then
             echo "Skipping investigation - duplicate"

--- a/.github/workflows/opencode_review.yml
+++ b/.github/workflows/opencode_review.yml
@@ -61,7 +61,7 @@ jobs:
           PR_SHA: ${{ steps.pr-git.outputs.sha }}
           PR_BASE: ${{ steps.pr-details.outputs.base }}
           PR_NUMBER: ${{ steps.pr-number.outputs.number }}
-          OPENCODE_MAIN_MODEL: ${{ secrets.OPENCODE_MAIN_MODEL }}
+          OPENCODE_MAIN_MODEL: ${{ vars.OPENCODE_MAIN_MODEL }}
         run: |
           PR_BODY=$(jq -r .body pr_data.json)
           cat > /tmp/prompt.txt <<PROMPT_EOF


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switches `OPENCODE_MAIN_MODEL` from `secrets` to `vars` in the issue triage, review, and main workflows so the model value is managed as a repository variable instead of a secret. This includes the `with.model` step in the main workflow, which previously still referenced the secret.

<sup>Written for commit bc2b775bdb6e2ecf3e0f1f15848ef5e8144a574e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

