### PR TITLE
ci: Manual trigger for issue triage

### DIFF
--- a/.github/workflows/opencode_issue_triage.yml
+++ b/.github/workflows/opencode_issue_triage.yml
@@ -2,9 +2,18 @@ name: opencode-issue-triage
 on:
   issues:
     types: [opened]
+  issue_comment:
+    types: [created]
 
 jobs:
   triage:
+    if: |
+      (github.event_name == 'issue_comment'
+        && !github.event.issue.pull_request
+        && startsWith(github.event.comment.body, '/triage')
+        && contains(fromJson('["OWNER","MEMBER"]'), github.event.comment.author_association))
+      || github.event_name == 'issues'
+
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a manual `/triage` command so project owners and members can trigger issue triage on demand, in addition to the existing automatic trigger when an issue is opened. Comments on pull requests or from non-owners/members are ignored.

<sup>Written for commit 6a1f437e7b4814c2672851d940cb630875a26dbe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1517?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

