### PR TITLE
fix: cleanup from enum changes fix saving and creation

### DIFF
--- a/objects/obj_ini/Create_0.gml
+++ b/objects/obj_ini/Create_0.gml
@@ -356,7 +356,7 @@ deserialize = function(save_data) {
                 continue;
             }
             var _required_names = global.role_data_keys;
-            for (var k = 0 ;k < array_legth(_required_names); k++){
+            for (var k = 0 ;k < array_length(_required_names); k++){
                 var _name = _required_names[k];
                 if (struct_exists(_save[i], _name)){
                     _defaults[i] = _save[i][$ _name];

--- a/objects/obj_ini/Create_0.gml
+++ b/objects/obj_ini/Create_0.gml
@@ -235,6 +235,7 @@ deserialize = function(save_data) {
         "artifact_list",
         "sector_handler",
         "company_lengths",
+        "player_role_data"
     ]; // skip automatic setting of certain vars, handle explicitly later
 
     // Automatic var setting
@@ -345,6 +346,24 @@ deserialize = function(save_data) {
         with (obj_ini.sector_handler) {
             move_data_to_current_scope(save_data.sector_handler);
         }
+    }
+
+    if (struct_exists(save_data, "player_role_data")) {
+        var _defaults = setup_default_gears();
+        var _save = save_data.player_role_data;
+        for (var i = 0; i < array_length(_save); i++){
+            if (!is_struct(_save[i])){
+                continue;
+            }
+            var _required_names = global.role_data_keys;
+            for (var k = 0 ;k < array_legth(_required_names); k++){
+                var _name = _required_names[k];
+                if (struct_exists(_save[i], _name)){
+                    _defaults[i] = _save[i][$ _name];
+                }
+            }
+        }
+        player_role_data = _defaults;
     }
 };
 

--- a/objects/obj_ini/Create_0.gml
+++ b/objects/obj_ini/Create_0.gml
@@ -359,7 +359,7 @@ deserialize = function(save_data) {
             for (var k = 0 ;k < array_legth(_required_names); k++){
                 var _name = _required_names[k];
                 if (struct_exists(_save[i], _name)){
-                    _defaults[i] = _save[i][$ _name];
+                    _defaults[i][$ _name] = _save[i][$ _name];
                 }
             }
         }

--- a/scripts/is_specialist/is_specialist.gml
+++ b/scripts/is_specialist/is_specialist.gml
@@ -226,7 +226,12 @@ function role_groups(group, include_trainee = false, include_heads = true) {
 /// @returns {Bool}
 function is_specialist(unit_role, type = SPECIALISTS_STANDARD, include_trainee = false, include_heads = true) {
     var _specialists = role_groups(type, include_trainee, include_heads);
-    var _check_string = is_string(unit_role) ? unit_role : obj_ini.player_role_data[unit_role].role;
-
+    var _check_string = "";
+    if (is_string(unit_role)){
+        _check_string = unit_role;
+    } else {
+        var _obj = instance_exists(obj_ini) ? obj_ini : obj_creation;
+        _check_string =  _obj.player_role_data[unit_role].role;
+    }
     return array_contains(_specialists, _check_string);
 }


### PR DESCRIPTION
<!--- YOU CAN DELETE ALL OF THIS AFTER READING. -->

<!--- Make use of markdown lists. They make stuff much easier to read through. -->
<!--- Explain why and what your changes do in simple terms. --->
<!--- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. --->

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->

<!--- "Inspired" by the CDDA PR template -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes saving and creation of specialist roles that broke after recent enum changes.

- Restores `player_role_data` from save files during deserialization.
- Makes `is_specialist` fall back to `obj_creation` when `obj_ini` doesn't exist, preventing crashes outside the main game scope.

<sup>Written for commit a4ccbb6f4d302f30e8d4f2989d37b99c8655c99b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

