### PR TITLE
ci(oc): GitHub Action to install OpenCode CLI

### DIFF
--- a/.github/actions/setup-opencode/action.yml
+++ b/.github/actions/setup-opencode/action.yml
@@ -1,0 +1,13 @@
+name: 'Setup OpenCode'
+description: 'Installs OpenCode CLI'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Install OpenCode
+      shell: bash
+      run: |
+        if ! command -v opencode &> /dev/null; then
+          curl -fsSL https://opencode.ai/install | bash
+          echo "$HOME/.opencode/bin" >> $GITHUB_PATH
+        fi

--- a/.github/workflows/opencode_issue_triage.yml
+++ b/.github/workflows/opencode_issue_triage.yml
@@ -43,8 +43,7 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Install OpenCode
-        run: curl -fsSL https://opencode.ai/install | bash
+      - uses: ./.github/actions/setup-opencode
 
       - name: Triage
         env:

--- a/.github/workflows/opencode_issue_triage.yml
+++ b/.github/workflows/opencode_issue_triage.yml
@@ -39,11 +39,11 @@ jobs:
         run: |
           gh api repos/${{ github.repository }}/issues/comments/${COMMENT_ID}/reactions -f content='eyes'
 
+      - uses: ./.github/actions/setup-opencode
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 1
-
-      - uses: ./.github/actions/setup-opencode
 
       - name: Triage
         env:

--- a/.github/workflows/opencode_review.yml
+++ b/.github/workflows/opencode_review.yml
@@ -48,8 +48,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.LYRA_PRS_ISSUES_PAT }}
 
-      - name: Install OpenCode
-        run: curl -fsSL https://opencode.ai/install | bash
+      - uses: ./.github/actions/setup-opencode
 
       - name: Run OpenCode
         env:

--- a/.github/workflows/opencode_review.yml
+++ b/.github/workflows/opencode_review.yml
@@ -23,7 +23,9 @@ jobs:
           else
             echo "number=${{ github.event.issue.number }}" >> $GITHUB_OUTPUT
           fi
-    
+
+      - uses: ./.github/actions/setup-opencode
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -47,8 +49,6 @@ jobs:
           echo "base=$(jq -r .base.ref pr_data.json)" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.LYRA_PRS_ISSUES_PAT }}
-
-      - uses: ./.github/actions/setup-opencode
 
       - name: Run OpenCode
         env:


### PR DESCRIPTION
Less typing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reusable `setup-opencode` composite action so workflows install the OpenCode CLI in one step instead of inline. The issue triage and review workflows now use this action, which skips the install when `opencode` is already on the PATH and adds `$HOME/.opencode/bin` to the PATH for subsequent steps.

<sup>Written for commit 48b736adaef9fe1b379c97e6342ae7bc900c137f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

