### PR TITLE
fix: exit planet_select_logic if no star select object

### DIFF
--- a/objects/obj_star_select/Create_0.gml
+++ b/objects/obj_star_select/Create_0.gml
@@ -3,6 +3,7 @@ owner = 0;
 target = instance_nearest(x, y, obj_star);
 loading = 0;
 loading_name = "";
+mission = "";
 alarm[0] = 1;
 debug = 0;
 guard = 0;

--- a/scripts/scr_PlanetData/scr_PlanetData.gml
+++ b/scripts/scr_PlanetData/scr_PlanetData.gml
@@ -1544,9 +1544,12 @@ function PlanetData(_planet, _system) constructor {
     };
 
     static planet_selection_logic = function() {
+        if (!instance_exists(obj_star_select)){
+            exit;
+        }
         var planet_is_allies = scr_is_planet_owned_by_allies(system, planet);
         var garrison_issue = !planet_is_allies || pdf <= 0;
-        var _mission = variable_instance_exists(obj_star_select, "mission") ? obj_star_select.mission : "";
+        var _mission = obj_star_select.mission;
 
         var _loading = obj_star_select.loading;
         var garrison_assignment = obj_controller.view_squad && _loading;


### PR DESCRIPTION
<!--- YOU CAN DELETE ALL OF THIS AFTER READING. -->

<!--- Make use of markdown lists. They make stuff much easier to read through. -->
<!--- Explain why and what your changes do in simple terms. --->
<!--- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. --->

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->

<!--- "Inspired" by the CDDA PR template -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in `planet_selection_logic` when `obj_star_select` doesn't exist. The function now exits early if the object is missing, and the `mission` variable is initialized in `obj_star_select` to avoid variable lookups.

<sup>Written for commit 036fefa3de0731ead2c31bb9d3870f3b8705aa31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adeptus-Dominus/ChapterMaster/pull/1532?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

